### PR TITLE
feat: add subscription base plan management

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -41,6 +41,12 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | `patch_subscription` | Partially update a subscription product (write) |
 | `delete_subscription` | Delete a subscription product (write) |
 | `batch_update_subscriptions` | Update multiple subscription products at once (write) |
+| `activate_base_plan` | Activate a subscription base plan (write) |
+| `deactivate_base_plan` | Deactivate a subscription base plan (write) |
+| `delete_base_plan` | Delete a subscription base plan (write) |
+| `migrate_base_plan_prices` | Migrate subscribers to current base plan prices (write) |
+| `batch_migrate_base_plan_prices` | Migrate prices for multiple base plans at once (write) |
+| `batch_update_base_plan_states` | Activate/deactivate multiple base plans at once (write) |
 | [`get_subscription_status`](tools/subscriptions.md#get_subscription_status) | Check subscription purchase status |
 | [`list_voided_purchases`](tools/subscriptions.md#list_voided_purchases) | List voided purchases |
 

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -187,6 +187,138 @@ batch_update_subscriptions(
 
 ---
 
+## Subscription Base Plans
+
+Manage base plans within a subscription (`monetization.subscriptions.basePlans`).
+All tools here are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+Activating and deactivating (including the batch state update) return the updated
+[Subscription](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions)
+as a subscription product. The price-migration tools take/return raw
+[MigrateBasePlanPrices](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans/migratePrices)
+request/response bodies.
+
+### activate_base_plan
+
+Activate a base plan, making it available to new subscribers. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `base_plan_id` | string | Yes | Base plan ID to activate |
+
+```python
+activate_base_plan("com.example.myapp", product_id="premium", base_plan_id="monthly")
+```
+
+### deactivate_base_plan
+
+Deactivate a base plan so it is unavailable to new subscribers (existing subscribers keep it). **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `base_plan_id` | string | Yes | Base plan ID to deactivate |
+
+```python
+deactivate_base_plan("com.example.myapp", product_id="premium", base_plan_id="monthly")
+```
+
+### delete_base_plan
+
+Delete a base plan (must be inactive with no active subscribers). **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `base_plan_id` | string | Yes | Base plan ID to delete |
+
+```python
+delete_base_plan("com.example.myapp", product_id="premium", base_plan_id="monthly")
+```
+
+### migrate_base_plan_prices
+
+Migrate subscribers to the base plan's current prices. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `base_plan_id` | string | Yes | Base plan ID whose prices to migrate |
+| `request` | object | Yes | MigrateBasePlanPricesRequest body (`regionalPriceMigrations`, `regionsVersion`) |
+
+Returns the raw `MigrateBasePlanPricesResponse` dict.
+
+```python
+migrate_base_plan_prices(
+    package_name="com.example.myapp",
+    product_id="premium",
+    base_plan_id="monthly",
+    request={
+        "regionalPriceMigrations": [
+            {"regionCode": "US", "oldestAllowedPriceVersionTime": "2023-01-01T00:00:00Z"}
+        ],
+        "regionsVersion": {"version": "2022/02"},
+    },
+)
+```
+
+### batch_migrate_base_plan_prices
+
+Migrate prices for multiple base plans in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `requests` | array of object | Yes | MigrateBasePlanPricesRequest bodies |
+
+Returns the raw `BatchMigrateBasePlanPricesResponse` dict.
+
+```python
+batch_migrate_base_plan_prices(
+    package_name="com.example.myapp",
+    product_id="premium",
+    requests=[
+        {
+            "basePlanId": "monthly",
+            "regionalPriceMigrations": [],
+            "regionsVersion": {"version": "2022/02"},
+        }
+    ],
+)
+```
+
+### batch_update_base_plan_states
+
+Activate or deactivate multiple base plans in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent subscription product ID |
+| `requests` | array of object | Yes | UpdateBasePlanStateRequest bodies (each with a nested `activateBasePlanRequest` or `deactivateBasePlanRequest`) |
+
+Returns the updated subscription product.
+
+```python
+batch_update_base_plan_states(
+    package_name="com.example.myapp",
+    product_id="premium",
+    requests=[
+        {"activateBasePlanRequest": {"basePlanId": "monthly"}},
+        {"deactivateBasePlanRequest": {"basePlanId": "yearly"}},
+    ],
+)
+```
+
+---
+
 ## list_in_app_products
 
 List all in-app products (managed products) for an app.

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -2153,6 +2153,276 @@ class PlayStoreClient:
             raise PlayStoreClientError(f"Failed to batch update subscriptions: {e.reason}") from e
 
     # =========================================================================
+    # Subscription Base Plans API
+    # =========================================================================
+
+    def activate_base_plan(
+        self, package_name: str, product_id: str, base_plan_id: str
+    ) -> SubscriptionProduct:
+        """Activate a subscription base plan.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            base_plan_id: Base plan ID to activate.
+
+        Returns:
+            The updated subscription product.
+        """
+        self._logger.info(
+            "Activating base plan",
+            package_name=package_name,
+            product_id=product_id,
+            base_plan_id=base_plan_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .activate(
+                    packageName=package_name,
+                    productId=product_id,
+                    basePlanId=base_plan_id,
+                    body={
+                        "packageName": package_name,
+                        "productId": product_id,
+                        "basePlanId": base_plan_id,
+                    },
+                )
+                .execute()
+            )
+            return self._parse_subscription(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to activate base plan", error=str(e))
+            raise PlayStoreClientError(f"Failed to activate base plan: {e.reason}") from e
+
+    def deactivate_base_plan(
+        self, package_name: str, product_id: str, base_plan_id: str
+    ) -> SubscriptionProduct:
+        """Deactivate a subscription base plan.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            base_plan_id: Base plan ID to deactivate.
+
+        Returns:
+            The updated subscription product.
+        """
+        self._logger.info(
+            "Deactivating base plan",
+            package_name=package_name,
+            product_id=product_id,
+            base_plan_id=base_plan_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .deactivate(
+                    packageName=package_name,
+                    productId=product_id,
+                    basePlanId=base_plan_id,
+                    body={
+                        "packageName": package_name,
+                        "productId": product_id,
+                        "basePlanId": base_plan_id,
+                    },
+                )
+                .execute()
+            )
+            return self._parse_subscription(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to deactivate base plan", error=str(e))
+            raise PlayStoreClientError(f"Failed to deactivate base plan: {e.reason}") from e
+
+    def delete_base_plan(
+        self, package_name: str, product_id: str, base_plan_id: str
+    ) -> SubscriptionCatalogResult:
+        """Delete a subscription base plan.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            base_plan_id: Base plan ID to delete.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Deleting base plan",
+            package_name=package_name,
+            product_id=product_id,
+            base_plan_id=base_plan_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.monetization().subscriptions().basePlans().delete(
+                packageName=package_name,
+                productId=product_id,
+                basePlanId=base_plan_id,
+            ).execute()
+
+            return SubscriptionCatalogResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                message=f"Base plan {base_plan_id} deleted successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete base plan", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete base plan: {e.reason}") from e
+
+    def migrate_base_plan_prices(
+        self,
+        package_name: str,
+        product_id: str,
+        base_plan_id: str,
+        request: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Migrate subscribers to the current base plan prices.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            base_plan_id: Base plan ID whose prices to migrate.
+            request: MigrateBasePlanPricesRequest body.
+
+        Returns:
+            The raw MigrateBasePlanPricesResponse dict.
+        """
+        self._logger.info(
+            "Migrating base plan prices",
+            package_name=package_name,
+            product_id=product_id,
+            base_plan_id=base_plan_id,
+        )
+        service = self._get_service()
+
+        try:
+            result: dict[str, Any] = (
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .migratePrices(
+                    packageName=package_name,
+                    productId=product_id,
+                    basePlanId=base_plan_id,
+                    body=request,
+                )
+                .execute()
+            )
+            return result
+
+        except HttpError as e:
+            self._logger.exception("Failed to migrate base plan prices", error=str(e))
+            raise PlayStoreClientError(f"Failed to migrate base plan prices: {e.reason}") from e
+
+    def batch_migrate_base_plan_prices(
+        self,
+        package_name: str,
+        product_id: str,
+        requests: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Migrate prices for multiple base plans in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            requests: List of MigrateBasePlanPricesRequest bodies.
+
+        Returns:
+            The raw BatchMigrateBasePlanPricesResponse dict.
+        """
+        self._logger.info(
+            "Batch migrating base plan prices",
+            package_name=package_name,
+            product_id=product_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result: dict[str, Any] = (
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .batchMigratePrices(
+                    packageName=package_name,
+                    productId=product_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+            return result
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch migrate base plan prices", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch migrate base plan prices: {e.reason}"
+            ) from e
+
+    def batch_update_base_plan_states(
+        self,
+        package_name: str,
+        product_id: str,
+        requests: list[dict[str, Any]],
+    ) -> SubscriptionProduct:
+        """Activate or deactivate multiple base plans in a single operation.
+
+        The API returns one updated subscription per request in order; this
+        returns the first one (all requests here target the same subscription).
+
+        Args:
+            package_name: App package name.
+            product_id: Parent subscription product ID.
+            requests: List of UpdateBasePlanStateRequest bodies (each with a
+                nested activateBasePlanRequest or deactivateBasePlanRequest).
+
+        Returns:
+            The updated subscription product.
+        """
+        self._logger.info(
+            "Batch updating base plan states",
+            package_name=package_name,
+            product_id=product_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .batchUpdateStates(
+                    packageName=package_name,
+                    productId=product_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+            subscriptions = result.get("subscriptions", [])
+            first = subscriptions[0] if subscriptions else {}
+            return self._parse_subscription(package_name, first)
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch update base plan states", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch update base plan states: {e.reason}"
+            ) from e
+
+    # =========================================================================
     # Store Listings API
     # =========================================================================
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -2377,11 +2377,8 @@ class PlayStoreClient:
         package_name: str,
         product_id: str,
         requests: list[dict[str, Any]],
-    ) -> SubscriptionProduct:
+    ) -> list[SubscriptionProduct]:
         """Activate or deactivate multiple base plans in a single operation.
-
-        The API returns one updated subscription per request in order; this
-        returns the first one (all requests here target the same subscription).
 
         Args:
             package_name: App package name.
@@ -2390,7 +2387,7 @@ class PlayStoreClient:
                 nested activateBasePlanRequest or deactivateBasePlanRequest).
 
         Returns:
-            The updated subscription product.
+            The updated subscriptions, one per request in order.
         """
         self._logger.info(
             "Batch updating base plan states",
@@ -2412,9 +2409,10 @@ class PlayStoreClient:
                 )
                 .execute()
             )
-            subscriptions = result.get("subscriptions", [])
-            first = subscriptions[0] if subscriptions else {}
-            return self._parse_subscription(package_name, first)
+            return [
+                self._parse_subscription(package_name, sub)
+                for sub in result.get("subscriptions", [])
+            ]
 
         except HttpError as e:
             self._logger.exception("Failed to batch update base plan states", error=str(e))

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1217,6 +1217,196 @@ def batch_update_subscriptions(
 
 
 # =============================================================================
+# Subscription Base Plan Tools
+# =============================================================================
+
+
+@mcp.tool()
+def activate_base_plan(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+) -> dict[str, Any]:
+    """Activate a subscription base plan, making it available to new subscribers.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        base_plan_id: Base plan ID to activate
+
+    Returns:
+        The updated subscription product
+    """
+    if blocked := _read_only_block("activate_base_plan"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.activate_base_plan(
+        package_name=package_name,
+        product_id=product_id,
+        base_plan_id=base_plan_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def deactivate_base_plan(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+) -> dict[str, Any]:
+    """Deactivate a subscription base plan, making it unavailable to new subscribers.
+
+    Existing subscribers keep their subscription. Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        base_plan_id: Base plan ID to deactivate
+
+    Returns:
+        The updated subscription product
+    """
+    if blocked := _read_only_block("deactivate_base_plan"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.deactivate_base_plan(
+        package_name=package_name,
+        product_id=product_id,
+        base_plan_id=base_plan_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_base_plan(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+) -> dict[str, Any]:
+    """Delete a subscription base plan.
+
+    Only inactive base plans with no active subscribers can be deleted.
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        base_plan_id: Base plan ID to delete
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("delete_base_plan"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_base_plan(
+        package_name=package_name,
+        product_id=product_id,
+        base_plan_id=base_plan_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def migrate_base_plan_prices(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    """Migrate subscribers to the current base plan prices.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        base_plan_id: Base plan ID whose prices to migrate
+        request: MigrateBasePlanPricesRequest body (e.g. regionalPriceMigrations,
+            regionsVersion)
+
+    Returns:
+        The MigrateBasePlanPricesResponse (raw dict), or an error object in read-only mode
+    """
+    if blocked := _read_only_block("migrate_base_plan_prices"):
+        return blocked
+    client = get_client_from_context()
+
+    return client.migrate_base_plan_prices(
+        package_name=package_name,
+        product_id=product_id,
+        base_plan_id=base_plan_id,
+        request=request,
+    )
+
+
+@mcp.tool()
+def batch_migrate_base_plan_prices(
+    package_name: str,
+    product_id: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Migrate prices for multiple base plans in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        requests: List of MigrateBasePlanPricesRequest bodies
+
+    Returns:
+        The BatchMigrateBasePlanPricesResponse (raw dict), or an error object in
+        read-only mode
+    """
+    if blocked := _read_only_block("batch_migrate_base_plan_prices"):
+        return blocked
+    client = get_client_from_context()
+
+    return client.batch_migrate_base_plan_prices(
+        package_name=package_name,
+        product_id=product_id,
+        requests=requests,
+    )
+
+
+@mcp.tool()
+def batch_update_base_plan_states(
+    package_name: str,
+    product_id: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Activate or deactivate multiple base plans in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent subscription product ID
+        requests: List of UpdateBasePlanStateRequest bodies (each with a nested
+            activateBasePlanRequest or deactivateBasePlanRequest)
+
+    Returns:
+        The updated subscription product
+    """
+    if blocked := _read_only_block("batch_update_base_plan_states"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.batch_update_base_plan_states(
+        package_name=package_name,
+        product_id=product_id,
+        requests=requests,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Store Listings Tools
 # =============================================================================
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1380,7 +1380,7 @@ def batch_update_base_plan_states(
     package_name: str,
     product_id: str,
     requests: list[dict[str, Any]],
-) -> dict[str, Any]:
+) -> list[dict[str, Any]] | dict[str, Any]:
     """Activate or deactivate multiple base plans in a single operation.
 
     Disabled in read-only mode.
@@ -1392,18 +1392,18 @@ def batch_update_base_plan_states(
             activateBasePlanRequest or deactivateBasePlanRequest)
 
     Returns:
-        The updated subscription product
+        The updated subscriptions, one per request
     """
     if blocked := _read_only_block("batch_update_base_plan_states"):
         return blocked
     client = get_client_from_context()
 
-    result = client.batch_update_base_plan_states(
+    results = client.batch_update_base_plan_states(
         package_name=package_name,
         product_id=product_id,
         requests=requests,
     )
-    return result.model_dump()
+    return [result.model_dump() for result in results]
 
 
 # =============================================================================

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -179,6 +179,55 @@ WRITE_TOOLS = [
         "batch_update_subscriptions",
         {"package_name": "com.example.app", "requests": [{"subscription": {}}]},
     ),
+    (
+        "activate_base_plan",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "base_plan_id": "monthly",
+        },
+    ),
+    (
+        "deactivate_base_plan",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "base_plan_id": "monthly",
+        },
+    ),
+    (
+        "delete_base_plan",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "base_plan_id": "monthly",
+        },
+    ),
+    (
+        "migrate_base_plan_prices",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "base_plan_id": "monthly",
+            "request": {"regionsVersion": {"version": "2022/02"}},
+        },
+    ),
+    (
+        "batch_migrate_base_plan_prices",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "requests": [{"basePlanId": "monthly"}],
+        },
+    ),
+    (
+        "batch_update_base_plan_states",
+        {
+            "package_name": "com.example.app",
+            "product_id": "premium_monthly",
+            "requests": [{"activateBasePlanRequest": {"basePlanId": "monthly"}}],
+        },
+    ),
 ]
 
 

--- a/tests/test_subscription_baseplans.py
+++ b/tests/test_subscription_baseplans.py
@@ -224,8 +224,7 @@ def test_batch_update_base_plan_states_success():
     requests = [{"activateBasePlanRequest": {"basePlanId": "monthly"}}]
     result = client.batch_update_base_plan_states("com.example.app", "premium_monthly", requests)
 
-    assert isinstance(result, SubscriptionProduct)
-    assert result.product_id == "premium_monthly"
+    assert [s.product_id for s in result] == ["premium_monthly"]
     _base_plans(service).batchUpdateStates.assert_called_once_with(
         packageName="com.example.app",
         productId="premium_monthly",
@@ -242,9 +241,7 @@ def test_batch_update_base_plan_states_empty():
         "com.example.app", "premium_monthly", [{"activateBasePlanRequest": {}}]
     )
 
-    assert isinstance(result, SubscriptionProduct)
-    assert result.product_id == ""
-    assert result.base_plans == []
+    assert result == []
 
 
 def test_batch_update_base_plan_states_http_error():
@@ -360,15 +357,15 @@ def test_tool_batch_migrate_base_plan_prices(monkeypatch):
 def test_tool_batch_update_base_plan_states(monkeypatch):
     monkeypatch.setattr(server, "READ_ONLY", False)
     mc = MagicMock()
-    mc.batch_update_base_plan_states.return_value = SubscriptionProduct(
-        product_id="premium_monthly", package_name="com.example.app"
-    )
+    mc.batch_update_base_plan_states.return_value = [
+        SubscriptionProduct(product_id="premium_monthly", package_name="com.example.app")
+    ]
     monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
 
     requests = [{"activateBasePlanRequest": {"basePlanId": "monthly"}}]
     result = server.batch_update_base_plan_states("com.example.app", "premium_monthly", requests)
 
-    assert result["product_id"] == "premium_monthly"
+    assert [s["product_id"] for s in result] == ["premium_monthly"]
     mc.batch_update_base_plan_states.assert_called_once_with(
         package_name="com.example.app",
         product_id="premium_monthly",

--- a/tests/test_subscription_baseplans.py
+++ b/tests/test_subscription_baseplans.py
@@ -1,0 +1,376 @@
+"""Tests for subscription base plan management (activate/deactivate/delete/migrate)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import SubscriptionCatalogResult, SubscriptionProduct
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _base_plans(service: MagicMock) -> MagicMock:
+    return service.monetization.return_value.subscriptions.return_value.basePlans.return_value
+
+
+_SUBSCRIPTION_RESPONSE = {
+    "productId": "premium_monthly",
+    "packageName": "com.example.app",
+    "basePlans": [{"basePlanId": "monthly", "state": "ACTIVE"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: activate
+# ---------------------------------------------------------------------------
+
+
+def test_activate_base_plan_success():
+    service = MagicMock()
+    _base_plans(service).activate.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    result = client.activate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert isinstance(result, SubscriptionProduct)
+    assert result.product_id == "premium_monthly"
+    assert result.base_plans == [{"basePlanId": "monthly", "state": "ACTIVE"}]
+    _base_plans(service).activate.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        basePlanId="monthly",
+        body={
+            "packageName": "com.example.app",
+            "productId": "premium_monthly",
+            "basePlanId": "monthly",
+        },
+    )
+
+
+def test_activate_base_plan_http_error():
+    service = MagicMock()
+    _base_plans(service).activate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to activate base plan"):
+        client.activate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+
+# ---------------------------------------------------------------------------
+# Client: deactivate
+# ---------------------------------------------------------------------------
+
+
+def test_deactivate_base_plan_success():
+    service = MagicMock()
+    _base_plans(service).deactivate.return_value.execute.return_value = _SUBSCRIPTION_RESPONSE
+    client = _client(service)
+
+    result = client.deactivate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert isinstance(result, SubscriptionProduct)
+    assert result.product_id == "premium_monthly"
+    _base_plans(service).deactivate.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        basePlanId="monthly",
+        body={
+            "packageName": "com.example.app",
+            "productId": "premium_monthly",
+            "basePlanId": "monthly",
+        },
+    )
+
+
+def test_deactivate_base_plan_http_error():
+    service = MagicMock()
+    _base_plans(service).deactivate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to deactivate base plan"):
+        client.deactivate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+
+# ---------------------------------------------------------------------------
+# Client: delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_base_plan_success():
+    service = MagicMock()
+    client = _client(service)
+
+    result = client.delete_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert isinstance(result, SubscriptionCatalogResult)
+    assert result.success is True
+    assert result.product_id == "premium_monthly"
+    assert "monthly" in result.message
+    _base_plans(service).delete.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        basePlanId="monthly",
+    )
+
+
+def test_delete_base_plan_http_error():
+    service = MagicMock()
+    _base_plans(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete base plan"):
+        client.delete_base_plan("com.example.app", "premium_monthly", "monthly")
+
+
+# ---------------------------------------------------------------------------
+# Client: migratePrices
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_base_plan_prices_success():
+    service = MagicMock()
+    _base_plans(service).migratePrices.return_value.execute.return_value = {"foo": "bar"}
+    client = _client(service)
+
+    request = {"regionalPriceMigrations": [], "regionsVersion": {"version": "2022/02"}}
+    result = client.migrate_base_plan_prices(
+        "com.example.app", "premium_monthly", "monthly", request
+    )
+
+    assert result == {"foo": "bar"}
+    _base_plans(service).migratePrices.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        basePlanId="monthly",
+        body=request,
+    )
+
+
+def test_migrate_base_plan_prices_http_error():
+    service = MagicMock()
+    _base_plans(service).migratePrices.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to migrate base plan prices"):
+        client.migrate_base_plan_prices("com.example.app", "premium_monthly", "monthly", {})
+
+
+# ---------------------------------------------------------------------------
+# Client: batchMigratePrices
+# ---------------------------------------------------------------------------
+
+
+def test_batch_migrate_base_plan_prices_success():
+    service = MagicMock()
+    _base_plans(service).batchMigratePrices.return_value.execute.return_value = {"responses": []}
+    client = _client(service)
+
+    requests = [{"basePlanId": "monthly", "regionsVersion": {"version": "2022/02"}}]
+    result = client.batch_migrate_base_plan_prices("com.example.app", "premium_monthly", requests)
+
+    assert result == {"responses": []}
+    _base_plans(service).batchMigratePrices.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        body={"requests": requests},
+    )
+
+
+def test_batch_migrate_base_plan_prices_http_error():
+    service = MagicMock()
+    _base_plans(service).batchMigratePrices.return_value.execute.side_effect = _make_http_error(
+        "bad"
+    )
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch migrate base plan prices"):
+        client.batch_migrate_base_plan_prices("com.example.app", "premium_monthly", [])
+
+
+# ---------------------------------------------------------------------------
+# Client: batchUpdateStates
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_base_plan_states_success():
+    service = MagicMock()
+    _base_plans(service).batchUpdateStates.return_value.execute.return_value = {
+        "subscriptions": [_SUBSCRIPTION_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [{"activateBasePlanRequest": {"basePlanId": "monthly"}}]
+    result = client.batch_update_base_plan_states("com.example.app", "premium_monthly", requests)
+
+    assert isinstance(result, SubscriptionProduct)
+    assert result.product_id == "premium_monthly"
+    _base_plans(service).batchUpdateStates.assert_called_once_with(
+        packageName="com.example.app",
+        productId="premium_monthly",
+        body={"requests": requests},
+    )
+
+
+def test_batch_update_base_plan_states_empty():
+    service = MagicMock()
+    _base_plans(service).batchUpdateStates.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_base_plan_states(
+        "com.example.app", "premium_monthly", [{"activateBasePlanRequest": {}}]
+    )
+
+    assert isinstance(result, SubscriptionProduct)
+    assert result.product_id == ""
+    assert result.base_plans == []
+
+
+def test_batch_update_base_plan_states_http_error():
+    service = MagicMock()
+    _base_plans(service).batchUpdateStates.return_value.execute.side_effect = _make_http_error(
+        "bad"
+    )
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch update base plan states"):
+        client.batch_update_base_plan_states("com.example.app", "premium_monthly", [])
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_activate_base_plan(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.activate_base_plan.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.activate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert result["product_id"] == "premium_monthly"
+    mc.activate_base_plan.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        base_plan_id="monthly",
+    )
+
+
+def test_tool_deactivate_base_plan(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.deactivate_base_plan.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.deactivate_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert result["product_id"] == "premium_monthly"
+    mc.deactivate_base_plan.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        base_plan_id="monthly",
+    )
+
+
+def test_tool_delete_base_plan(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_base_plan.return_value = SubscriptionCatalogResult(
+        success=True,
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        message="ok",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert result["success"] is True
+    mc.delete_base_plan.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        base_plan_id="monthly",
+    )
+
+
+def test_tool_migrate_base_plan_prices(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.migrate_base_plan_prices.return_value = {"foo": "bar"}
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    request = {"regionsVersion": {"version": "2022/02"}}
+    result = server.migrate_base_plan_prices(
+        "com.example.app", "premium_monthly", "monthly", request
+    )
+
+    assert result == {"foo": "bar"}
+    mc.migrate_base_plan_prices.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        base_plan_id="monthly",
+        request=request,
+    )
+
+
+def test_tool_batch_migrate_base_plan_prices(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_migrate_base_plan_prices.return_value = {"responses": []}
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"basePlanId": "monthly"}]
+    result = server.batch_migrate_base_plan_prices("com.example.app", "premium_monthly", requests)
+
+    assert result == {"responses": []}
+    mc.batch_migrate_base_plan_prices.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        requests=requests,
+    )
+
+
+def test_tool_batch_update_base_plan_states(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_base_plan_states.return_value = SubscriptionProduct(
+        product_id="premium_monthly", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"activateBasePlanRequest": {"basePlanId": "monthly"}}]
+    result = server.batch_update_base_plan_states("com.example.app", "premium_monthly", requests)
+
+    assert result["product_id"] == "premium_monthly"
+    mc.batch_update_base_plan_states.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="premium_monthly",
+        requests=requests,
+    )


### PR DESCRIPTION
## Summary

Adds `monetization.subscriptions.basePlans` management (all writes, read-only-gated) — first half of the base-plans-&-offers subsystem:

- **`activate_base_plan`** / **`deactivate_base_plan`** → updated `Subscription`
- **`delete_base_plan`**
- **`migrate_base_plan_prices`** / **`batch_migrate_base_plan_prices`** → raw response dicts
- **`batch_update_base_plan_states`** → `list[SubscriptionProduct]` (one per request)

## Changes
- `client.py`: 6 methods; reuses `_parse_subscription` + `SubscriptionCatalogResult` (no new models). activate/deactivate echo the required `packageName`/`productId`/`basePlanId` in the request body (per schema). Verified vs discovery rev 20260701.
- `server.py`: 6 write tools, all `_read_only_block`-guarded.
- Tests: `tests/test_subscription_baseplans.py` + 6 `WRITE_TOOLS` entries.
- Docs: `docs/tools/subscriptions.md` + `docs/tools-reference.md`.

## Validation
- `pytest` → **358 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP**; its one MINOR (make `batch_update_base_plan_states` return a list, matching `batch_update_subscriptions`) is applied in this PR.

Offers (`basePlans.offers`) follow in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2