### PR TITLE
feat: add one-time product catalog management

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -76,6 +76,18 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`acknowledge_product_purchase`](tools/subscriptions.md#acknowledge_product_purchase) | Acknowledge an in-app product purchase (write) |
 | [`consume_product_purchase`](tools/subscriptions.md#consume_product_purchase) | Consume an in-app product purchase (write) |
 
+## One-Time Product Tools
+
+| Tool | Description |
+|---|---|
+| [`get_one_time_product`](tools/subscriptions.md#get_one_time_product) | Get details of a specific one-time product |
+| [`list_one_time_products`](tools/subscriptions.md#list_one_time_products) | List all one-time products |
+| [`batch_get_one_time_products`](tools/subscriptions.md#batch_get_one_time_products) | Get details for multiple one-time products at once |
+| `patch_one_time_product` | Create or update a one-time product (write) |
+| `delete_one_time_product` | Delete a one-time product (write) |
+| `batch_update_one_time_products` | Update multiple one-time products at once (write) |
+| `batch_delete_one_time_products` | Delete multiple one-time products at once (write) |
+
 ## Purchase Management Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -740,6 +740,139 @@ batch_delete_in_app_products("com.example.myapp", skus=["premium_upgrade", "coin
 
 ---
 
+## One-Time Products
+
+Manage one-time products (`monetization.oneTimeProducts`) in your catalog. The
+read tools (`get_one_time_product`, `list_one_time_products`, and
+`batch_get_one_time_products`) are available in read-only mode; all other tools
+here are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+The `product` parameter is a
+[OneTimeProduct](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.onetimeproducts)
+resource body — for example `listings`, `purchaseOptions`, `offerTags`, and
+`restrictedPaymentCountries`. Write operations take a `regions_version` (default
+`"2022/02"`) identifying the version of available regions used for regional
+prices. One-time-product-returning tools include: `product_id`, `package_name`,
+`listings`, `purchase_options`, `offer_tags`, and `restricted_payment_countries`.
+
+### get_one_time_product
+
+Get details of a specific one-time product. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | One-time product ID |
+
+```python
+get_one_time_product("com.example.myapp", product_id="coins_pack")
+```
+
+### list_one_time_products
+
+List all one-time products for an app. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+
+```python
+list_one_time_products("com.example.myapp")
+```
+
+### batch_get_one_time_products
+
+Get details for multiple one-time products at once. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_ids` | array of string | Yes | One-time product IDs to retrieve |
+
+```python
+batch_get_one_time_products("com.example.myapp", product_ids=["coins_pack", "gems_pack"])
+```
+
+### patch_one_time_product
+
+Create or update a one-time product — for one-time products, `patch` is
+create-or-update. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `product_id` | string | Yes | — | One-time product ID |
+| `product` | object | Yes | — | Partial OneTimeProduct body with the fields to change |
+| `update_mask` | string | Yes | — | Comma-separated list of fields to update |
+| `regions_version` | string | No | `"2022/02"` | Version of available regions for regional prices |
+
+```python
+patch_one_time_product(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    product={"listings": [{"languageCode": "en-US", "title": "Coins Pack"}]},
+    update_mask="listings",
+)
+```
+
+### delete_one_time_product
+
+Delete a one-time product from the catalog. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | One-time product ID |
+
+```python
+delete_one_time_product("com.example.myapp", product_id="coins_pack")
+```
+
+### batch_update_one_time_products
+
+Update multiple one-time products in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `requests` | array of object | Yes | UpdateOneTimeProductRequest bodies (each with `oneTimeProduct`, `updateMask`, and optional `regionsVersion` / `allowMissing`) |
+
+```python
+batch_update_one_time_products(
+    package_name="com.example.myapp",
+    requests=[
+        {
+            "oneTimeProduct": {
+                "packageName": "com.example.myapp",
+                "productId": "coins_pack",
+                "listings": [{"languageCode": "en-US", "title": "Coins Pack"}],
+            },
+            "updateMask": "listings",
+            "regionsVersion": {"version": "2022/02"},
+        }
+    ],
+)
+```
+
+### batch_delete_one_time_products
+
+Delete multiple one-time products in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `requests` | array of object | Yes | DeleteOneTimeProductRequest bodies (each with `productId` and optional `packageName` / `latencyTolerance`) |
+
+```python
+batch_delete_one_time_products(
+    package_name="com.example.myapp",
+    requests=[{"productId": "coins_pack"}, {"productId": "gems_pack"}],
+)
+```
+
+---
+
 ## Purchase Management
 
 Manage and refund purchases. All actions except `get_product_purchase_v2` are

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -27,6 +27,8 @@ from play_store_mcp.models import (
     InAppProductActionResult,
     Listing,
     ListingUpdateResult,
+    OneTimeProduct,
+    OneTimeProductActionResult,
     Order,
     OrderRefundResult,
     ProductPurchase,
@@ -1934,6 +1936,258 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to batch delete in-app products", error=str(e))
             raise PlayStoreClientError(f"Failed to batch delete in-app products: {e.reason}") from e
+
+    # =========================================================================
+    # One-Time Product Catalog API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_one_time_product(package_name: str, data: dict[str, Any]) -> OneTimeProduct:
+        """Parse a OneTimeProduct API resource into a OneTimeProduct model."""
+        return OneTimeProduct(
+            product_id=data.get("productId", ""),
+            package_name=package_name,
+            listings=data.get("listings", []),
+            purchase_options=data.get("purchaseOptions", []),
+            offer_tags=data.get("offerTags", []),
+            restricted_payment_countries=data.get("restrictedPaymentCountries"),
+        )
+
+    def get_one_time_product(self, package_name: str, product_id: str) -> OneTimeProduct:
+        """Get details of a specific one-time product.
+
+        Args:
+            package_name: App package name.
+            product_id: One-time product ID.
+
+        Returns:
+            One-time product details.
+        """
+        self._logger.info(
+            "Getting one-time product", package_name=package_name, product_id=product_id
+        )
+        service = self._get_service()
+
+        try:
+            data = (
+                service.monetization()
+                .onetimeproducts()
+                .get(packageName=package_name, productId=product_id)
+                .execute()
+            )
+            return self._parse_one_time_product(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to get one-time product", error=str(e))
+            raise PlayStoreClientError(f"Failed to get one-time product: {e.reason}") from e
+
+    def list_one_time_products(self, package_name: str) -> list[OneTimeProduct]:
+        """List one-time products for an app.
+
+        Args:
+            package_name: App package name.
+
+        Returns:
+            List of one-time products.
+        """
+        self._logger.info("Listing one-time products", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization().onetimeproducts().list(packageName=package_name).execute()
+            )
+
+            return [
+                self._parse_one_time_product(package_name, data)
+                for data in result.get("oneTimeProducts", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list one-time products", error=str(e))
+            raise PlayStoreClientError(f"Failed to list one-time products: {e.reason}") from e
+
+    def batch_get_one_time_products(
+        self, package_name: str, product_ids: list[str]
+    ) -> list[OneTimeProduct]:
+        """Get details for multiple one-time products.
+
+        Args:
+            package_name: App package name.
+            product_ids: List of one-time product IDs to retrieve.
+
+        Returns:
+            List of one-time products.
+        """
+        self._logger.info(
+            "Batch getting one-time products", package_name=package_name, count=len(product_ids)
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .batchGet(packageName=package_name, productIds=product_ids)
+                .execute()
+            )
+
+            return [
+                self._parse_one_time_product(package_name, data)
+                for data in result.get("oneTimeProducts", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch get one-time products", error=str(e))
+            raise PlayStoreClientError(f"Failed to batch get one-time products: {e.reason}") from e
+
+    def patch_one_time_product(
+        self,
+        package_name: str,
+        product_id: str,
+        product: dict[str, Any],
+        update_mask: str,
+        regions_version: str = "2022/02",
+    ) -> OneTimeProduct:
+        """Create or update a one-time product (patch is create-or-update).
+
+        Args:
+            package_name: App package name.
+            product_id: One-time product ID.
+            product: Partial OneTimeProduct resource body.
+            update_mask: Comma-separated list of fields to update.
+            regions_version: Version of available regions to use for regional prices.
+
+        Returns:
+            The patched one-time product.
+        """
+        self._logger.info(
+            "Patching one-time product", package_name=package_name, product_id=product_id
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .patch(
+                    packageName=package_name,
+                    productId=product_id,
+                    updateMask=update_mask,
+                    regionsVersion_version=regions_version,
+                    body=product,
+                )
+                .execute()
+            )
+            return self._parse_one_time_product(package_name, result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to patch one-time product", error=str(e))
+            raise PlayStoreClientError(f"Failed to patch one-time product: {e.reason}") from e
+
+    def delete_one_time_product(
+        self, package_name: str, product_id: str
+    ) -> OneTimeProductActionResult:
+        """Delete a one-time product.
+
+        Args:
+            package_name: App package name.
+            product_id: One-time product ID.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Deleting one-time product", package_name=package_name, product_id=product_id
+        )
+        service = self._get_service()
+
+        try:
+            service.monetization().onetimeproducts().delete(
+                packageName=package_name, productId=product_id
+            ).execute()
+
+            return OneTimeProductActionResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                message=f"One-time product {product_id} deleted successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete one-time product", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete one-time product: {e.reason}") from e
+
+    def batch_update_one_time_products(
+        self, package_name: str, requests: list[dict[str, Any]]
+    ) -> list[OneTimeProduct]:
+        """Update multiple one-time products in a single operation.
+
+        Args:
+            package_name: App package name.
+            requests: List of UpdateOneTimeProductRequest bodies.
+
+        Returns:
+            List of updated one-time products.
+        """
+        self._logger.info(
+            "Batch updating one-time products", package_name=package_name, count=len(requests)
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .batchUpdate(packageName=package_name, body={"requests": requests})
+                .execute()
+            )
+
+            return [
+                self._parse_one_time_product(package_name, data)
+                for data in result.get("oneTimeProducts", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch update one-time products", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch update one-time products: {e.reason}"
+            ) from e
+
+    def batch_delete_one_time_products(
+        self, package_name: str, requests: list[dict[str, Any]]
+    ) -> OneTimeProductActionResult:
+        """Delete multiple one-time products in a single operation.
+
+        Args:
+            package_name: App package name.
+            requests: List of DeleteOneTimeProductRequest bodies.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Batch deleting one-time products", package_name=package_name, count=len(requests)
+        )
+        service = self._get_service()
+
+        try:
+            service.monetization().onetimeproducts().batchDelete(
+                packageName=package_name, body={"requests": requests}
+            ).execute()
+
+            return OneTimeProductActionResult(
+                success=True,
+                package_name=package_name,
+                product_id=None,
+                message=f"Deleted {len(requests)} one-time product(s) successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch delete one-time products", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch delete one-time products: {e.reason}"
+            ) from e
 
     # =========================================================================
     # Subscription Catalog API

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -322,6 +322,37 @@ class SubscriptionOffer(BaseModel):
     regions_version: str | None = Field(None, description="Regions catalog version")
 
 
+class OneTimeProduct(BaseModel):
+    """One-time product definition (monetization.oneTimeProducts resource)."""
+
+    product_id: str = Field(..., description="One-time product ID")
+    package_name: str = Field(..., description="App package name")
+    listings: list[dict[str, Any]] = Field(
+        default_factory=list, description="Store listing definitions"
+    )
+    purchase_options: list[dict[str, Any]] = Field(
+        default_factory=list, description="Purchase option definitions"
+    )
+    offer_tags: list[dict[str, Any]] = Field(
+        default_factory=list, description="Offer tag definitions"
+    )
+    restricted_payment_countries: dict[str, Any] | None = Field(
+        None, description="Restricted payment countries configuration"
+    )
+
+
+class OneTimeProductActionResult(BaseModel):
+    """Result of a delete/batch-delete action on a one-time product catalog resource."""
+
+    success: bool = Field(..., description="Whether the action succeeded")
+    package_name: str = Field(..., description="App package name")
+    product_id: str | None = Field(
+        None, description="One-time product ID (None for batch operations)"
+    )
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
 class ProductPurchaseV2(BaseModel):
     """Status of an in-app product purchase (Purchases.productsv2)."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1052,6 +1052,181 @@ def batch_delete_in_app_products(
 
 
 # =============================================================================
+# One-Time Product Catalog Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_one_time_product(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Get details of a specific one-time product.
+
+    Args:
+        package_name: App package name
+        product_id: One-time product ID
+
+    Returns:
+        One-time product details including listings and purchase options
+    """
+    client = get_client_from_context()
+
+    product = client.get_one_time_product(package_name, product_id)
+    return product.model_dump()
+
+
+@mcp.tool()
+def list_one_time_products(
+    package_name: str,
+) -> list[dict[str, Any]]:
+    """List all one-time products for an app.
+
+    Args:
+        package_name: App package name
+
+    Returns:
+        List of one-time products
+    """
+    client = get_client_from_context()
+
+    products = client.list_one_time_products(package_name)
+    return [product.model_dump() for product in products]
+
+
+@mcp.tool()
+def batch_get_one_time_products(
+    package_name: str,
+    product_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Get details for multiple one-time products at once.
+
+    Args:
+        package_name: App package name
+        product_ids: List of one-time product IDs to retrieve
+
+    Returns:
+        List of one-time products
+    """
+    client = get_client_from_context()
+
+    products = client.batch_get_one_time_products(
+        package_name=package_name, product_ids=product_ids
+    )
+    return [product.model_dump() for product in products]
+
+
+@mcp.tool()
+def patch_one_time_product(
+    package_name: str,
+    product_id: str,
+    product: dict[str, Any],
+    update_mask: str,
+    regions_version: str = "2022/02",
+) -> dict[str, Any]:
+    """Create or update a one-time product (patch is create-or-update).
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: One-time product ID
+        product: Partial OneTimeProduct resource body with fields to change
+        update_mask: Comma-separated list of fields to update
+        regions_version: Version of available regions for regional prices (default: "2022/02")
+
+    Returns:
+        The patched one-time product
+    """
+    if blocked := _read_only_block("patch_one_time_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.patch_one_time_product(
+        package_name=package_name,
+        product_id=product_id,
+        product=product,
+        update_mask=update_mask,
+        regions_version=regions_version,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_one_time_product(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Delete a one-time product from the catalog.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: One-time product ID
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("delete_one_time_product"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_one_time_product(package_name=package_name, product_id=product_id)
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_update_one_time_products(
+    package_name: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """Update multiple one-time products in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        requests: List of UpdateOneTimeProductRequest bodies (each with oneTimeProduct,
+            updateMask, and optional regionsVersion / allowMissing)
+
+    Returns:
+        List of updated one-time products, or an error object in read-only mode
+    """
+    if blocked := _read_only_block("batch_update_one_time_products"):
+        return blocked
+    client = get_client_from_context()
+
+    products = client.batch_update_one_time_products(package_name=package_name, requests=requests)
+    return [product.model_dump() for product in products]
+
+
+@mcp.tool()
+def batch_delete_one_time_products(
+    package_name: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Delete multiple one-time products in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        requests: List of DeleteOneTimeProductRequest bodies (each with productId
+            and optional packageName / latencyTolerance)
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("batch_delete_one_time_products"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.batch_delete_one_time_products(package_name=package_name, requests=requests)
+    return result.model_dump()
+
+
+# =============================================================================
 # Subscription Catalog Tools
 # =============================================================================
 

--- a/tests/test_onetimeproducts.py
+++ b/tests/test_onetimeproducts.py
@@ -1,0 +1,511 @@
+"""Tests for one-time product catalog management (get/list/patch/delete/batch)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import OneTimeProduct, OneTimeProductActionResult
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_one_time_product_defaults():
+    p = OneTimeProduct(product_id="coins_pack", package_name="com.example.app")
+    assert p.product_id == "coins_pack"
+    assert p.package_name == "com.example.app"
+    assert p.listings == []
+    assert p.purchase_options == []
+    assert p.offer_tags == []
+    assert p.restricted_payment_countries is None
+
+
+def test_one_time_product_populated():
+    p = OneTimeProduct(
+        product_id="coins_pack",
+        package_name="com.example.app",
+        listings=[{"languageCode": "en-US", "title": "Coins"}],
+        purchase_options=[{"purchaseOptionId": "opt1"}],
+        offer_tags=[{"tag": "promo"}],
+        restricted_payment_countries={"regionCodes": ["US"]},
+    )
+    assert p.listings == [{"languageCode": "en-US", "title": "Coins"}]
+    assert p.purchase_options == [{"purchaseOptionId": "opt1"}]
+    assert p.offer_tags == [{"tag": "promo"}]
+    assert p.restricted_payment_countries == {"regionCodes": ["US"]}
+
+
+def test_one_time_product_action_result_defaults():
+    r = OneTimeProductActionResult(
+        success=True,
+        package_name="com.example.app",
+        product_id="coins_pack",
+        message="ok",
+    )
+    assert r.success is True
+    assert r.product_id == "coins_pack"
+    assert r.error is None
+
+
+def test_one_time_product_action_result_batch_product_id_none():
+    r = OneTimeProductActionResult(success=True, package_name="com.example.app", message="ok")
+    assert r.product_id is None
+    assert r.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _otp(service: MagicMock) -> MagicMock:
+    return service.monetization.return_value.onetimeproducts.return_value
+
+
+_OTP_RESPONSE = {
+    "productId": "coins_pack",
+    "packageName": "com.example.app",
+    "listings": [{"languageCode": "en-US", "title": "Coins Pack"}],
+    "purchaseOptions": [{"purchaseOptionId": "opt1"}],
+    "offerTags": [{"tag": "promo"}],
+    "restrictedPaymentCountries": {"regionCodes": ["US"]},
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: get
+# ---------------------------------------------------------------------------
+
+
+def test_get_one_time_product_success():
+    service = MagicMock()
+    _otp(service).get.return_value.execute.return_value = _OTP_RESPONSE
+    client = _client(service)
+
+    result = client.get_one_time_product("com.example.app", "coins_pack")
+
+    assert isinstance(result, OneTimeProduct)
+    assert result.product_id == "coins_pack"
+    assert result.package_name == "com.example.app"
+    assert result.listings == [{"languageCode": "en-US", "title": "Coins Pack"}]
+    assert result.purchase_options == [{"purchaseOptionId": "opt1"}]
+    assert result.offer_tags == [{"tag": "promo"}]
+    assert result.restricted_payment_countries == {"regionCodes": ["US"]}
+    _otp(service).get.assert_called_once_with(packageName="com.example.app", productId="coins_pack")
+
+
+def test_get_one_time_product_missing_fields():
+    service = MagicMock()
+    _otp(service).get.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.get_one_time_product("com.example.app", "coins_pack")
+
+    assert result.product_id == ""
+    assert result.listings == []
+    assert result.purchase_options == []
+    assert result.offer_tags == []
+    assert result.restricted_payment_countries is None
+
+
+def test_get_one_time_product_http_error():
+    service = MagicMock()
+    _otp(service).get.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to get one-time product"):
+        client.get_one_time_product("com.example.app", "coins_pack")
+
+
+# ---------------------------------------------------------------------------
+# Client: list
+# ---------------------------------------------------------------------------
+
+
+def test_list_one_time_products_success():
+    service = MagicMock()
+    _otp(service).list.return_value.execute.return_value = {
+        "oneTimeProducts": [
+            _OTP_RESPONSE,
+            {"productId": "gems_pack"},
+        ]
+    }
+    client = _client(service)
+
+    result = client.list_one_time_products("com.example.app")
+
+    assert [p.product_id for p in result] == ["coins_pack", "gems_pack"]
+    assert result[1].listings == []
+    _otp(service).list.assert_called_once_with(packageName="com.example.app")
+
+
+def test_list_one_time_products_empty():
+    service = MagicMock()
+    _otp(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_one_time_products("com.example.app")
+
+    assert result == []
+
+
+def test_list_one_time_products_http_error():
+    service = MagicMock()
+    _otp(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list one-time products"):
+        client.list_one_time_products("com.example.app")
+
+
+# ---------------------------------------------------------------------------
+# Client: batchGet
+# ---------------------------------------------------------------------------
+
+
+def test_batch_get_one_time_products_success():
+    service = MagicMock()
+    _otp(service).batchGet.return_value.execute.return_value = {
+        "oneTimeProducts": [
+            _OTP_RESPONSE,
+            {"productId": "gems_pack"},
+        ]
+    }
+    client = _client(service)
+
+    result = client.batch_get_one_time_products("com.example.app", ["coins_pack", "gems_pack"])
+
+    assert [p.product_id for p in result] == ["coins_pack", "gems_pack"]
+    assert result[1].purchase_options == []
+    _otp(service).batchGet.assert_called_once_with(
+        packageName="com.example.app", productIds=["coins_pack", "gems_pack"]
+    )
+
+
+def test_batch_get_one_time_products_empty():
+    service = MagicMock()
+    _otp(service).batchGet.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_get_one_time_products("com.example.app", ["coins_pack"])
+
+    assert result == []
+
+
+def test_batch_get_one_time_products_http_error():
+    service = MagicMock()
+    _otp(service).batchGet.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch get one-time products"):
+        client.batch_get_one_time_products("com.example.app", ["coins_pack"])
+
+
+# ---------------------------------------------------------------------------
+# Client: patch
+# ---------------------------------------------------------------------------
+
+
+def test_patch_one_time_product_success():
+    service = MagicMock()
+    _otp(service).patch.return_value.execute.return_value = _OTP_RESPONSE
+    client = _client(service)
+
+    body = {"listings": [{"languageCode": "en-US", "title": "Coins"}]}
+    result = client.patch_one_time_product(
+        "com.example.app", "coins_pack", body, update_mask="listings"
+    )
+
+    assert result.product_id == "coins_pack"
+    _otp(service).patch.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        updateMask="listings",
+        regionsVersion_version="2022/02",
+        body=body,
+    )
+
+
+def test_patch_one_time_product_custom_regions_version():
+    service = MagicMock()
+    _otp(service).patch.return_value.execute.return_value = _OTP_RESPONSE
+    client = _client(service)
+
+    body = {"offerTags": [{"tag": "promo"}]}
+    client.patch_one_time_product(
+        "com.example.app",
+        "coins_pack",
+        body,
+        update_mask="offerTags",
+        regions_version="2023/06",
+    )
+
+    _otp(service).patch.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        updateMask="offerTags",
+        regionsVersion_version="2023/06",
+        body=body,
+    )
+
+
+def test_patch_one_time_product_http_error():
+    service = MagicMock()
+    _otp(service).patch.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to patch one-time product"):
+        client.patch_one_time_product(
+            "com.example.app", "coins_pack", {"offerTags": []}, update_mask="offerTags"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_one_time_product_success():
+    service = MagicMock()
+    client = _client(service)
+
+    result = client.delete_one_time_product("com.example.app", "coins_pack")
+
+    assert isinstance(result, OneTimeProductActionResult)
+    assert result.success is True
+    assert result.product_id == "coins_pack"
+    assert "coins_pack" in result.message
+    _otp(service).delete.assert_called_once_with(
+        packageName="com.example.app", productId="coins_pack"
+    )
+
+
+def test_delete_one_time_product_http_error():
+    service = MagicMock()
+    _otp(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete one-time product"):
+        client.delete_one_time_product("com.example.app", "coins_pack")
+
+
+# ---------------------------------------------------------------------------
+# Client: batchUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_one_time_products_success():
+    service = MagicMock()
+    _otp(service).batchUpdate.return_value.execute.return_value = {
+        "oneTimeProducts": [_OTP_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [
+        {
+            "oneTimeProduct": {"productId": "coins_pack"},
+            "updateMask": "listings",
+        }
+    ]
+    result = client.batch_update_one_time_products("com.example.app", requests)
+
+    assert [p.product_id for p in result] == ["coins_pack"]
+    _otp(service).batchUpdate.assert_called_once_with(
+        packageName="com.example.app", body={"requests": requests}
+    )
+
+
+def test_batch_update_one_time_products_empty():
+    service = MagicMock()
+    _otp(service).batchUpdate.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_one_time_products(
+        "com.example.app", [{"oneTimeProduct": {"productId": "x"}}]
+    )
+
+    assert result == []
+
+
+def test_batch_update_one_time_products_http_error():
+    service = MagicMock()
+    _otp(service).batchUpdate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch update one-time products"):
+        client.batch_update_one_time_products("com.example.app", [{"oneTimeProduct": {}}])
+
+
+# ---------------------------------------------------------------------------
+# Client: batchDelete
+# ---------------------------------------------------------------------------
+
+
+def test_batch_delete_one_time_products_success():
+    service = MagicMock()
+    client = _client(service)
+
+    requests = [{"productId": "coins_pack"}, {"productId": "gems_pack"}]
+    result = client.batch_delete_one_time_products("com.example.app", requests)
+
+    assert isinstance(result, OneTimeProductActionResult)
+    assert result.success is True
+    assert result.product_id is None
+    assert "2" in result.message
+    _otp(service).batchDelete.assert_called_once_with(
+        packageName="com.example.app", body={"requests": requests}
+    )
+
+
+def test_batch_delete_one_time_products_http_error():
+    service = MagicMock()
+    _otp(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch delete one-time products"):
+        client.batch_delete_one_time_products("com.example.app", [{"productId": "coins_pack"}])
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_get_one_time_product(monkeypatch):
+    mc = MagicMock()
+    mc.get_one_time_product.return_value = OneTimeProduct(
+        product_id="coins_pack", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.get_one_time_product("com.example.app", "coins_pack")
+
+    assert result["product_id"] == "coins_pack"
+    mc.get_one_time_product.assert_called_once_with("com.example.app", "coins_pack")
+
+
+def test_tool_list_one_time_products(monkeypatch):
+    mc = MagicMock()
+    mc.list_one_time_products.return_value = [
+        OneTimeProduct(product_id="coins_pack", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_one_time_products("com.example.app")
+
+    assert result[0]["product_id"] == "coins_pack"
+    mc.list_one_time_products.assert_called_once_with("com.example.app")
+
+
+def test_tool_batch_get_one_time_products(monkeypatch):
+    mc = MagicMock()
+    mc.batch_get_one_time_products.return_value = [
+        OneTimeProduct(product_id="coins_pack", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.batch_get_one_time_products("com.example.app", ["coins_pack"])
+
+    assert result[0]["product_id"] == "coins_pack"
+    mc.batch_get_one_time_products.assert_called_once_with(
+        package_name="com.example.app", product_ids=["coins_pack"]
+    )
+
+
+def test_tool_patch_one_time_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.patch_one_time_product.return_value = OneTimeProduct(
+        product_id="coins_pack", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"listings": [{"languageCode": "en-US", "title": "Coins"}]}
+    result = server.patch_one_time_product(
+        "com.example.app", "coins_pack", body, update_mask="listings"
+    )
+
+    assert result["product_id"] == "coins_pack"
+    mc.patch_one_time_product.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        product=body,
+        update_mask="listings",
+        regions_version="2022/02",
+    )
+
+
+def test_tool_delete_one_time_product(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_one_time_product.return_value = OneTimeProductActionResult(
+        success=True,
+        package_name="com.example.app",
+        product_id="coins_pack",
+        message="ok",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_one_time_product("com.example.app", "coins_pack")
+
+    assert result["success"] is True
+    mc.delete_one_time_product.assert_called_once_with(
+        package_name="com.example.app", product_id="coins_pack"
+    )
+
+
+def test_tool_batch_update_one_time_products(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_one_time_products.return_value = [
+        OneTimeProduct(product_id="coins_pack", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"oneTimeProduct": {"productId": "coins_pack"}, "updateMask": "listings"}]
+    result = server.batch_update_one_time_products("com.example.app", requests)
+
+    assert result[0]["product_id"] == "coins_pack"
+    mc.batch_update_one_time_products.assert_called_once_with(
+        package_name="com.example.app", requests=requests
+    )
+
+
+def test_tool_batch_delete_one_time_products(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_delete_one_time_products.return_value = OneTimeProductActionResult(
+        success=True,
+        package_name="com.example.app",
+        message="ok",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"productId": "coins_pack"}]
+    result = server.batch_delete_one_time_products("com.example.app", requests)
+
+    assert result["success"] is True
+    mc.batch_delete_one_time_products.assert_called_once_with(
+        package_name="com.example.app", requests=requests
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -155,6 +155,27 @@ WRITE_TOOLS = [
         {"package_name": "com.example.app", "skus": ["sku1", "sku2"]},
     ),
     (
+        "patch_one_time_product",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "product": {"productId": "coins_pack"},
+            "update_mask": "listings",
+        },
+    ),
+    (
+        "delete_one_time_product",
+        {"package_name": "com.example.app", "product_id": "coins_pack"},
+    ),
+    (
+        "batch_update_one_time_products",
+        {"package_name": "com.example.app", "requests": [{"oneTimeProduct": {}}]},
+    ),
+    (
+        "batch_delete_one_time_products",
+        {"package_name": "com.example.app", "requests": [{"productId": "coins_pack"}]},
+    ),
+    (
         "create_subscription",
         {
             "package_name": "com.example.app",


### PR DESCRIPTION
## Summary

Adds `monetization.onetimeproducts` core catalog management (purchaseOptions/offers follow in the next PR):

- **Reads**: `get_one_time_product`, `list_one_time_products`, `batch_get_one_time_products`
- **Writes** (read-only-gated): `patch_one_time_product` (create-or-update), `delete_one_time_product`, `batch_update_one_time_products`, `batch_delete_one_time_products`

## Changes
- `models.py`: `OneTimeProduct` + `OneTimeProductActionResult`.
- `client.py`: 7 methods + `_parse_one_time_product` helper. Verified vs discovery rev 20260701: envelope key `oneTimeProducts`, `patch` uses `updateMask`+`regionsVersion_version`, `batchGet` `productIds`, batch bodies `{"requests":[...]}`.
- `server.py`: 7 tools (4 writes guard-first; `batch_update` `list | dict`).
- Tests: `tests/test_onetimeproducts.py` (30) + 4 `WRITE_TOOLS` entries.
- Docs: `docs/tools/subscriptions.md` + `docs/tools-reference.md`.

## Validation
- `pytest` → **438 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (2 non-blocking NITs, consistent with existing conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing one-time in-app products across the app.
  * New tools and client actions now let you view, list, batch fetch, update, and delete one-time products.
  * One-time product responses are now returned in a structured format for easier use.

* **Documentation**
  * Expanded the tools reference with one-time product guidance, including read-only and write-capable operations.
  * Added usage examples for single, batch, and management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->