### PR TITLE
docs: update documentation for v0.3.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
 | 0.2.x   | :white_check_mark: |
-| 0.1.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ docker run -p 8000:8000 \
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON key file | Yes (or use per-request credentials) | — |
 | `GOOGLE_PLAY_STORE_CREDENTIALS` | Inline JSON credentials string | Alternative to file path | — |
 | `PLAY_STORE_MCP_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | No | `INFO` |
+| `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
 
 ## HTTP Transport
 


### PR DESCRIPTION
Updates documentation for v0.3.0 release:\n- SECURITY.md: Added v0.3.x as supported, dropped v0.1.x\n- docs/configuration.md: Added PLAY_STORE_MCP_DISABLE_DNS_REBINDING env var\n- Wiki submodule: Updated Configuration.md and Troubleshooting.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Security policy updated: Version 0.3.x now supported, version 0.1.x no longer supported, version 0.2.x support unchanged.
  * Added documentation for a new environment variable to disable DNS rebinding protection for cloud and reverse-proxy deployments.
  * Wiki content updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->