### PR TITLE
feat: add in-app product catalog management (create/update/patch/delete/batch)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -44,6 +44,12 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 |---|---|
 | [`list_in_app_products`](tools/subscriptions.md#list_in_app_products) | List all in-app products |
 | [`get_in_app_product`](tools/subscriptions.md#get_in_app_product) | Get details of a specific product |
+| [`batch_get_in_app_products`](tools/subscriptions.md#batch_get_in_app_products) | Get details for multiple products at once |
+| `create_in_app_product` | Create a new in-app product (write) |
+| `update_in_app_product` | Update (replace) an in-app product (write) |
+| `patch_in_app_product` | Partially update an in-app product (write) |
+| `delete_in_app_product` | Delete an in-app product (write) |
+| `batch_delete_in_app_products` | Delete multiple in-app products at once (write) |
 | [`get_product_purchase`](tools/subscriptions.md#get_product_purchase) | Check status of an in-app product purchase |
 | [`acknowledge_product_purchase`](tools/subscriptions.md#acknowledge_product_purchase) | Acknowledge an in-app product purchase (write) |
 | [`consume_product_purchase`](tools/subscriptions.md#consume_product_purchase) | Consume an in-app product purchase (write) |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -141,6 +141,118 @@ consume_product_purchase("com.example.myapp", product_id="coins_100", purchase_t
 
 ---
 
+## In-App Product Management
+
+Create, update, and delete in-app products (managed products) in your catalog.
+All tools here except `batch_get_in_app_products` are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+The `product` parameter is an
+[InAppProduct](https://developers.google.com/android-publisher/api-ref/rest/v3/inappproducts)
+resource body — for example `sku`, `purchaseType` (`managedProduct` or
+`subscription`), `defaultLanguage`, `defaultPrice`, `prices`, `listings`, and
+`status`.
+
+### create_in_app_product
+
+Create a new in-app product. **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product` | object | Yes | InAppProduct resource body |
+
+```python
+create_in_app_product(
+    package_name="com.example.myapp",
+    product={
+        "sku": "premium_upgrade",
+        "purchaseType": "managedProduct",
+        "defaultLanguage": "en-US",
+        "status": "active",
+        "defaultPrice": {"priceMicros": "990000", "currency": "USD"},
+        "listings": {"en-US": {"title": "Premium Upgrade", "description": "Unlock everything"}},
+    },
+)
+```
+
+### update_in_app_product
+
+Update (replace) an existing in-app product. **Write.**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `sku` | string | Yes | — | Product SKU identifier |
+| `product` | object | Yes | — | InAppProduct resource body |
+| `auto_convert_missing_prices` | boolean | No | `false` | Auto-convert prices for regions without a specified price from the default price |
+
+```python
+update_in_app_product(
+    package_name="com.example.myapp",
+    sku="premium_upgrade",
+    product={"sku": "premium_upgrade", "status": "active", "defaultPrice": {"priceMicros": "1990000", "currency": "USD"}},
+    auto_convert_missing_prices=True,
+)
+```
+
+### patch_in_app_product
+
+Partially update an existing in-app product. **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `sku` | string | Yes | Product SKU identifier |
+| `product` | object | Yes | Partial InAppProduct body with only the fields to change |
+
+```python
+patch_in_app_product("com.example.myapp", sku="premium_upgrade", product={"status": "inactive"})
+```
+
+### delete_in_app_product
+
+Delete an in-app product from the catalog. **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `sku` | string | Yes | Product SKU identifier |
+
+```python
+delete_in_app_product("com.example.myapp", sku="premium_upgrade")
+```
+
+### batch_get_in_app_products
+
+Get details for multiple in-app products at once. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `skus` | array of string | Yes | Product SKUs to retrieve |
+
+Returns a list of products in the same order as requested.
+
+```python
+batch_get_in_app_products("com.example.myapp", skus=["premium_upgrade", "coins_100"])
+```
+
+### batch_delete_in_app_products
+
+Delete multiple in-app products in a single operation (up to 100). **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `skus` | array of string | Yes | Product SKUs to delete |
+
+```python
+batch_delete_in_app_products("com.example.myapp", skus=["premium_upgrade", "coins_100"])
+```
+
+---
+
 ## Purchase Management
 
 Manage and refund purchases. All actions except `get_product_purchase_v2` are

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -1702,31 +1702,10 @@ class PlayStoreClient:
         try:
             result = service.inappproducts().list(packageName=package_name).execute()
 
-            products: list[InAppProduct] = []
-            for product_data in result.get("inappproduct", []):
-                # Get default price if available
-                default_price = None
-                if "defaultPrice" in product_data:
-                    default_price = product_data["defaultPrice"]
-
-                # Get localized listings
-                listings = product_data.get("listings", {})
-                default_listing = listings.get(product_data.get("defaultLanguage", "en-US"), {})
-
-                products.append(
-                    InAppProduct(
-                        sku=product_data.get("sku", ""),
-                        package_name=package_name,
-                        product_type=product_data.get("purchaseType", "managedProduct"),
-                        status=product_data.get("status"),
-                        default_language=product_data.get("defaultLanguage"),
-                        title=default_listing.get("title"),
-                        description=default_listing.get("description"),
-                        default_price=default_price,
-                    )
-                )
-
-            return products
+            return [
+                self._parse_in_app_product(package_name, product_data)
+                for product_data in result.get("inappproduct", [])
+            ]
 
         except HttpError as e:
             self._logger.exception("Failed to list in-app products", error=str(e))

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -24,6 +24,7 @@ from play_store_mcp.models import (
     DeploymentResult,
     ExpansionFile,
     InAppProduct,
+    InAppProductActionResult,
     Listing,
     ListingUpdateResult,
     Order,
@@ -1746,30 +1747,212 @@ class PlayStoreClient:
 
         try:
             product_data = service.inappproducts().get(packageName=package_name, sku=sku).execute()
-
-            # Get default price if available
-            default_price = None
-            if "defaultPrice" in product_data:
-                default_price = product_data["defaultPrice"]
-
-            # Get localized listings
-            listings = product_data.get("listings", {})
-            default_listing = listings.get(product_data.get("defaultLanguage", "en-US"), {})
-
-            return InAppProduct(
-                sku=product_data.get("sku", ""),
-                package_name=package_name,
-                product_type=product_data.get("purchaseType", "managedProduct"),
-                status=product_data.get("status"),
-                default_language=product_data.get("defaultLanguage"),
-                title=default_listing.get("title"),
-                description=default_listing.get("description"),
-                default_price=default_price,
-            )
+            return self._parse_in_app_product(package_name, product_data)
 
         except HttpError as e:
             self._logger.exception("Failed to get in-app product", error=str(e))
             raise PlayStoreClientError(f"Failed to get in-app product: {e.reason}") from e
+
+    @staticmethod
+    def _parse_in_app_product(package_name: str, product_data: dict[str, Any]) -> InAppProduct:
+        """Parse an InappProduct API resource into an InAppProduct model."""
+        # Get default price if available
+        default_price = None
+        if "defaultPrice" in product_data:
+            default_price = product_data["defaultPrice"]
+
+        # Get localized listings
+        listings = product_data.get("listings", {})
+        default_listing = listings.get(product_data.get("defaultLanguage", "en-US"), {})
+
+        return InAppProduct(
+            sku=product_data.get("sku", ""),
+            package_name=package_name,
+            product_type=product_data.get("purchaseType", "managedProduct"),
+            status=product_data.get("status"),
+            default_language=product_data.get("defaultLanguage"),
+            title=default_listing.get("title"),
+            description=default_listing.get("description"),
+            default_price=default_price,
+        )
+
+    def create_in_app_product(self, package_name: str, product: dict[str, Any]) -> InAppProduct:
+        """Create a new in-app product.
+
+        Args:
+            package_name: App package name.
+            product: In-app product body (InAppProduct resource).
+
+        Returns:
+            The created in-app product.
+        """
+        self._logger.info("Creating in-app product", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.inappproducts().insert(packageName=package_name, body=product).execute()
+            )
+            return self._parse_in_app_product(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create in-app product", error=str(e))
+            raise PlayStoreClientError(f"Failed to create in-app product: {e.reason}") from e
+
+    def update_in_app_product(
+        self,
+        package_name: str,
+        sku: str,
+        product: dict[str, Any],
+        auto_convert_missing_prices: bool = False,
+    ) -> InAppProduct:
+        """Update (replace) an existing in-app product.
+
+        Args:
+            package_name: App package name.
+            sku: Product SKU.
+            product: In-app product body (InAppProduct resource).
+            auto_convert_missing_prices: If True, auto-convert prices for regions
+                without a specified price based on the default price.
+
+        Returns:
+            The updated in-app product.
+        """
+        self._logger.info("Updating in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.inappproducts()
+                .update(
+                    packageName=package_name,
+                    sku=sku,
+                    autoConvertMissingPrices=auto_convert_missing_prices,
+                    body=product,
+                )
+                .execute()
+            )
+            return self._parse_in_app_product(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to update in-app product", error=str(e))
+            raise PlayStoreClientError(f"Failed to update in-app product: {e.reason}") from e
+
+    def patch_in_app_product(
+        self, package_name: str, sku: str, product: dict[str, Any]
+    ) -> InAppProduct:
+        """Partially update an existing in-app product.
+
+        Args:
+            package_name: App package name.
+            sku: Product SKU.
+            product: Partial in-app product body (InAppProduct resource).
+
+        Returns:
+            The patched in-app product.
+        """
+        self._logger.info("Patching in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.inappproducts()
+                .patch(packageName=package_name, sku=sku, body=product)
+                .execute()
+            )
+            return self._parse_in_app_product(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to patch in-app product", error=str(e))
+            raise PlayStoreClientError(f"Failed to patch in-app product: {e.reason}") from e
+
+    def delete_in_app_product(self, package_name: str, sku: str) -> InAppProductActionResult:
+        """Delete an in-app product.
+
+        Args:
+            package_name: App package name.
+            sku: Product SKU.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info("Deleting in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+
+        try:
+            service.inappproducts().delete(packageName=package_name, sku=sku).execute()
+
+            return InAppProductActionResult(
+                success=True,
+                package_name=package_name,
+                sku=sku,
+                message=f"In-app product {sku} deleted successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete in-app product", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete in-app product: {e.reason}") from e
+
+    def batch_get_in_app_products(self, package_name: str, skus: list[str]) -> list[InAppProduct]:
+        """Get details for multiple in-app products.
+
+        Args:
+            package_name: App package name.
+            skus: List of product SKUs to retrieve.
+
+        Returns:
+            List of in-app products, in the same order as the request.
+        """
+        self._logger.info(
+            "Batch getting in-app products", package_name=package_name, count=len(skus)
+        )
+        service = self._get_service()
+
+        try:
+            result = service.inappproducts().batchGet(packageName=package_name, sku=skus).execute()
+
+            return [
+                self._parse_in_app_product(package_name, product_data)
+                for product_data in result.get("inappproduct", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch get in-app products", error=str(e))
+            raise PlayStoreClientError(f"Failed to batch get in-app products: {e.reason}") from e
+
+    def batch_delete_in_app_products(
+        self, package_name: str, skus: list[str]
+    ) -> InAppProductActionResult:
+        """Delete multiple in-app products in a single operation.
+
+        Args:
+            package_name: App package name.
+            skus: List of product SKUs to delete.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Batch deleting in-app products", package_name=package_name, count=len(skus)
+        )
+        service = self._get_service()
+
+        try:
+            service.inappproducts().batchDelete(
+                packageName=package_name,
+                body={"requests": [{"packageName": package_name, "sku": s} for s in skus]},
+            ).execute()
+
+            return InAppProductActionResult(
+                success=True,
+                package_name=package_name,
+                sku=None,
+                message=f"Deleted {len(skus)} in-app product(s) successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch delete in-app products", error=str(e))
+            raise PlayStoreClientError(f"Failed to batch delete in-app products: {e.reason}") from e
 
     # =========================================================================
     # Store Listings API

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -153,6 +153,16 @@ class InAppProduct(BaseModel):
     default_price: dict[str, Any] | None = Field(None, description="Default price information")
 
 
+class InAppProductActionResult(BaseModel):
+    """Result of a delete/batch-delete action on in-app products."""
+
+    success: bool = Field(..., description="Whether the action succeeded")
+    package_name: str = Field(..., description="App package name")
+    sku: str | None = Field(None, description="Product SKU (None for batch operations)")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
 class Listing(BaseModel):
     """Store listing for a specific language."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -898,6 +898,159 @@ def get_in_app_product(
     return product.model_dump()
 
 
+@mcp.tool()
+def create_in_app_product(
+    package_name: str,
+    product: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a new in-app product in the catalog.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product: In-app product resource body (e.g. sku, purchaseType, defaultPrice,
+            listings, status, defaultLanguage)
+
+    Returns:
+        The created in-app product
+    """
+    if blocked := _read_only_block("create_in_app_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_in_app_product(package_name=package_name, product=product)
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_in_app_product(
+    package_name: str,
+    sku: str,
+    product: dict[str, Any],
+    auto_convert_missing_prices: bool = False,
+) -> dict[str, Any]:
+    """Update (replace) an existing in-app product.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        sku: Product SKU identifier
+        product: In-app product resource body
+        auto_convert_missing_prices: Auto-convert prices for regions without a
+            specified price based on the default price (default: False)
+
+    Returns:
+        The updated in-app product
+    """
+    if blocked := _read_only_block("update_in_app_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.update_in_app_product(
+        package_name=package_name,
+        sku=sku,
+        product=product,
+        auto_convert_missing_prices=auto_convert_missing_prices,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def patch_in_app_product(
+    package_name: str,
+    sku: str,
+    product: dict[str, Any],
+) -> dict[str, Any]:
+    """Partially update an existing in-app product.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        sku: Product SKU identifier
+        product: Partial in-app product resource body with fields to change
+
+    Returns:
+        The patched in-app product
+    """
+    if blocked := _read_only_block("patch_in_app_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.patch_in_app_product(package_name=package_name, sku=sku, product=product)
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_in_app_product(
+    package_name: str,
+    sku: str,
+) -> dict[str, Any]:
+    """Delete an in-app product from the catalog.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        sku: Product SKU identifier
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("delete_in_app_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_in_app_product(package_name=package_name, sku=sku)
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_get_in_app_products(
+    package_name: str,
+    skus: list[str],
+) -> list[dict[str, Any]]:
+    """Get details for multiple in-app products at once.
+
+    Args:
+        package_name: App package name
+        skus: List of product SKUs to retrieve
+
+    Returns:
+        List of in-app products, in the same order as requested
+    """
+    client = get_client_from_context()
+
+    products = client.batch_get_in_app_products(package_name=package_name, skus=skus)
+    return [product.model_dump() for product in products]
+
+
+@mcp.tool()
+def batch_delete_in_app_products(
+    package_name: str,
+    skus: list[str],
+) -> dict[str, Any]:
+    """Delete multiple in-app products in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        skus: List of product SKUs to delete
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("batch_delete_in_app_products"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.batch_delete_in_app_products(package_name=package_name, skus=skus)
+    return result.model_dump()
+
+
 # =============================================================================
 # Store Listings Tools
 # =============================================================================

--- a/tests/test_inappproducts.py
+++ b/tests/test_inappproducts.py
@@ -1,0 +1,403 @@
+"""Tests for in-app product catalog management (create/update/patch/delete/batch)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import InAppProduct, InAppProductActionResult
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_in_app_product_action_result_defaults():
+    r = InAppProductActionResult(
+        success=True, package_name="com.example.app", sku="sku1", message="ok"
+    )
+    assert r.success is True
+    assert r.sku == "sku1"
+    assert r.error is None
+
+
+def test_in_app_product_action_result_batch_sku_none():
+    r = InAppProductActionResult(success=True, package_name="com.example.app", message="ok")
+    assert r.sku is None
+    assert r.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _iap(service: MagicMock) -> MagicMock:
+    return service.inappproducts.return_value
+
+
+_PRODUCT_RESPONSE = {
+    "sku": "premium_upgrade",
+    "purchaseType": "managedProduct",
+    "status": "active",
+    "defaultLanguage": "en-US",
+    "defaultPrice": {"priceMicros": "990000", "currency": "USD"},
+    "listings": {"en-US": {"title": "Premium Upgrade", "description": "Unlock premium features"}},
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: create
+# ---------------------------------------------------------------------------
+
+
+def test_create_in_app_product_success():
+    service = MagicMock()
+    _iap(service).insert.return_value.execute.return_value = _PRODUCT_RESPONSE
+    client = _client(service)
+
+    body = {"sku": "premium_upgrade", "purchaseType": "managedProduct"}
+    result = client.create_in_app_product("com.example.app", body)
+
+    assert isinstance(result, InAppProduct)
+    assert result.sku == "premium_upgrade"
+    assert result.product_type == "managedProduct"
+    assert result.title == "Premium Upgrade"
+    assert result.description == "Unlock premium features"
+    assert result.default_price == {"priceMicros": "990000", "currency": "USD"}
+    _iap(service).insert.assert_called_once_with(packageName="com.example.app", body=body)
+
+
+def test_create_in_app_product_http_error():
+    service = MagicMock()
+    _iap(service).insert.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create in-app product"):
+        client.create_in_app_product("com.example.app", {"sku": "sku1"})
+
+
+# ---------------------------------------------------------------------------
+# Client: update
+# ---------------------------------------------------------------------------
+
+
+def test_update_in_app_product_success_defaults():
+    service = MagicMock()
+    _iap(service).update.return_value.execute.return_value = _PRODUCT_RESPONSE
+    client = _client(service)
+
+    body = {"sku": "premium_upgrade", "status": "active"}
+    result = client.update_in_app_product("com.example.app", "premium_upgrade", body)
+
+    assert result.sku == "premium_upgrade"
+    _iap(service).update.assert_called_once_with(
+        packageName="com.example.app",
+        sku="premium_upgrade",
+        autoConvertMissingPrices=False,
+        body=body,
+    )
+
+
+def test_update_in_app_product_auto_convert_true():
+    service = MagicMock()
+    _iap(service).update.return_value.execute.return_value = _PRODUCT_RESPONSE
+    client = _client(service)
+
+    body = {"sku": "premium_upgrade"}
+    client.update_in_app_product(
+        "com.example.app", "premium_upgrade", body, auto_convert_missing_prices=True
+    )
+
+    _iap(service).update.assert_called_once_with(
+        packageName="com.example.app",
+        sku="premium_upgrade",
+        autoConvertMissingPrices=True,
+        body=body,
+    )
+
+
+def test_update_in_app_product_http_error():
+    service = MagicMock()
+    _iap(service).update.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to update in-app product"):
+        client.update_in_app_product("com.example.app", "sku1", {"sku": "sku1"})
+
+
+# ---------------------------------------------------------------------------
+# Client: patch
+# ---------------------------------------------------------------------------
+
+
+def test_patch_in_app_product_success():
+    service = MagicMock()
+    _iap(service).patch.return_value.execute.return_value = _PRODUCT_RESPONSE
+    client = _client(service)
+
+    body = {"status": "inactive"}
+    result = client.patch_in_app_product("com.example.app", "premium_upgrade", body)
+
+    assert result.sku == "premium_upgrade"
+    _iap(service).patch.assert_called_once_with(
+        packageName="com.example.app", sku="premium_upgrade", body=body
+    )
+
+
+def test_patch_in_app_product_no_default_price():
+    service = MagicMock()
+    _iap(service).patch.return_value.execute.return_value = {
+        "sku": "premium_upgrade",
+        "status": "active",
+    }
+    client = _client(service)
+
+    result = client.patch_in_app_product("com.example.app", "premium_upgrade", {"status": "active"})
+
+    assert result.default_price is None
+    assert result.title is None
+    assert result.product_type == "managedProduct"
+
+
+def test_patch_in_app_product_http_error():
+    service = MagicMock()
+    _iap(service).patch.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to patch in-app product"):
+        client.patch_in_app_product("com.example.app", "sku1", {"status": "active"})
+
+
+# ---------------------------------------------------------------------------
+# Client: delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_in_app_product_success():
+    service = MagicMock()
+    client = _client(service)
+
+    result = client.delete_in_app_product("com.example.app", "premium_upgrade")
+
+    assert isinstance(result, InAppProductActionResult)
+    assert result.success is True
+    assert result.sku == "premium_upgrade"
+    assert "premium_upgrade" in result.message
+    _iap(service).delete.assert_called_once_with(
+        packageName="com.example.app", sku="premium_upgrade"
+    )
+
+
+def test_delete_in_app_product_http_error():
+    service = MagicMock()
+    _iap(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete in-app product"):
+        client.delete_in_app_product("com.example.app", "sku1")
+
+
+# ---------------------------------------------------------------------------
+# Client: batchGet
+# ---------------------------------------------------------------------------
+
+
+def test_batch_get_in_app_products_success():
+    service = MagicMock()
+    _iap(service).batchGet.return_value.execute.return_value = {
+        "inappproduct": [
+            _PRODUCT_RESPONSE,
+            {"sku": "coins_100", "purchaseType": "managedProduct"},
+        ]
+    }
+    client = _client(service)
+
+    result = client.batch_get_in_app_products("com.example.app", ["premium_upgrade", "coins_100"])
+
+    assert [p.sku for p in result] == ["premium_upgrade", "coins_100"]
+    assert result[1].default_price is None
+    _iap(service).batchGet.assert_called_once_with(
+        packageName="com.example.app", sku=["premium_upgrade", "coins_100"]
+    )
+
+
+def test_batch_get_in_app_products_empty():
+    service = MagicMock()
+    _iap(service).batchGet.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_get_in_app_products("com.example.app", ["sku1"])
+
+    assert result == []
+
+
+def test_batch_get_in_app_products_http_error():
+    service = MagicMock()
+    _iap(service).batchGet.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch get in-app products"):
+        client.batch_get_in_app_products("com.example.app", ["sku1"])
+
+
+# ---------------------------------------------------------------------------
+# Client: batchDelete
+# ---------------------------------------------------------------------------
+
+
+def test_batch_delete_in_app_products_success():
+    service = MagicMock()
+    client = _client(service)
+
+    result = client.batch_delete_in_app_products("com.example.app", ["sku1", "sku2"])
+
+    assert isinstance(result, InAppProductActionResult)
+    assert result.success is True
+    assert result.sku is None
+    assert "2" in result.message
+    _iap(service).batchDelete.assert_called_once_with(
+        packageName="com.example.app",
+        body={
+            "requests": [
+                {"packageName": "com.example.app", "sku": "sku1"},
+                {"packageName": "com.example.app", "sku": "sku2"},
+            ]
+        },
+    )
+
+
+def test_batch_delete_in_app_products_http_error():
+    service = MagicMock()
+    _iap(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch delete in-app products"):
+        client.batch_delete_in_app_products("com.example.app", ["sku1"])
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_create_in_app_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_in_app_product.return_value = InAppProduct(
+        sku="premium_upgrade", package_name="com.example.app", product_type="managedProduct"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"sku": "premium_upgrade"}
+    result = server.create_in_app_product("com.example.app", body)
+
+    assert result["sku"] == "premium_upgrade"
+    mc.create_in_app_product.assert_called_once_with(package_name="com.example.app", product=body)
+
+
+def test_tool_update_in_app_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.update_in_app_product.return_value = InAppProduct(
+        sku="premium_upgrade", package_name="com.example.app", product_type="managedProduct"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"sku": "premium_upgrade"}
+    result = server.update_in_app_product(
+        "com.example.app", "premium_upgrade", body, auto_convert_missing_prices=True
+    )
+
+    assert result["sku"] == "premium_upgrade"
+    mc.update_in_app_product.assert_called_once_with(
+        package_name="com.example.app",
+        sku="premium_upgrade",
+        product=body,
+        auto_convert_missing_prices=True,
+    )
+
+
+def test_tool_patch_in_app_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.patch_in_app_product.return_value = InAppProduct(
+        sku="premium_upgrade", package_name="com.example.app", product_type="managedProduct"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"status": "inactive"}
+    result = server.patch_in_app_product("com.example.app", "premium_upgrade", body)
+
+    assert result["sku"] == "premium_upgrade"
+    mc.patch_in_app_product.assert_called_once_with(
+        package_name="com.example.app", sku="premium_upgrade", product=body
+    )
+
+
+def test_tool_delete_in_app_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_in_app_product.return_value = InAppProductActionResult(
+        success=True, package_name="com.example.app", sku="premium_upgrade", message="ok"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_in_app_product("com.example.app", "premium_upgrade")
+
+    assert result["success"] is True
+    mc.delete_in_app_product.assert_called_once_with(
+        package_name="com.example.app", sku="premium_upgrade"
+    )
+
+
+def test_tool_batch_get_in_app_products(monkeypatch):
+    mc = MagicMock()
+    mc.batch_get_in_app_products.return_value = [
+        InAppProduct(
+            sku="premium_upgrade", package_name="com.example.app", product_type="managedProduct"
+        )
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.batch_get_in_app_products("com.example.app", ["premium_upgrade"])
+
+    assert result[0]["sku"] == "premium_upgrade"
+    mc.batch_get_in_app_products.assert_called_once_with(
+        package_name="com.example.app", skus=["premium_upgrade"]
+    )
+
+
+def test_tool_batch_delete_in_app_products(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_delete_in_app_products.return_value = InAppProductActionResult(
+        success=True, package_name="com.example.app", message="ok"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.batch_delete_in_app_products("com.example.app", ["sku1", "sku2"])
+
+    assert result["success"] is True
+    mc.batch_delete_in_app_products.assert_called_once_with(
+        package_name="com.example.app", skus=["sku1", "sku2"]
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -137,6 +137,23 @@ WRITE_TOOLS = [
         "revoke_subscription_purchase",
         {"package_name": "com.example.app", "purchase_token": "tok"},
     ),
+    (
+        "create_in_app_product",
+        {"package_name": "com.example.app", "product": {"sku": "sku1"}},
+    ),
+    (
+        "update_in_app_product",
+        {"package_name": "com.example.app", "sku": "sku1", "product": {"sku": "sku1"}},
+    ),
+    (
+        "patch_in_app_product",
+        {"package_name": "com.example.app", "sku": "sku1", "product": {"status": "active"}},
+    ),
+    ("delete_in_app_product", {"package_name": "com.example.app", "sku": "sku1"}),
+    (
+        "batch_delete_in_app_products",
+        {"package_name": "com.example.app", "skus": ["sku1", "sku2"]},
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds write/batch management for the `inappproducts` resource (the server already had `get`/`list`):

- **`create_in_app_product`** (`insert`) — write
- **`update_in_app_product`** (`update`, supports `auto_convert_missing_prices`) — write
- **`patch_in_app_product`** (`patch`) — write
- **`delete_in_app_product`** (`delete`) — write
- **`batch_get_in_app_products`** (`batchGet`, repeated `sku` query) — read
- **`batch_delete_in_app_products`** (`batchDelete`) — write

All 5 writes are gated by read-only mode and added to the read-only `WRITE_TOOLS`.

## Changes
- `models.py`: new `InAppProductActionResult` (delete/batch-delete result).
- `client.py`: 6 methods; extracted a shared `_parse_in_app_product` helper now used by `get`/`create`/`update`/`patch`/`batchGet` **and** `list` (DRY). Write bodies are pass-through `dict` (the `InAppProduct` schema is large). HttpError → `PlayStoreClientError`.
- `server.py`: 6 tools (5 writes guard-first, `batch_get` ungated).
- Tests: `tests/test_inappproducts.py` (model + per-method success/HttpError + per-tool delegation) + 5 `WRITE_TOOLS` entries.
- Docs: `docs/tools/subscriptions.md` ("In-App Product Management") + `docs/tools-reference.md`.

## Validation
- `pytest` → **304 passed, 18 skipped**; 100% new-code coverage (2 pre-existing unreachable arcs remain).
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (its one MINOR — leftover duplicate parsing in `list_in_app_products` — is fixed in this PR).
- Plan: `docs/superpowers/plans/` (see read-siblings pattern); shapes verified against discovery rev 20260701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2