### PR TITLE
feat: add subscription catalog management (get/create/patch/delete/batch)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -35,6 +35,12 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | Tool | Description |
 |---|---|
 | [`list_subscriptions`](tools/subscriptions.md#list_subscriptions) | List subscription products |
+| [`get_subscription`](tools/subscriptions.md#get_subscription) | Get details of a specific subscription product |
+| [`batch_get_subscriptions`](tools/subscriptions.md#batch_get_subscriptions) | Get details for multiple subscription products at once |
+| `create_subscription` | Create a new subscription product (write) |
+| `patch_subscription` | Partially update a subscription product (write) |
+| `delete_subscription` | Delete a subscription product (write) |
+| `batch_update_subscriptions` | Update multiple subscription products at once (write) |
 | [`get_subscription_status`](tools/subscriptions.md#get_subscription_status) | Check subscription purchase status |
 | [`list_voided_purchases`](tools/subscriptions.md#list_voided_purchases) | List voided purchases |
 

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -59,6 +59,134 @@ list_voided_purchases("com.example.myapp", max_results=50)
 
 ---
 
+## Subscription Catalog Management
+
+Create, patch, and delete subscription products (`monetization.subscriptions`) in
+your catalog. All tools here except `get_subscription` and
+`batch_get_subscriptions` are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+The `subscription` parameter is a
+[Subscription](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions)
+resource body — for example `basePlans` and `listings`. Write operations take a
+`regions_version` (default `"2022/02"`) identifying the version of available
+regions used for regional prices.
+
+### get_subscription
+
+Get details of a specific subscription product. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Subscription product ID |
+
+```python
+get_subscription("com.example.myapp", product_id="premium_monthly")
+```
+
+### create_subscription
+
+Create a new subscription product. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `product_id` | string | Yes | — | Subscription product ID |
+| `subscription` | object | Yes | — | Subscription resource body |
+| `regions_version` | string | No | `"2022/02"` | Version of available regions for regional prices |
+
+```python
+create_subscription(
+    package_name="com.example.myapp",
+    product_id="premium_monthly",
+    subscription={
+        "basePlans": [
+            {
+                "basePlanId": "monthly",
+                "autoRenewingBasePlanType": {"billingPeriodDuration": "P1M"},
+            }
+        ],
+        "listings": [{"languageCode": "en-US", "title": "Premium Monthly"}],
+    },
+)
+```
+
+### patch_subscription
+
+Partially update an existing subscription product. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `product_id` | string | Yes | — | Subscription product ID |
+| `subscription` | object | Yes | — | Partial Subscription body with only the fields to change |
+| `update_mask` | string | Yes | — | Comma-separated list of fields to update |
+| `regions_version` | string | No | `"2022/02"` | Version of available regions for regional prices |
+
+```python
+patch_subscription(
+    package_name="com.example.myapp",
+    product_id="premium_monthly",
+    subscription={"listings": [{"languageCode": "en-US", "title": "Premium (Monthly)"}]},
+    update_mask="listings",
+)
+```
+
+### delete_subscription
+
+Delete a subscription product from the catalog. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Subscription product ID |
+
+```python
+delete_subscription("com.example.myapp", product_id="premium_monthly")
+```
+
+### batch_get_subscriptions
+
+Get details for multiple subscription products at once. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_ids` | array of string | Yes | Subscription product IDs to retrieve (up to 100) |
+
+```python
+batch_get_subscriptions("com.example.myapp", product_ids=["premium_monthly", "premium_yearly"])
+```
+
+### batch_update_subscriptions
+
+Update multiple subscription products in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `requests` | array of object | Yes | UpdateSubscriptionRequest bodies (each with `subscription`, `updateMask`, and optional `regionsVersion`) |
+
+```python
+batch_update_subscriptions(
+    package_name="com.example.myapp",
+    requests=[
+        {
+            "subscription": {
+                "packageName": "com.example.myapp",
+                "productId": "premium_monthly",
+                "listings": [{"languageCode": "en-US", "title": "Premium Monthly"}],
+            },
+            "updateMask": "listings",
+            "regionsVersion": {"version": "2022/02"},
+        }
+    ],
+)
+```
+
+---
+
 ## list_in_app_products
 
 List all in-app products (managed products) for an app.

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -36,6 +36,7 @@ from play_store_mcp.models import (
     Review,
     ReviewReplyResult,
     SubscriptionActionResult,
+    SubscriptionCatalogResult,
     SubscriptionProduct,
     SubscriptionPurchase,
     TesterInfo,
@@ -1932,6 +1933,224 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to batch delete in-app products", error=str(e))
             raise PlayStoreClientError(f"Failed to batch delete in-app products: {e.reason}") from e
+
+    # =========================================================================
+    # Subscription Catalog API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_subscription(package_name: str, data: dict[str, Any]) -> SubscriptionProduct:
+        """Parse a Subscription API resource into a SubscriptionProduct model."""
+        return SubscriptionProduct(
+            product_id=data.get("productId", ""),
+            package_name=package_name,
+            status=None,
+            base_plans=data.get("basePlans", []),
+        )
+
+    def get_subscription(self, package_name: str, product_id: str) -> SubscriptionProduct:
+        """Get details of a specific subscription product.
+
+        Args:
+            package_name: App package name.
+            product_id: Subscription product ID.
+
+        Returns:
+            Subscription product details.
+        """
+        self._logger.info("Getting subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+
+        try:
+            data = (
+                service.monetization()
+                .subscriptions()
+                .get(packageName=package_name, productId=product_id)
+                .execute()
+            )
+            return self._parse_subscription(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to get subscription", error=str(e))
+            raise PlayStoreClientError(f"Failed to get subscription: {e.reason}") from e
+
+    def create_subscription(
+        self,
+        package_name: str,
+        product_id: str,
+        subscription: dict[str, Any],
+        regions_version: str = "2022/02",
+    ) -> SubscriptionProduct:
+        """Create a new subscription product.
+
+        Args:
+            package_name: App package name.
+            product_id: Subscription product ID (query param).
+            subscription: Subscription resource body.
+            regions_version: Version of available regions to use for regional prices.
+
+        Returns:
+            The created subscription product.
+        """
+        self._logger.info("Creating subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .create(
+                    packageName=package_name,
+                    productId=product_id,
+                    regionsVersion_version=regions_version,
+                    body=subscription,
+                )
+                .execute()
+            )
+            return self._parse_subscription(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create subscription", error=str(e))
+            raise PlayStoreClientError(f"Failed to create subscription: {e.reason}") from e
+
+    def patch_subscription(
+        self,
+        package_name: str,
+        product_id: str,
+        subscription: dict[str, Any],
+        update_mask: str,
+        regions_version: str = "2022/02",
+    ) -> SubscriptionProduct:
+        """Partially update an existing subscription product.
+
+        Args:
+            package_name: App package name.
+            product_id: Subscription product ID.
+            subscription: Partial Subscription resource body.
+            update_mask: Comma-separated list of fields to update.
+            regions_version: Version of available regions to use for regional prices.
+
+        Returns:
+            The patched subscription product.
+        """
+        self._logger.info("Patching subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .patch(
+                    packageName=package_name,
+                    productId=product_id,
+                    updateMask=update_mask,
+                    regionsVersion_version=regions_version,
+                    body=subscription,
+                )
+                .execute()
+            )
+            return self._parse_subscription(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to patch subscription", error=str(e))
+            raise PlayStoreClientError(f"Failed to patch subscription: {e.reason}") from e
+
+    def delete_subscription(self, package_name: str, product_id: str) -> SubscriptionCatalogResult:
+        """Delete a subscription product.
+
+        Args:
+            package_name: App package name.
+            product_id: Subscription product ID.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info("Deleting subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+
+        try:
+            service.monetization().subscriptions().delete(
+                packageName=package_name, productId=product_id
+            ).execute()
+
+            return SubscriptionCatalogResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                message=f"Subscription {product_id} deleted successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete subscription", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete subscription: {e.reason}") from e
+
+    def batch_get_subscriptions(
+        self, package_name: str, product_ids: list[str]
+    ) -> list[SubscriptionProduct]:
+        """Get details for multiple subscription products.
+
+        Args:
+            package_name: App package name.
+            product_ids: List of subscription product IDs to retrieve.
+
+        Returns:
+            List of subscription products.
+        """
+        self._logger.info(
+            "Batch getting subscriptions", package_name=package_name, count=len(product_ids)
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .batchGet(packageName=package_name, productIds=product_ids)
+                .execute()
+            )
+
+            return [
+                self._parse_subscription(package_name, data)
+                for data in result.get("subscriptions", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch get subscriptions", error=str(e))
+            raise PlayStoreClientError(f"Failed to batch get subscriptions: {e.reason}") from e
+
+    def batch_update_subscriptions(
+        self, package_name: str, requests: list[dict[str, Any]]
+    ) -> list[SubscriptionProduct]:
+        """Update multiple subscription products in a single operation.
+
+        Args:
+            package_name: App package name.
+            requests: List of UpdateSubscriptionRequest bodies.
+
+        Returns:
+            List of updated subscription products.
+        """
+        self._logger.info(
+            "Batch updating subscriptions", package_name=package_name, count=len(requests)
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .batchUpdate(packageName=package_name, body={"requests": requests})
+                .execute()
+            )
+
+            return [
+                self._parse_subscription(package_name, data)
+                for data in result.get("subscriptions", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch update subscriptions", error=str(e))
+            raise PlayStoreClientError(f"Failed to batch update subscriptions: {e.reason}") from e
 
     # =========================================================================
     # Store Listings API

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -295,6 +295,18 @@ class SubscriptionActionResult(BaseModel):
     error: str | None = Field(None, description="Error details if failed")
 
 
+class SubscriptionCatalogResult(BaseModel):
+    """Result of a delete action on a subscription catalog product."""
+
+    success: bool = Field(..., description="Whether the action succeeded")
+    package_name: str = Field(..., description="App package name")
+    product_id: str | None = Field(
+        None, description="Subscription product ID (None for batch operations)"
+    )
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
 class ProductPurchaseV2(BaseModel):
     """Status of an in-app product purchase (Purchases.productsv2)."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1052,6 +1052,171 @@ def batch_delete_in_app_products(
 
 
 # =============================================================================
+# Subscription Catalog Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_subscription(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Get details of a specific subscription product.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+
+    Returns:
+        Subscription product details including base plans
+    """
+    client = get_client_from_context()
+
+    subscription = client.get_subscription(package_name, product_id)
+    return subscription.model_dump()
+
+
+@mcp.tool()
+def create_subscription(
+    package_name: str,
+    product_id: str,
+    subscription: dict[str, Any],
+    regions_version: str = "2022/02",
+) -> dict[str, Any]:
+    """Create a new subscription product in the catalog.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+        subscription: Subscription resource body (e.g. basePlans, listings)
+        regions_version: Version of available regions for regional prices (default: "2022/02")
+
+    Returns:
+        The created subscription product
+    """
+    if blocked := _read_only_block("create_subscription"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_subscription(
+        package_name=package_name,
+        product_id=product_id,
+        subscription=subscription,
+        regions_version=regions_version,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def patch_subscription(
+    package_name: str,
+    product_id: str,
+    subscription: dict[str, Any],
+    update_mask: str,
+    regions_version: str = "2022/02",
+) -> dict[str, Any]:
+    """Partially update an existing subscription product.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+        subscription: Partial Subscription resource body with fields to change
+        update_mask: Comma-separated list of fields to update
+        regions_version: Version of available regions for regional prices (default: "2022/02")
+
+    Returns:
+        The patched subscription product
+    """
+    if blocked := _read_only_block("patch_subscription"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.patch_subscription(
+        package_name=package_name,
+        product_id=product_id,
+        subscription=subscription,
+        update_mask=update_mask,
+        regions_version=regions_version,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_subscription(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Delete a subscription product from the catalog.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("delete_subscription"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_subscription(package_name=package_name, product_id=product_id)
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_get_subscriptions(
+    package_name: str,
+    product_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Get details for multiple subscription products at once.
+
+    Args:
+        package_name: App package name
+        product_ids: List of subscription product IDs to retrieve
+
+    Returns:
+        List of subscription products
+    """
+    client = get_client_from_context()
+
+    subscriptions = client.batch_get_subscriptions(
+        package_name=package_name, product_ids=product_ids
+    )
+    return [sub.model_dump() for sub in subscriptions]
+
+
+@mcp.tool()
+def batch_update_subscriptions(
+    package_name: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """Update multiple subscription products in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        requests: List of UpdateSubscriptionRequest bodies (each with subscription,
+            updateMask, and optional regionsVersion)
+
+    Returns:
+        List of updated subscription products, or an error object in read-only mode
+    """
+    if blocked := _read_only_block("batch_update_subscriptions"):
+        return blocked
+    client = get_client_from_context()
+
+    subscriptions = client.batch_update_subscriptions(package_name=package_name, requests=requests)
+    return [sub.model_dump() for sub in subscriptions]
+
+
+# =============================================================================
 # Store Listings Tools
 # =============================================================================
 

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -154,6 +154,31 @@ WRITE_TOOLS = [
         "batch_delete_in_app_products",
         {"package_name": "com.example.app", "skus": ["sku1", "sku2"]},
     ),
+    (
+        "create_subscription",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "subscription": {"productId": "premium_monthly"},
+        },
+    ),
+    (
+        "patch_subscription",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "subscription": {"productId": "premium_monthly"},
+            "update_mask": "basePlans",
+        },
+    ),
+    (
+        "delete_subscription",
+        {"package_name": "com.example.app", "product_id": "premium_monthly"},
+    ),
+    (
+        "batch_update_subscriptions",
+        {"package_name": "com.example.app", "requests": [{"subscription": {}}]},
+    ),
 ]
 
 

--- a/tests/test_subscription_catalog.py
+++ b/tests/test_subscription_catalog.py
@@ -1,0 +1,451 @@
+"""Tests for subscription catalog management (get/create/patch/delete/batch)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import SubscriptionCatalogResult, SubscriptionProduct
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_catalog_result_defaults():
+    r = SubscriptionCatalogResult(
+        success=True,
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        message="ok",
+    )
+    assert r.success is True
+    assert r.product_id == "premium_monthly"
+    assert r.error is None
+
+
+def test_subscription_catalog_result_batch_product_id_none():
+    r = SubscriptionCatalogResult(success=True, package_name="com.example.app", message="ok")
+    assert r.product_id is None
+    assert r.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _subs(service: MagicMock) -> MagicMock:
+    return service.monetization.return_value.subscriptions.return_value
+
+
+_SUBSCRIPTION_RESPONSE = {
+    "productId": "premium_monthly",
+    "packageName": "com.example.app",
+    "basePlans": [{"basePlanId": "monthly", "state": "ACTIVE"}],
+    "listings": [{"languageCode": "en-US", "title": "Premium Monthly"}],
+    "archived": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: get
+# ---------------------------------------------------------------------------
+
+
+def test_get_subscription_success():
+    service = MagicMock()
+    _subs(service).get.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    result = client.get_subscription("com.example.app", "premium_monthly")
+
+    assert isinstance(result, SubscriptionProduct)
+    assert result.product_id == "premium_monthly"
+    assert result.package_name == "com.example.app"
+    assert result.status is None
+    assert result.base_plans == [{"basePlanId": "monthly", "state": "ACTIVE"}]
+    _subs(service).get.assert_called_once_with(
+        packageName="com.example.app", productId="premium_monthly"
+    )
+
+
+def test_get_subscription_missing_fields():
+    service = MagicMock()
+    _subs(service).get.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.get_subscription("com.example.app", "premium_monthly")
+
+    assert result.product_id == ""
+    assert result.base_plans == []
+    assert result.status is None
+
+
+def test_get_subscription_http_error():
+    service = MagicMock()
+    _subs(service).get.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to get subscription"):
+        client.get_subscription("com.example.app", "premium_monthly")
+
+
+# ---------------------------------------------------------------------------
+# Client: create
+# ---------------------------------------------------------------------------
+
+
+def test_create_subscription_success_defaults():
+    service = MagicMock()
+    _subs(service).create.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    body = {"productId": "premium_monthly", "basePlans": []}
+    result = client.create_subscription("com.example.app", "premium_monthly", body)
+
+    assert result.product_id == "premium_monthly"
+    _subs(service).create.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        regionsVersion_version="2022/02",
+        body=body,
+    )
+
+
+def test_create_subscription_custom_regions_version():
+    service = MagicMock()
+    _subs(service).create.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    body = {"productId": "premium_monthly"}
+    client.create_subscription(
+        "com.example.app", "premium_monthly", body, regions_version="2023/06"
+    )
+
+    _subs(service).create.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        regionsVersion_version="2023/06",
+        body=body,
+    )
+
+
+def test_create_subscription_http_error():
+    service = MagicMock()
+    _subs(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create subscription"):
+        client.create_subscription("com.example.app", "premium_monthly", {"productId": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Client: patch
+# ---------------------------------------------------------------------------
+
+
+def test_patch_subscription_success():
+    service = MagicMock()
+    _subs(service).patch.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    body = {"listings": [{"languageCode": "en-US", "title": "Premium"}]}
+    result = client.patch_subscription(
+        "com.example.app", "premium_monthly", body, update_mask="listings"
+    )
+
+    assert result.product_id == "premium_monthly"
+    _subs(service).patch.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        updateMask="listings",
+        regionsVersion_version="2022/02",
+        body=body,
+    )
+
+
+def test_patch_subscription_custom_regions_version():
+    service = MagicMock()
+    _subs(service).patch.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    body = {"archived": True}
+    client.patch_subscription(
+        "com.example.app",
+        "premium_monthly",
+        body,
+        update_mask="archived",
+        regions_version="2023/06",
+    )
+
+    _subs(service).patch.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        updateMask="archived",
+        regionsVersion_version="2023/06",
+        body=body,
+    )
+
+
+def test_patch_subscription_http_error():
+    service = MagicMock()
+    _subs(service).patch.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to patch subscription"):
+        client.patch_subscription(
+            "com.example.app", "premium_monthly", {"archived": True}, update_mask="archived"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_subscription_success():
+    service = MagicMock()
+    client = _client(service)
+
+    result = client.delete_subscription("com.example.app", "premium_monthly")
+
+    assert isinstance(result, SubscriptionCatalogResult)
+    assert result.success is True
+    assert result.product_id == "premium_monthly"
+    assert "premium_monthly" in result.message
+    _subs(service).delete.assert_called_once_with(
+        packageName="com.example.app", productId="premium_monthly"
+    )
+
+
+def test_delete_subscription_http_error():
+    service = MagicMock()
+    _subs(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete subscription"):
+        client.delete_subscription("com.example.app", "premium_monthly")
+
+
+# ---------------------------------------------------------------------------
+# Client: batchGet
+# ---------------------------------------------------------------------------
+
+
+def test_batch_get_subscriptions_success():
+    service = MagicMock()
+    _subs(service).batchGet.return_value.execute.return_value = {
+        "subscriptions": [
+            _SUBSCRIPTION_RESPONSE,
+            {"productId": "premium_yearly", "basePlans": []},
+        ]
+    }
+    client = _client(service)
+
+    result = client.batch_get_subscriptions(
+        "com.example.app", ["premium_monthly", "premium_yearly"]
+    )
+
+    assert [s.product_id for s in result] == ["premium_monthly", "premium_yearly"]
+    assert result[1].base_plans == []
+    _subs(service).batchGet.assert_called_once_with(
+        packageName="com.example.app", productIds=["premium_monthly", "premium_yearly"]
+    )
+
+
+def test_batch_get_subscriptions_empty():
+    service = MagicMock()
+    _subs(service).batchGet.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_get_subscriptions("com.example.app", ["premium_monthly"])
+
+    assert result == []
+
+
+def test_batch_get_subscriptions_http_error():
+    service = MagicMock()
+    _subs(service).batchGet.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch get subscriptions"):
+        client.batch_get_subscriptions("com.example.app", ["premium_monthly"])
+
+
+# ---------------------------------------------------------------------------
+# Client: batchUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_subscriptions_success():
+    service = MagicMock()
+    _subs(service).batchUpdate.return_value.execute.return_value = {
+        "subscriptions": [_SUBSCRIPTION_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [
+        {
+            "subscription": {"productId": "premium_monthly"},
+            "updateMask": "listings",
+        }
+    ]
+    result = client.batch_update_subscriptions("com.example.app", requests)
+
+    assert [s.product_id for s in result] == ["premium_monthly"]
+    _subs(service).batchUpdate.assert_called_once_with(
+        packageName="com.example.app", body={"requests": requests}
+    )
+
+
+def test_batch_update_subscriptions_empty():
+    service = MagicMock()
+    _subs(service).batchUpdate.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_subscriptions(
+        "com.example.app", [{"subscription": {"productId": "x"}}]
+    )
+
+    assert result == []
+
+
+def test_batch_update_subscriptions_http_error():
+    service = MagicMock()
+    _subs(service).batchUpdate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch update subscriptions"):
+        client.batch_update_subscriptions("com.example.app", [{"subscription": {}}])
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_get_subscription(monkeypatch):
+    mc = MagicMock()
+    mc.get_subscription.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.get_subscription("com.example.app", "premium_monthly")
+
+    assert result["product_id"] == "premium_monthly"
+    mc.get_subscription.assert_called_once_with("com.example.app", "premium_monthly")
+
+
+def test_tool_create_subscription(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_subscription.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"productId": "premium_monthly"}
+    result = server.create_subscription("com.example.app", "premium_monthly", body)
+
+    assert result["product_id"] == "premium_monthly"
+    mc.create_subscription.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        subscription=body,
+        regions_version="2022/02",
+    )
+
+
+def test_tool_patch_subscription(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.patch_subscription.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"archived": True}
+    result = server.patch_subscription(
+        "com.example.app", "premium_monthly", body, update_mask="archived"
+    )
+
+    assert result["product_id"] == "premium_monthly"
+    mc.patch_subscription.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        subscription=body,
+        update_mask="archived",
+        regions_version="2022/02",
+    )
+
+
+def test_tool_delete_subscription(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_subscription.return_value = SubscriptionCatalogResult(
+        success=True,
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        message="ok",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_subscription("com.example.app", "premium_monthly")
+
+    assert result["success"] is True
+    mc.delete_subscription.assert_called_once_with(
+        package_name="com.example.app", product_id="premium_monthly"
+    )
+
+
+def test_tool_batch_get_subscriptions(monkeypatch):
+    mc = MagicMock()
+    mc.batch_get_subscriptions.return_value = [
+        SubscriptionProduct(product_id="premium_monthly", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.batch_get_subscriptions("com.example.app", ["premium_monthly"])
+
+    assert result[0]["product_id"] == "premium_monthly"
+    mc.batch_get_subscriptions.assert_called_once_with(
+        package_name="com.example.app", product_ids=["premium_monthly"]
+    )
+
+
+def test_tool_batch_update_subscriptions(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_subscriptions.return_value = [
+        SubscriptionProduct(product_id="premium_monthly", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"subscription": {"productId": "premium_monthly"}, "updateMask": "listings"}]
+    result = server.batch_update_subscriptions("com.example.app", requests)
+
+    assert result[0]["product_id"] == "premium_monthly"
+    mc.batch_update_subscriptions.assert_called_once_with(
+        package_name="com.example.app", requests=requests
+    )


### PR DESCRIPTION
## Summary

Adds catalog authoring for `monetization.subscriptions` (the server previously only had `list`):

- **`get_subscription`** / **`batch_get_subscriptions`** — reads
- **`create_subscription`** (`productId` query + `regionsVersion_version`) — write
- **`patch_subscription`** (`update_mask` + `regionsVersion_version`) — write
- **`delete_subscription`** — write
- **`batch_update_subscriptions`** — write

The 4 writes are read-only-gated and in `WRITE_TOOLS`.

## Changes
- `models.py`: `SubscriptionCatalogResult` (delete result).
- `client.py`: 6 methods + `_parse_subscription` helper (Subscription → `SubscriptionProduct`). Pass-through `dict` bodies. googleapiclient kwargs verified vs discovery rev 20260701: `regionsVersion_version` (flattened dotted query), `updateMask`, `productIds` (repeated).
- `server.py`: 6 tools (`batch_update_subscriptions` return-type widened to `list | dict` so the read-only guard's dict error works).
- Tests: `tests/test_subscription_catalog.py` + 4 `WRITE_TOOLS` entries.
- Docs: `docs/tools/subscriptions.md` + `docs/tools-reference.md`.

## Validation
- `pytest` → **333 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2