### PR TITLE
feat: add one-time product purchase options & offers

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -88,6 +88,21 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | `batch_update_one_time_products` | Update multiple one-time products at once (write) |
 | `batch_delete_one_time_products` | Delete multiple one-time products at once (write) |
 
+## One-Time Product Offer Tools
+
+| Tool | Description |
+|---|---|
+| [`list_purchase_option_offers`](tools/subscriptions.md#list_purchase_option_offers) | List all offers for a purchase option |
+| [`batch_get_purchase_option_offers`](tools/subscriptions.md#batch_get_purchase_option_offers) | Get details for multiple one-time product offers at once |
+| `batch_delete_purchase_options` | Delete multiple purchase options at once (write) |
+| `batch_update_purchase_option_states` | Activate/deactivate multiple purchase options at once (write) |
+| `activate_purchase_option_offer` | Activate a one-time product offer (write) |
+| `deactivate_purchase_option_offer` | Deactivate a one-time product offer (write) |
+| `cancel_purchase_option_offer` | Cancel a one-time product offer (write) |
+| `batch_update_purchase_option_offers` | Update multiple one-time product offers at once (write) |
+| `batch_update_purchase_option_offer_states` | Activate/deactivate/cancel multiple one-time product offers at once (write) |
+| `batch_delete_purchase_option_offers` | Delete multiple one-time product offers at once (write) |
+
 ## Purchase Management Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -873,6 +873,222 @@ batch_delete_one_time_products(
 
 ---
 
+## One-Time Product Offers
+
+Manage purchase options and their offers for one-time products
+(`monetization.onetimeproducts.purchaseOptions` and
+`monetization.onetimeproducts.purchaseOptions.offers`). The read tools
+(`list_purchase_option_offers` and `batch_get_purchase_option_offers`) are
+available in read-only mode; all other tools here are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+Offer-returning tools include: `package_name`, `product_id`,
+`purchase_option_id`, `offer_id`, `state`, `offer_tags`, and `regions_version`.
+Where noted, `product_id` and `purchase_option_id` accept the `-` wildcard to
+operate across products / purchase options.
+
+### batch_delete_purchase_options
+
+Delete multiple purchase options from a one-time product in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID |
+| `requests` | array of object | Yes | DeletePurchaseOptionRequest bodies (each with `purchaseOptionId` and optional `latencyTolerance`) |
+
+```python
+batch_delete_purchase_options(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    requests=[{"purchaseOptionId": "opt1"}, {"purchaseOptionId": "opt2"}],
+)
+```
+
+### batch_update_purchase_option_states
+
+Activate or deactivate multiple purchase options in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID |
+| `requests` | array of object | Yes | UpdatePurchaseOptionStateRequest bodies (each with a nested `activatePurchaseOptionRequest` or `deactivatePurchaseOptionRequest`) |
+
+```python
+batch_update_purchase_option_states(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    requests=[{"activatePurchaseOptionRequest": {"purchaseOptionId": "opt1"}}],
+)
+```
+
+### list_purchase_option_offers
+
+List all offers for a one-time product purchase option. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID (`-` wildcard lists across products) |
+| `purchase_option_id` | string | Yes | Parent purchase option ID (`-` wildcard lists across purchase options) |
+
+```python
+list_purchase_option_offers("com.example.myapp", product_id="coins_pack", purchase_option_id="opt1")
+```
+
+### batch_get_purchase_option_offers
+
+Get details for multiple one-time product offers at once. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID (`-` wildcard allowed) |
+| `purchase_option_id` | string | Yes | Parent purchase option ID (`-` wildcard allowed) |
+| `requests` | array of object | Yes | GetOneTimeProductOfferRequest bodies (each with `offerId` and optional `purchaseOptionId` / `productId`) |
+
+```python
+batch_get_purchase_option_offers(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    requests=[{"offerId": "intro"}],
+)
+```
+
+### activate_purchase_option_offer
+
+Activate a one-time product offer, making it available to eligible buyers. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID |
+| `purchase_option_id` | string | Yes | Parent purchase option ID |
+| `offer_id` | string | Yes | One-time product offer ID |
+
+```python
+activate_purchase_option_offer(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    offer_id="intro",
+)
+```
+
+### deactivate_purchase_option_offer
+
+Deactivate a one-time product offer so it is unavailable to new buyers. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID |
+| `purchase_option_id` | string | Yes | Parent purchase option ID |
+| `offer_id` | string | Yes | One-time product offer ID |
+
+```python
+deactivate_purchase_option_offer(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    offer_id="intro",
+)
+```
+
+### cancel_purchase_option_offer
+
+Cancel a one-time product offer (for example, a pre-order offer). **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID |
+| `purchase_option_id` | string | Yes | Parent purchase option ID |
+| `offer_id` | string | Yes | One-time product offer ID |
+
+```python
+cancel_purchase_option_offer(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    offer_id="preorder",
+)
+```
+
+### batch_update_purchase_option_offers
+
+Create or update multiple one-time product offers in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID (`-` wildcard allowed) |
+| `purchase_option_id` | string | Yes | Parent purchase option ID (`-` wildcard allowed) |
+| `requests` | array of object | Yes | UpdateOneTimeProductOfferRequest bodies (each with `oneTimeProductOffer`, `updateMask`, and optional `allowMissing` / `latencyTolerance`) |
+
+```python
+batch_update_purchase_option_offers(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    requests=[
+        {
+            "oneTimeProductOffer": {
+                "packageName": "com.example.myapp",
+                "productId": "coins_pack",
+                "purchaseOptionId": "opt1",
+                "offerId": "intro",
+            },
+            "updateMask": "regionalPricingAndAvailabilityConfigs",
+        }
+    ],
+)
+```
+
+### batch_update_purchase_option_offer_states
+
+Activate, deactivate, or cancel multiple one-time product offers in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID (`-` wildcard allowed) |
+| `purchase_option_id` | string | Yes | Parent purchase option ID (`-` wildcard allowed) |
+| `requests` | array of object | Yes | UpdateOneTimeProductOfferStateRequest bodies (each with a nested activate / deactivate / cancel one-time product offer request) |
+
+```python
+batch_update_purchase_option_offer_states(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    requests=[{"activateOneTimeProductOfferRequest": {"offerId": "intro"}}],
+)
+```
+
+### batch_delete_purchase_option_offers
+
+Delete multiple one-time product offers in a single operation. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | Parent one-time product ID (`-` wildcard allowed) |
+| `purchase_option_id` | string | Yes | Parent purchase option ID (`-` wildcard allowed) |
+| `requests` | array of object | Yes | DeleteOneTimeProductOfferRequest bodies (each with `offerId` and optional `latencyTolerance`) |
+
+```python
+batch_delete_purchase_option_offers(
+    package_name="com.example.myapp",
+    product_id="coins_pack",
+    purchase_option_id="opt1",
+    requests=[{"offerId": "intro"}],
+)
+```
+
+---
+
 ## Purchase Management
 
 Manage and refund purchases. All actions except `get_product_purchase_v2` are

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -29,6 +29,7 @@ from play_store_mcp.models import (
     ListingUpdateResult,
     OneTimeProduct,
     OneTimeProductActionResult,
+    OneTimeProductOffer,
     Order,
     OrderRefundResult,
     ProductPurchase,
@@ -2187,6 +2188,517 @@ class PlayStoreClient:
             self._logger.exception("Failed to batch delete one-time products", error=str(e))
             raise PlayStoreClientError(
                 f"Failed to batch delete one-time products: {e.reason}"
+            ) from e
+
+    # =========================================================================
+    # One-Time Product Purchase Options API
+    # =========================================================================
+
+    def batch_delete_purchase_options(
+        self, package_name: str, product_id: str, requests: list[dict[str, Any]]
+    ) -> OneTimeProductActionResult:
+        """Delete multiple purchase options from a one-time product in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID.
+            requests: List of DeletePurchaseOptionRequest bodies.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Batch deleting purchase options",
+            package_name=package_name,
+            product_id=product_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            service.monetization().onetimeproducts().purchaseOptions().batchDelete(
+                packageName=package_name,
+                productId=product_id,
+                body={"requests": requests},
+            ).execute()
+
+            return OneTimeProductActionResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                message=f"Deleted {len(requests)} purchase option(s) successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch delete purchase options", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch delete purchase options: {e.reason}"
+            ) from e
+
+    def batch_update_purchase_option_states(
+        self, package_name: str, product_id: str, requests: list[dict[str, Any]]
+    ) -> list[OneTimeProduct]:
+        """Activate or deactivate multiple purchase options in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID.
+            requests: List of UpdatePurchaseOptionStateRequest bodies (each with a
+                nested activatePurchaseOptionRequest or deactivatePurchaseOptionRequest).
+
+        Returns:
+            The updated one-time products, one per request in order.
+        """
+        self._logger.info(
+            "Batch updating purchase option states",
+            package_name=package_name,
+            product_id=product_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .batchUpdateStates(
+                    packageName=package_name,
+                    productId=product_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+
+            return [
+                self._parse_one_time_product(package_name, data)
+                for data in result.get("oneTimeProducts", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch update purchase option states", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch update purchase option states: {e.reason}"
+            ) from e
+
+    # =========================================================================
+    # One-Time Product Purchase Option Offers API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_one_time_product_offer(data: dict[str, Any]) -> OneTimeProductOffer:
+        """Parse a OneTimeProductOffer API resource into a OneTimeProductOffer model."""
+        return OneTimeProductOffer(
+            package_name=data.get("packageName", ""),
+            product_id=data.get("productId", ""),
+            purchase_option_id=data.get("purchaseOptionId", ""),
+            offer_id=data.get("offerId", ""),
+            state=data.get("state"),
+            offer_tags=[
+                tag["tag"] for tag in data.get("offerTags", []) if tag.get("tag") is not None
+            ],
+            regions_version=data.get("regionsVersion", {}).get("version"),
+        )
+
+    def list_purchase_option_offers(
+        self, package_name: str, product_id: str, purchase_option_id: str
+    ) -> list[OneTimeProductOffer]:
+        """List all offers for a one-time product purchase option.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID ('-' wildcard allowed).
+            purchase_option_id: Parent purchase option ID ('-' wildcard allowed).
+
+        Returns:
+            List of one-time product offers.
+        """
+        self._logger.info(
+            "Listing purchase option offers",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .list(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                )
+                .execute()
+            )
+            return [
+                self._parse_one_time_product_offer(offer)
+                for offer in result.get("oneTimeProductOffers", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list purchase option offers", error=str(e))
+            raise PlayStoreClientError(f"Failed to list purchase option offers: {e.reason}") from e
+
+    def batch_get_purchase_option_offers(
+        self,
+        package_name: str,
+        product_id: str,
+        purchase_option_id: str,
+        requests: list[dict[str, Any]],
+    ) -> list[OneTimeProductOffer]:
+        """Get details for multiple one-time product offers in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID ('-' wildcard allowed).
+            purchase_option_id: Parent purchase option ID ('-' wildcard allowed).
+            requests: List of GetOneTimeProductOfferRequest bodies.
+
+        Returns:
+            List of one-time product offers.
+        """
+        self._logger.info(
+            "Batch getting purchase option offers",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .batchGet(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+            return [
+                self._parse_one_time_product_offer(offer)
+                for offer in result.get("oneTimeProductOffers", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch get purchase option offers", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch get purchase option offers: {e.reason}"
+            ) from e
+
+    def activate_purchase_option_offer(
+        self, package_name: str, product_id: str, purchase_option_id: str, offer_id: str
+    ) -> OneTimeProductOffer:
+        """Activate a one-time product offer.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID.
+            purchase_option_id: Parent purchase option ID.
+            offer_id: One-time product offer ID to activate.
+
+        Returns:
+            The updated one-time product offer.
+        """
+        self._logger.info(
+            "Activating purchase option offer",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            offer_id=offer_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .activate(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    offerId=offer_id,
+                    body={
+                        "packageName": package_name,
+                        "productId": product_id,
+                        "purchaseOptionId": purchase_option_id,
+                        "offerId": offer_id,
+                    },
+                )
+                .execute()
+            )
+            return self._parse_one_time_product_offer(result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to activate purchase option offer", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to activate purchase option offer: {e.reason}"
+            ) from e
+
+    def deactivate_purchase_option_offer(
+        self, package_name: str, product_id: str, purchase_option_id: str, offer_id: str
+    ) -> OneTimeProductOffer:
+        """Deactivate a one-time product offer.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID.
+            purchase_option_id: Parent purchase option ID.
+            offer_id: One-time product offer ID to deactivate.
+
+        Returns:
+            The updated one-time product offer.
+        """
+        self._logger.info(
+            "Deactivating purchase option offer",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            offer_id=offer_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .deactivate(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    offerId=offer_id,
+                    body={
+                        "packageName": package_name,
+                        "productId": product_id,
+                        "purchaseOptionId": purchase_option_id,
+                        "offerId": offer_id,
+                    },
+                )
+                .execute()
+            )
+            return self._parse_one_time_product_offer(result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to deactivate purchase option offer", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to deactivate purchase option offer: {e.reason}"
+            ) from e
+
+    def cancel_purchase_option_offer(
+        self, package_name: str, product_id: str, purchase_option_id: str, offer_id: str
+    ) -> OneTimeProductOffer:
+        """Cancel a one-time product offer (e.g. a pre-order offer).
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID.
+            purchase_option_id: Parent purchase option ID.
+            offer_id: One-time product offer ID to cancel.
+
+        Returns:
+            The updated one-time product offer.
+        """
+        self._logger.info(
+            "Cancelling purchase option offer",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            offer_id=offer_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .cancel(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    offerId=offer_id,
+                    body={
+                        "packageName": package_name,
+                        "productId": product_id,
+                        "purchaseOptionId": purchase_option_id,
+                        "offerId": offer_id,
+                    },
+                )
+                .execute()
+            )
+            return self._parse_one_time_product_offer(result)
+
+        except HttpError as e:
+            self._logger.exception("Failed to cancel purchase option offer", error=str(e))
+            raise PlayStoreClientError(f"Failed to cancel purchase option offer: {e.reason}") from e
+
+    def batch_update_purchase_option_offers(
+        self,
+        package_name: str,
+        product_id: str,
+        purchase_option_id: str,
+        requests: list[dict[str, Any]],
+    ) -> list[OneTimeProductOffer]:
+        """Create or update multiple one-time product offers in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID ('-' wildcard allowed).
+            purchase_option_id: Parent purchase option ID ('-' wildcard allowed).
+            requests: List of UpdateOneTimeProductOfferRequest bodies.
+
+        Returns:
+            List of updated one-time product offers.
+        """
+        self._logger.info(
+            "Batch updating purchase option offers",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .batchUpdate(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+            return [
+                self._parse_one_time_product_offer(offer)
+                for offer in result.get("oneTimeProductOffers", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch update purchase option offers", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch update purchase option offers: {e.reason}"
+            ) from e
+
+    def batch_update_purchase_option_offer_states(
+        self,
+        package_name: str,
+        product_id: str,
+        purchase_option_id: str,
+        requests: list[dict[str, Any]],
+    ) -> list[OneTimeProductOffer]:
+        """Activate, deactivate or cancel multiple one-time product offers at once.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID ('-' wildcard allowed).
+            purchase_option_id: Parent purchase option ID ('-' wildcard allowed).
+            requests: List of UpdateOneTimeProductOfferStateRequest bodies (each with a
+                nested activate/deactivate/cancel one-time product offer request).
+
+        Returns:
+            The updated one-time product offers, one per request in order.
+        """
+        self._logger.info(
+            "Batch updating purchase option offer states",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .batchUpdateStates(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    body={"requests": requests},
+                )
+                .execute()
+            )
+            return [
+                self._parse_one_time_product_offer(offer)
+                for offer in result.get("oneTimeProductOffers", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception(
+                "Failed to batch update purchase option offer states", error=str(e)
+            )
+            raise PlayStoreClientError(
+                f"Failed to batch update purchase option offer states: {e.reason}"
+            ) from e
+
+    def batch_delete_purchase_option_offers(
+        self,
+        package_name: str,
+        product_id: str,
+        purchase_option_id: str,
+        requests: list[dict[str, Any]],
+    ) -> OneTimeProductActionResult:
+        """Delete multiple one-time product offers in a single operation.
+
+        Args:
+            package_name: App package name.
+            product_id: Parent one-time product ID ('-' wildcard allowed).
+            purchase_option_id: Parent purchase option ID ('-' wildcard allowed).
+            requests: List of DeleteOneTimeProductOfferRequest bodies.
+
+        Returns:
+            Action result with success status.
+        """
+        self._logger.info(
+            "Batch deleting purchase option offers",
+            package_name=package_name,
+            product_id=product_id,
+            purchase_option_id=purchase_option_id,
+            count=len(requests),
+        )
+        service = self._get_service()
+
+        try:
+            service.monetization().onetimeproducts().purchaseOptions().offers().batchDelete(
+                packageName=package_name,
+                productId=product_id,
+                purchaseOptionId=purchase_option_id,
+                body={"requests": requests},
+            ).execute()
+
+            return OneTimeProductActionResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                message=f"Deleted {len(requests)} one-time product offer(s) successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to batch delete purchase option offers", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to batch delete purchase option offers: {e.reason}"
             ) from e
 
     # =========================================================================

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -353,6 +353,18 @@ class OneTimeProductActionResult(BaseModel):
     error: str | None = Field(None, description="Error details if failed")
 
 
+class OneTimeProductOffer(BaseModel):
+    """One-time product offer definition (purchaseOptions.offers resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    product_id: str = Field(..., description="Parent one-time product ID")
+    purchase_option_id: str = Field(..., description="Parent purchase option ID")
+    offer_id: str = Field(..., description="One-time product offer ID")
+    state: str | None = Field(None, description="Offer state (e.g. DRAFT, ACTIVE, INACTIVE)")
+    offer_tags: list[str] = Field(default_factory=list, description="Offer tag strings")
+    regions_version: str | None = Field(None, description="Regions catalog version")
+
+
 class ProductPurchaseV2(BaseModel):
     """Status of an in-app product purchase (Purchases.productsv2)."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1227,6 +1227,330 @@ def batch_delete_one_time_products(
 
 
 # =============================================================================
+# One-Time Product Purchase Option Tools
+# =============================================================================
+
+
+@mcp.tool()
+def batch_delete_purchase_options(
+    package_name: str,
+    product_id: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Delete multiple purchase options from a one-time product in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID
+        requests: List of DeletePurchaseOptionRequest bodies (each with purchaseOptionId
+            and optional latencyTolerance)
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("batch_delete_purchase_options"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.batch_delete_purchase_options(
+        package_name=package_name, product_id=product_id, requests=requests
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_update_purchase_option_states(
+    package_name: str,
+    product_id: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """Activate or deactivate multiple purchase options in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID
+        requests: List of UpdatePurchaseOptionStateRequest bodies (each with a nested
+            activatePurchaseOptionRequest or deactivatePurchaseOptionRequest)
+
+    Returns:
+        List of updated one-time products, or an error object in read-only mode
+    """
+    if blocked := _read_only_block("batch_update_purchase_option_states"):
+        return blocked
+    client = get_client_from_context()
+
+    products = client.batch_update_purchase_option_states(
+        package_name=package_name, product_id=product_id, requests=requests
+    )
+    return [product.model_dump() for product in products]
+
+
+# =============================================================================
+# One-Time Product Purchase Option Offer Tools
+# =============================================================================
+
+
+@mcp.tool()
+def list_purchase_option_offers(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+) -> list[dict[str, Any]]:
+    """List all offers for a one-time product purchase option.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID ('-' wildcard lists across products)
+        purchase_option_id: Parent purchase option ID ('-' wildcard lists across options)
+
+    Returns:
+        List of one-time product offers
+    """
+    client = get_client_from_context()
+
+    offers = client.list_purchase_option_offers(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+    )
+    return [offer.model_dump() for offer in offers]
+
+
+@mcp.tool()
+def batch_get_purchase_option_offers(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Get details for multiple one-time product offers at once.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID ('-' wildcard allowed)
+        purchase_option_id: Parent purchase option ID ('-' wildcard allowed)
+        requests: List of GetOneTimeProductOfferRequest bodies
+
+    Returns:
+        List of one-time product offers
+    """
+    client = get_client_from_context()
+
+    offers = client.batch_get_purchase_option_offers(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        requests=requests,
+    )
+    return [offer.model_dump() for offer in offers]
+
+
+@mcp.tool()
+def activate_purchase_option_offer(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    offer_id: str,
+) -> dict[str, Any]:
+    """Activate a one-time product offer, making it available to eligible buyers.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID
+        purchase_option_id: Parent purchase option ID
+        offer_id: One-time product offer ID to activate
+
+    Returns:
+        The updated one-time product offer
+    """
+    if blocked := _read_only_block("activate_purchase_option_offer"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.activate_purchase_option_offer(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        offer_id=offer_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def deactivate_purchase_option_offer(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    offer_id: str,
+) -> dict[str, Any]:
+    """Deactivate a one-time product offer, making it unavailable to new buyers.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID
+        purchase_option_id: Parent purchase option ID
+        offer_id: One-time product offer ID to deactivate
+
+    Returns:
+        The updated one-time product offer
+    """
+    if blocked := _read_only_block("deactivate_purchase_option_offer"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.deactivate_purchase_option_offer(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        offer_id=offer_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def cancel_purchase_option_offer(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    offer_id: str,
+) -> dict[str, Any]:
+    """Cancel a one-time product offer (e.g. a pre-order offer).
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID
+        purchase_option_id: Parent purchase option ID
+        offer_id: One-time product offer ID to cancel
+
+    Returns:
+        The updated one-time product offer
+    """
+    if blocked := _read_only_block("cancel_purchase_option_offer"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.cancel_purchase_option_offer(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        offer_id=offer_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_update_purchase_option_offers(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """Create or update multiple one-time product offers in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID ('-' wildcard allowed)
+        purchase_option_id: Parent purchase option ID ('-' wildcard allowed)
+        requests: List of UpdateOneTimeProductOfferRequest bodies (each with
+            oneTimeProductOffer, updateMask, and optional allowMissing / latencyTolerance)
+
+    Returns:
+        List of updated one-time product offers, or an error object in read-only mode
+    """
+    if blocked := _read_only_block("batch_update_purchase_option_offers"):
+        return blocked
+    client = get_client_from_context()
+
+    offers = client.batch_update_purchase_option_offers(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        requests=requests,
+    )
+    return [offer.model_dump() for offer in offers]
+
+
+@mcp.tool()
+def batch_update_purchase_option_offer_states(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """Activate, deactivate or cancel multiple one-time product offers in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID ('-' wildcard allowed)
+        purchase_option_id: Parent purchase option ID ('-' wildcard allowed)
+        requests: List of UpdateOneTimeProductOfferStateRequest bodies (each with a nested
+            activate/deactivate/cancel one-time product offer request)
+
+    Returns:
+        List of updated one-time product offers, or an error object in read-only mode
+    """
+    if blocked := _read_only_block("batch_update_purchase_option_offer_states"):
+        return blocked
+    client = get_client_from_context()
+
+    offers = client.batch_update_purchase_option_offer_states(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        requests=requests,
+    )
+    return [offer.model_dump() for offer in offers]
+
+
+@mcp.tool()
+def batch_delete_purchase_option_offers(
+    package_name: str,
+    product_id: str,
+    purchase_option_id: str,
+    requests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Delete multiple one-time product offers in a single operation.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        product_id: Parent one-time product ID ('-' wildcard allowed)
+        purchase_option_id: Parent purchase option ID ('-' wildcard allowed)
+        requests: List of DeleteOneTimeProductOfferRequest bodies (each with offerId
+            and optional latencyTolerance)
+
+    Returns:
+        Result with success status
+    """
+    if blocked := _read_only_block("batch_delete_purchase_option_offers"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.batch_delete_purchase_option_offers(
+        package_name=package_name,
+        product_id=product_id,
+        purchase_option_id=purchase_option_id,
+        requests=requests,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Subscription Catalog Tools
 # =============================================================================
 

--- a/tests/test_onetimeproduct_offers.py
+++ b/tests/test_onetimeproduct_offers.py
@@ -1,0 +1,742 @@
+"""Tests for one-time product purchase options and offers.
+
+Covers purchaseOptions batch-delete / batch-update-states and the
+purchaseOptions.offers resource (list/batchGet/activate/deactivate/cancel/
+batchUpdate/batchUpdateStates/batchDelete).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import (
+    OneTimeProduct,
+    OneTimeProductActionResult,
+    OneTimeProductOffer,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _options(service: MagicMock) -> MagicMock:
+    return (
+        service.monetization.return_value.onetimeproducts.return_value.purchaseOptions.return_value
+    )
+
+
+def _offers(service: MagicMock) -> MagicMock:
+    return _options(service).offers.return_value
+
+
+_OTP_RESPONSE = {
+    "productId": "coins_pack",
+    "packageName": "com.example.app",
+    "purchaseOptions": [{"purchaseOptionId": "opt1"}],
+}
+
+_OFFER_RESPONSE = {
+    "packageName": "com.example.app",
+    "productId": "coins_pack",
+    "purchaseOptionId": "opt1",
+    "offerId": "intro",
+    "state": "ACTIVE",
+    "offerTags": [{"tag": "promo"}, {"tag": "welcome"}],
+    "regionsVersion": {"version": "2022/02"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_one_time_product_offer_model_defaults():
+    offer = OneTimeProductOffer(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        offer_id="intro",
+    )
+    assert offer.state is None
+    assert offer.offer_tags == []
+    assert offer.regions_version is None
+
+
+def test_parse_one_time_product_offer_maps_fields():
+    offer = PlayStoreClient._parse_one_time_product_offer(_OFFER_RESPONSE)
+
+    assert isinstance(offer, OneTimeProductOffer)
+    assert offer.package_name == "com.example.app"
+    assert offer.product_id == "coins_pack"
+    assert offer.purchase_option_id == "opt1"
+    assert offer.offer_id == "intro"
+    assert offer.state == "ACTIVE"
+    assert offer.offer_tags == ["promo", "welcome"]
+    assert offer.regions_version == "2022/02"
+
+
+def test_parse_one_time_product_offer_missing_fields():
+    offer = PlayStoreClient._parse_one_time_product_offer({})
+
+    assert offer.package_name == ""
+    assert offer.product_id == ""
+    assert offer.purchase_option_id == ""
+    assert offer.offer_id == ""
+    assert offer.state is None
+    assert offer.offer_tags == []
+    assert offer.regions_version is None
+
+
+# ---------------------------------------------------------------------------
+# Client: purchaseOptions.batchDelete
+# ---------------------------------------------------------------------------
+
+
+def test_batch_delete_purchase_options_success():
+    service = MagicMock()
+    client = _client(service)
+
+    requests = [{"purchaseOptionId": "opt1"}, {"purchaseOptionId": "opt2"}]
+    result = client.batch_delete_purchase_options("com.example.app", "coins_pack", requests)
+
+    assert isinstance(result, OneTimeProductActionResult)
+    assert result.success is True
+    assert result.product_id == "coins_pack"
+    assert "2" in result.message
+    _options(service).batchDelete.assert_called_once_with(
+        packageName="com.example.app", productId="coins_pack", body={"requests": requests}
+    )
+
+
+def test_batch_delete_purchase_options_http_error():
+    service = MagicMock()
+    _options(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch delete purchase options"):
+        client.batch_delete_purchase_options(
+            "com.example.app", "coins_pack", [{"purchaseOptionId": "opt1"}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: purchaseOptions.batchUpdateStates
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_purchase_option_states_success():
+    service = MagicMock()
+    _options(service).batchUpdateStates.return_value.execute.return_value = {
+        "oneTimeProducts": [_OTP_RESPONSE, {"productId": "gems_pack"}]
+    }
+    client = _client(service)
+
+    requests = [{"activatePurchaseOptionRequest": {"purchaseOptionId": "opt1"}}]
+    result = client.batch_update_purchase_option_states("com.example.app", "coins_pack", requests)
+
+    assert [p.product_id for p in result] == ["coins_pack", "gems_pack"]
+    assert all(isinstance(p, OneTimeProduct) for p in result)
+    _options(service).batchUpdateStates.assert_called_once_with(
+        packageName="com.example.app", productId="coins_pack", body={"requests": requests}
+    )
+
+
+def test_batch_update_purchase_option_states_empty():
+    service = MagicMock()
+    _options(service).batchUpdateStates.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_purchase_option_states(
+        "com.example.app", "coins_pack", [{"activatePurchaseOptionRequest": {}}]
+    )
+
+    assert result == []
+
+
+def test_batch_update_purchase_option_states_http_error():
+    service = MagicMock()
+    _options(service).batchUpdateStates.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch update purchase option states"):
+        client.batch_update_purchase_option_states(
+            "com.example.app", "coins_pack", [{"activatePurchaseOptionRequest": {}}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.list
+# ---------------------------------------------------------------------------
+
+
+def test_list_purchase_option_offers_success():
+    service = MagicMock()
+    _offers(service).list.return_value.execute.return_value = {
+        "oneTimeProductOffers": [_OFFER_RESPONSE, {"offerId": "welcome"}]
+    }
+    client = _client(service)
+
+    result = client.list_purchase_option_offers("com.example.app", "coins_pack", "opt1")
+
+    assert [o.offer_id for o in result] == ["intro", "welcome"]
+    assert result[0].offer_tags == ["promo", "welcome"]
+    assert result[1].offer_tags == []
+    _offers(service).list.assert_called_once_with(
+        packageName="com.example.app", productId="coins_pack", purchaseOptionId="opt1"
+    )
+
+
+def test_list_purchase_option_offers_wildcard():
+    service = MagicMock()
+    _offers(service).list.return_value.execute.return_value = {
+        "oneTimeProductOffers": [_OFFER_RESPONSE]
+    }
+    client = _client(service)
+
+    result = client.list_purchase_option_offers("com.example.app", "-", "-")
+
+    assert [o.offer_id for o in result] == ["intro"]
+    _offers(service).list.assert_called_once_with(
+        packageName="com.example.app", productId="-", purchaseOptionId="-"
+    )
+
+
+def test_list_purchase_option_offers_empty():
+    service = MagicMock()
+    _offers(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_purchase_option_offers("com.example.app", "coins_pack", "opt1")
+
+    assert result == []
+
+
+def test_list_purchase_option_offers_http_error():
+    service = MagicMock()
+    _offers(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list purchase option offers"):
+        client.list_purchase_option_offers("com.example.app", "coins_pack", "opt1")
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.batchGet
+# ---------------------------------------------------------------------------
+
+
+def test_batch_get_purchase_option_offers_success():
+    service = MagicMock()
+    _offers(service).batchGet.return_value.execute.return_value = {
+        "oneTimeProductOffers": [_OFFER_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [{"offerId": "intro"}]
+    result = client.batch_get_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert [o.offer_id for o in result] == ["intro"]
+    _offers(service).batchGet.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        body={"requests": requests},
+    )
+
+
+def test_batch_get_purchase_option_offers_empty():
+    service = MagicMock()
+    _offers(service).batchGet.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_get_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", [{"offerId": "intro"}]
+    )
+
+    assert result == []
+
+
+def test_batch_get_purchase_option_offers_http_error():
+    service = MagicMock()
+    _offers(service).batchGet.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch get purchase option offers"):
+        client.batch_get_purchase_option_offers(
+            "com.example.app", "coins_pack", "opt1", [{"offerId": "intro"}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.activate
+# ---------------------------------------------------------------------------
+
+
+def test_activate_purchase_option_offer_success():
+    service = MagicMock()
+    _offers(service).activate.return_value.execute.return_value = _OFFER_RESPONSE
+    client = _client(service)
+
+    result = client.activate_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+    assert isinstance(result, OneTimeProductOffer)
+    assert result.offer_id == "intro"
+    assert result.state == "ACTIVE"
+    _offers(service).activate.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        offerId="intro",
+        body={
+            "packageName": "com.example.app",
+            "productId": "coins_pack",
+            "purchaseOptionId": "opt1",
+            "offerId": "intro",
+        },
+    )
+
+
+def test_activate_purchase_option_offer_http_error():
+    service = MagicMock()
+    _offers(service).activate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to activate purchase option offer"):
+        client.activate_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.deactivate
+# ---------------------------------------------------------------------------
+
+
+def test_deactivate_purchase_option_offer_success():
+    service = MagicMock()
+    _offers(service).deactivate.return_value.execute.return_value = _OFFER_RESPONSE
+    client = _client(service)
+
+    result = client.deactivate_purchase_option_offer(
+        "com.example.app", "coins_pack", "opt1", "intro"
+    )
+
+    assert isinstance(result, OneTimeProductOffer)
+    assert result.offer_id == "intro"
+    _offers(service).deactivate.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        offerId="intro",
+        body={
+            "packageName": "com.example.app",
+            "productId": "coins_pack",
+            "purchaseOptionId": "opt1",
+            "offerId": "intro",
+        },
+    )
+
+
+def test_deactivate_purchase_option_offer_http_error():
+    service = MagicMock()
+    _offers(service).deactivate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to deactivate purchase option offer"):
+        client.deactivate_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.cancel
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_purchase_option_offer_success():
+    service = MagicMock()
+    _offers(service).cancel.return_value.execute.return_value = _OFFER_RESPONSE
+    client = _client(service)
+
+    result = client.cancel_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+    assert isinstance(result, OneTimeProductOffer)
+    assert result.offer_id == "intro"
+    _offers(service).cancel.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        offerId="intro",
+        body={
+            "packageName": "com.example.app",
+            "productId": "coins_pack",
+            "purchaseOptionId": "opt1",
+            "offerId": "intro",
+        },
+    )
+
+
+def test_cancel_purchase_option_offer_http_error():
+    service = MagicMock()
+    _offers(service).cancel.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to cancel purchase option offer"):
+        client.cancel_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.batchUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_purchase_option_offers_success():
+    service = MagicMock()
+    _offers(service).batchUpdate.return_value.execute.return_value = {
+        "oneTimeProductOffers": [_OFFER_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [{"oneTimeProductOffer": {"offerId": "intro"}, "updateMask": "state"}]
+    result = client.batch_update_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert [o.offer_id for o in result] == ["intro"]
+    _offers(service).batchUpdate.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        body={"requests": requests},
+    )
+
+
+def test_batch_update_purchase_option_offers_empty():
+    service = MagicMock()
+    _offers(service).batchUpdate.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", [{"oneTimeProductOffer": {}}]
+    )
+
+    assert result == []
+
+
+def test_batch_update_purchase_option_offers_http_error():
+    service = MagicMock()
+    _offers(service).batchUpdate.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch update purchase option offers"):
+        client.batch_update_purchase_option_offers(
+            "com.example.app", "coins_pack", "opt1", [{"oneTimeProductOffer": {}}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.batchUpdateStates
+# ---------------------------------------------------------------------------
+
+
+def test_batch_update_purchase_option_offer_states_success():
+    service = MagicMock()
+    _offers(service).batchUpdateStates.return_value.execute.return_value = {
+        "oneTimeProductOffers": [_OFFER_RESPONSE]
+    }
+    client = _client(service)
+
+    requests = [{"activateOneTimeProductOfferRequest": {"offerId": "intro"}}]
+    result = client.batch_update_purchase_option_offer_states(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert [o.offer_id for o in result] == ["intro"]
+    _offers(service).batchUpdateStates.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        body={"requests": requests},
+    )
+
+
+def test_batch_update_purchase_option_offer_states_empty():
+    service = MagicMock()
+    _offers(service).batchUpdateStates.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.batch_update_purchase_option_offer_states(
+        "com.example.app", "coins_pack", "opt1", [{"activateOneTimeProductOfferRequest": {}}]
+    )
+
+    assert result == []
+
+
+def test_batch_update_purchase_option_offer_states_http_error():
+    service = MagicMock()
+    _offers(service).batchUpdateStates.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(
+        PlayStoreClientError, match="Failed to batch update purchase option offer states"
+    ):
+        client.batch_update_purchase_option_offer_states(
+            "com.example.app", "coins_pack", "opt1", [{"activateOneTimeProductOfferRequest": {}}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: offers.batchDelete
+# ---------------------------------------------------------------------------
+
+
+def test_batch_delete_purchase_option_offers_success():
+    service = MagicMock()
+    client = _client(service)
+
+    requests = [{"offerId": "intro"}, {"offerId": "welcome"}]
+    result = client.batch_delete_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert isinstance(result, OneTimeProductActionResult)
+    assert result.success is True
+    assert result.product_id == "coins_pack"
+    assert "2" in result.message
+    _offers(service).batchDelete.assert_called_once_with(
+        packageName="com.example.app",
+        productId="coins_pack",
+        purchaseOptionId="opt1",
+        body={"requests": requests},
+    )
+
+
+def test_batch_delete_purchase_option_offers_http_error():
+    service = MagicMock()
+    _offers(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to batch delete purchase option offers"):
+        client.batch_delete_purchase_option_offers(
+            "com.example.app", "coins_pack", "opt1", [{"offerId": "intro"}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# MCP tools: purchase options
+# ---------------------------------------------------------------------------
+
+
+def test_tool_batch_delete_purchase_options(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_delete_purchase_options.return_value = OneTimeProductActionResult(
+        success=True, package_name="com.example.app", product_id="coins_pack", message="ok"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"purchaseOptionId": "opt1"}]
+    result = server.batch_delete_purchase_options("com.example.app", "coins_pack", requests)
+
+    assert result["success"] is True
+    mc.batch_delete_purchase_options.assert_called_once_with(
+        package_name="com.example.app", product_id="coins_pack", requests=requests
+    )
+
+
+def test_tool_batch_update_purchase_option_states(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_purchase_option_states.return_value = [
+        OneTimeProduct(product_id="coins_pack", package_name="com.example.app")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"activatePurchaseOptionRequest": {"purchaseOptionId": "opt1"}}]
+    result = server.batch_update_purchase_option_states("com.example.app", "coins_pack", requests)
+
+    assert result[0]["product_id"] == "coins_pack"
+    mc.batch_update_purchase_option_states.assert_called_once_with(
+        package_name="com.example.app", product_id="coins_pack", requests=requests
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP tools: offers
+# ---------------------------------------------------------------------------
+
+
+def _offer_model() -> OneTimeProductOffer:
+    return OneTimeProductOffer(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        offer_id="intro",
+    )
+
+
+def test_tool_list_purchase_option_offers(monkeypatch):
+    mc = MagicMock()
+    mc.list_purchase_option_offers.return_value = [_offer_model()]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_purchase_option_offers("com.example.app", "coins_pack", "opt1")
+
+    assert result[0]["offer_id"] == "intro"
+    mc.list_purchase_option_offers.assert_called_once_with(
+        package_name="com.example.app", product_id="coins_pack", purchase_option_id="opt1"
+    )
+
+
+def test_tool_batch_get_purchase_option_offers(monkeypatch):
+    mc = MagicMock()
+    mc.batch_get_purchase_option_offers.return_value = [_offer_model()]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"offerId": "intro"}]
+    result = server.batch_get_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert result[0]["offer_id"] == "intro"
+    mc.batch_get_purchase_option_offers.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        requests=requests,
+    )
+
+
+def test_tool_activate_purchase_option_offer(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.activate_purchase_option_offer.return_value = _offer_model()
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.activate_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+    assert result["offer_id"] == "intro"
+    mc.activate_purchase_option_offer.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        offer_id="intro",
+    )
+
+
+def test_tool_deactivate_purchase_option_offer(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.deactivate_purchase_option_offer.return_value = _offer_model()
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.deactivate_purchase_option_offer(
+        "com.example.app", "coins_pack", "opt1", "intro"
+    )
+
+    assert result["offer_id"] == "intro"
+    mc.deactivate_purchase_option_offer.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        offer_id="intro",
+    )
+
+
+def test_tool_cancel_purchase_option_offer(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.cancel_purchase_option_offer.return_value = _offer_model()
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.cancel_purchase_option_offer("com.example.app", "coins_pack", "opt1", "intro")
+
+    assert result["offer_id"] == "intro"
+    mc.cancel_purchase_option_offer.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        offer_id="intro",
+    )
+
+
+def test_tool_batch_update_purchase_option_offers(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_purchase_option_offers.return_value = [_offer_model()]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"oneTimeProductOffer": {"offerId": "intro"}, "updateMask": "state"}]
+    result = server.batch_update_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert result[0]["offer_id"] == "intro"
+    mc.batch_update_purchase_option_offers.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        requests=requests,
+    )
+
+
+def test_tool_batch_update_purchase_option_offer_states(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_update_purchase_option_offer_states.return_value = [_offer_model()]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"activateOneTimeProductOfferRequest": {"offerId": "intro"}}]
+    result = server.batch_update_purchase_option_offer_states(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert result[0]["offer_id"] == "intro"
+    mc.batch_update_purchase_option_offer_states.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        requests=requests,
+    )
+
+
+def test_tool_batch_delete_purchase_option_offers(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.batch_delete_purchase_option_offers.return_value = OneTimeProductActionResult(
+        success=True, package_name="com.example.app", product_id="coins_pack", message="ok"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    requests = [{"offerId": "intro"}]
+    result = server.batch_delete_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", requests
+    )
+
+    assert result["success"] is True
+    mc.batch_delete_purchase_option_offers.assert_called_once_with(
+        package_name="com.example.app",
+        product_id="coins_pack",
+        purchase_option_id="opt1",
+        requests=requests,
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -315,6 +315,76 @@ WRITE_TOOLS = [
             "requests": [{"activateSubscriptionOfferRequest": {"offerId": "intro"}}],
         },
     ),
+    (
+        "batch_delete_purchase_options",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "requests": [{"purchaseOptionId": "opt1"}],
+        },
+    ),
+    (
+        "batch_update_purchase_option_states",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "requests": [{"activatePurchaseOptionRequest": {"purchaseOptionId": "opt1"}}],
+        },
+    ),
+    (
+        "activate_purchase_option_offer",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "offer_id": "intro",
+        },
+    ),
+    (
+        "deactivate_purchase_option_offer",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "offer_id": "intro",
+        },
+    ),
+    (
+        "cancel_purchase_option_offer",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "offer_id": "intro",
+        },
+    ),
+    (
+        "batch_update_purchase_option_offers",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "requests": [{"oneTimeProductOffer": {}}],
+        },
+    ),
+    (
+        "batch_update_purchase_option_offer_states",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "requests": [{"activateOneTimeProductOfferRequest": {"offerId": "intro"}}],
+        },
+    ),
+    (
+        "batch_delete_purchase_option_offers",
+        {
+            "package_name": "com.example.app",
+            "product_id": "coins_pack",
+            "purchase_option_id": "opt1",
+            "requests": [{"offerId": "intro"}],
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Completes the one-time-products subsystem: `monetization.onetimeproducts.purchaseOptions` + `.purchaseOptions.offers` (10 methods).

- **Purchase options** (writes): `batch_delete_purchase_options`, `batch_update_purchase_option_states`
- **Offers** — reads: `list_purchase_option_offers`, `batch_get_purchase_option_offers`; writes: `activate`/`deactivate`/`cancel_purchase_option_offer`, `batch_update_purchase_option_offers`, `batch_update_purchase_option_offer_states`, `batch_delete_purchase_option_offers`

## Changes
- `models.py`: new `OneTimeProductOffer`.
- `client.py`: 10 methods + `_parse_one_time_product_offer`. Verified vs discovery rev 20260701: `purchaseOptions.batchUpdateStates` → `oneTimeProducts` envelope; offer batches → `oneTimeProductOffers`; activate/deactivate/cancel echo the 4 ids in body; batch-deletes empty.
- `server.py`: 10 tools (8 writes guard-first; list-returning writes `list | dict`).
- Tests: `tests/test_onetimeproduct_offers.py` + 8 `WRITE_TOOLS` entries.
- Docs updated.

## Validation
- `pytest` → **485 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (2 non-blocking cosmetic NITs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2