### PR TITLE
feat: add external transactions (alternative billing)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -113,6 +113,14 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`defer_subscription_purchase`](tools/subscriptions.md#defer_subscription_purchase) | Defer a subscription's next renewal (write) |
 | [`revoke_subscription_purchase`](tools/subscriptions.md#revoke_subscription_purchase) | Revoke/refund a subscription (write) |
 
+## External Transactions Tools
+
+| Tool | Description |
+|---|---|
+| [`get_external_transaction`](tools/subscriptions.md#get_external_transaction) | Get an external (alternative billing) transaction |
+| `create_external_transaction` | Create an external transaction (write) |
+| `refund_external_transaction` | Refund an external transaction (write) |
+
 ## Testers Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1143,3 +1143,72 @@ Revoke (refund) a subscription. **Write / money.**
 | `package_name` | string | Yes | App package name |
 | `purchase_token` | string | Yes | Purchase token |
 | `refund_type` | string | No | `full` (default) or `prorated` |
+
+## External Transactions
+
+Manage external (alternative billing) transactions
+([externaltransactions](https://developers.google.com/android-publisher/api-ref/rest/v3/externaltransactions)).
+`get_external_transaction` is read-only; `create_external_transaction` and
+`refund_external_transaction` are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+The `transaction` parameter is an
+[ExternalTransaction](https://developers.google.com/android-publisher/api-ref/rest/v3/externaltransactions#ExternalTransaction)
+resource body; the `refund` parameter is a
+[RefundExternalTransactionRequest](https://developers.google.com/android-publisher/api-ref/rest/v3/externaltransactions/refundexternaltransaction#request-body)
+body. The client builds the `applications/{packageName}/externalTransactions/{externalTransactionId}`
+resource name for you from `package_name` and `external_transaction_id`.
+
+### get_external_transaction
+
+Get an external transaction. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `external_transaction_id` | string | Yes | External transaction ID |
+
+```python
+get_external_transaction("com.example.myapp", external_transaction_id="tx123")
+```
+
+### create_external_transaction
+
+Create an external transaction. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `external_transaction_id` | string | Yes | External transaction ID to assign |
+| `transaction` | object | Yes | ExternalTransaction resource body |
+
+```python
+create_external_transaction(
+    package_name="com.example.myapp",
+    external_transaction_id="tx123",
+    transaction={
+        "originalPreTaxAmount": {"currencyCode": "USD", "units": "1", "nanos": 990000000},
+        "originalTaxAmount": {"currencyCode": "USD", "units": "0", "nanos": 100000000},
+        "transactionTime": "2026-01-01T00:00:00Z",
+        "oneTimeTransaction": {"externalTransactionToken": "token123"},
+    },
+)
+```
+
+### refund_external_transaction
+
+Refund an external transaction. **Write / money.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `external_transaction_id` | string | Yes | External transaction ID to refund |
+| `refund` | object | Yes | RefundExternalTransactionRequest body (`refundTime` plus `fullRefund` or `partialRefund`) |
+
+```python
+refund_external_transaction(
+    package_name="com.example.myapp",
+    external_transaction_id="tx123",
+    refund={"refundTime": "2026-01-02T00:00:00Z", "fullRefund": {}},
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -23,6 +23,7 @@ from play_store_mcp.models import (
     BatchDeploymentResult,
     DeploymentResult,
     ExpansionFile,
+    ExternalTransaction,
     InAppProduct,
     InAppProductActionResult,
     Listing,
@@ -4074,3 +4075,135 @@ class PlayStoreClient:
             raise PlayStoreClientError(f"Failed to get expansion file: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
+
+    # =========================================================================
+    # External Transactions API (alternative billing)
+    # =========================================================================
+
+    @staticmethod
+    def _parse_external_transaction(
+        package_name: str,
+        external_transaction_id: str,
+        data: dict[str, Any],
+    ) -> ExternalTransaction:
+        """Parse an ExternalTransaction API resource into an ExternalTransaction model.
+
+        The API's externalTransactionId is the full resource-name suffix; we prefer
+        the caller-supplied external_transaction_id for a stable, plain identifier.
+        """
+        return ExternalTransaction(
+            package_name=package_name,
+            external_transaction_id=external_transaction_id,
+            transaction_state=data.get("transactionState"),
+            create_time=data.get("createTime"),
+            current_pre_tax_amount=data.get("currentPreTaxAmount"),
+            original_pre_tax_amount=data.get("originalPreTaxAmount"),
+            test_purchase="testPurchase" in data,
+        )
+
+    def get_external_transaction(
+        self,
+        package_name: str,
+        external_transaction_id: str,
+    ) -> ExternalTransaction:
+        """Get an external (alternative billing) transaction.
+
+        Args:
+            package_name: App package name.
+            external_transaction_id: External transaction ID.
+
+        Returns:
+            The external transaction.
+        """
+        self._logger.info(
+            "Getting external transaction",
+            package_name=package_name,
+            external_transaction_id=external_transaction_id,
+        )
+        service = self._get_service()
+        name = f"applications/{package_name}/externalTransactions/{external_transaction_id}"
+
+        try:
+            data = service.externaltransactions().getexternaltransaction(name=name).execute()
+            return self._parse_external_transaction(package_name, external_transaction_id, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to get external transaction", error=str(e))
+            raise PlayStoreClientError(f"Failed to get external transaction: {e.reason}") from e
+
+    def create_external_transaction(
+        self,
+        package_name: str,
+        external_transaction_id: str,
+        transaction: dict[str, Any],
+    ) -> ExternalTransaction:
+        """Create an external (alternative billing) transaction.
+
+        Args:
+            package_name: App package name.
+            external_transaction_id: External transaction ID to assign.
+            transaction: ExternalTransaction resource body.
+
+        Returns:
+            The created external transaction.
+        """
+        self._logger.info(
+            "Creating external transaction",
+            package_name=package_name,
+            external_transaction_id=external_transaction_id,
+        )
+        service = self._get_service()
+        parent = f"applications/{package_name}"
+
+        try:
+            data = (
+                service.externaltransactions()
+                .createexternaltransaction(
+                    parent=parent,
+                    externalTransactionId=external_transaction_id,
+                    body=transaction,
+                )
+                .execute()
+            )
+            return self._parse_external_transaction(package_name, external_transaction_id, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create external transaction", error=str(e))
+            raise PlayStoreClientError(f"Failed to create external transaction: {e.reason}") from e
+
+    def refund_external_transaction(
+        self,
+        package_name: str,
+        external_transaction_id: str,
+        refund: dict[str, Any],
+    ) -> ExternalTransaction:
+        """Refund an external (alternative billing) transaction.
+
+        Args:
+            package_name: App package name.
+            external_transaction_id: External transaction ID to refund.
+            refund: RefundExternalTransactionRequest body (e.g. refundTime plus
+                fullRefund or partialRefund).
+
+        Returns:
+            The refunded external transaction.
+        """
+        self._logger.info(
+            "Refunding external transaction",
+            package_name=package_name,
+            external_transaction_id=external_transaction_id,
+        )
+        service = self._get_service()
+        name = f"applications/{package_name}/externalTransactions/{external_transaction_id}"
+
+        try:
+            data = (
+                service.externaltransactions()
+                .refundexternaltransaction(name=name, body=refund)
+                .execute()
+            )
+            return self._parse_external_transaction(package_name, external_transaction_id, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to refund external transaction", error=str(e))
+            raise PlayStoreClientError(f"Failed to refund external transaction: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -386,3 +386,19 @@ class ProductPurchaseV2(BaseModel):
         None, description="Obfuscated external profile ID"
     )
     test_purchase: bool = Field(False, description="Whether this is a test purchase")
+
+
+class ExternalTransaction(BaseModel):
+    """External (alternative billing) transaction (externaltransactions resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    external_transaction_id: str = Field(..., description="External transaction ID")
+    transaction_state: str | None = Field(None, description="Current transaction state")
+    create_time: str | None = Field(None, description="Time the transaction was created (RFC3339)")
+    current_pre_tax_amount: dict[str, Any] | None = Field(
+        None, description="Current transaction amount before tax (Price)"
+    )
+    original_pre_tax_amount: dict[str, Any] | None = Field(
+        None, description="Original transaction amount before tax (Price)"
+    )
+    test_purchase: bool = Field(False, description="Whether this is a test purchase")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2416,6 +2416,91 @@ def batch_get_orders(
 
 
 # =============================================================================
+# External Transactions Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_external_transaction(
+    package_name: str,
+    external_transaction_id: str,
+) -> dict[str, Any]:
+    """Get an external (alternative billing) transaction.
+
+    Args:
+        package_name: App package name
+        external_transaction_id: External transaction ID
+
+    Returns:
+        External transaction details including state, amounts, and create time
+    """
+    client = get_client_from_context()
+
+    transaction = client.get_external_transaction(
+        package_name=package_name,
+        external_transaction_id=external_transaction_id,
+    )
+    return transaction.model_dump()
+
+
+@mcp.tool()
+def create_external_transaction(
+    package_name: str,
+    external_transaction_id: str,
+    transaction: dict[str, Any],
+) -> dict[str, Any]:
+    """Create an external (alternative billing) transaction.
+
+    Args:
+        package_name: App package name
+        external_transaction_id: External transaction ID to assign
+        transaction: ExternalTransaction resource body
+
+    Returns:
+        The created external transaction
+    """
+    if blocked := _read_only_block("create_external_transaction"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_external_transaction(
+        package_name=package_name,
+        external_transaction_id=external_transaction_id,
+        transaction=transaction,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def refund_external_transaction(
+    package_name: str,
+    external_transaction_id: str,
+    refund: dict[str, Any],
+) -> dict[str, Any]:
+    """Refund an external (alternative billing) transaction.
+
+    Args:
+        package_name: App package name
+        external_transaction_id: External transaction ID to refund
+        refund: RefundExternalTransactionRequest body (e.g. refundTime plus
+            fullRefund or partialRefund)
+
+    Returns:
+        The refunded external transaction
+    """
+    if blocked := _read_only_block("refund_external_transaction"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.refund_external_transaction(
+        package_name=package_name,
+        external_transaction_id=external_transaction_id,
+        refund=refund,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_external_transactions.py
+++ b/tests/test_external_transactions.py
@@ -1,0 +1,230 @@
+"""Tests for external transaction tools (alternative billing)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import ExternalTransaction
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_external_transaction_defaults():
+    tx = ExternalTransaction(
+        package_name="com.example.app",
+        external_transaction_id="tx123",
+    )
+    assert tx.transaction_state is None
+    assert tx.create_time is None
+    assert tx.current_pre_tax_amount is None
+    assert tx.original_pre_tax_amount is None
+    assert tx.test_purchase is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _ext(service: MagicMock) -> MagicMock:
+    return service.externaltransactions.return_value
+
+
+_NAME = "applications/com.example.app/externalTransactions/tx123"
+_PARENT = "applications/com.example.app"
+
+
+# ---------------------------------------------------------------------------
+# Client: get_external_transaction
+# ---------------------------------------------------------------------------
+
+
+def test_get_external_transaction_success():
+    service = MagicMock()
+    _ext(service).getexternaltransaction.return_value.execute.return_value = {
+        "externalTransactionId": _NAME,
+        "transactionState": "TRANSACTION_COMPLETED",
+        "createTime": "2026-01-01T00:00:00Z",
+        "currentPreTaxAmount": {"currencyCode": "USD", "units": "1"},
+        "originalPreTaxAmount": {"currencyCode": "USD", "units": "1"},
+        "testPurchase": {},
+    }
+    client = _client(service)
+
+    result = client.get_external_transaction("com.example.app", "tx123")
+
+    assert result.external_transaction_id == "tx123"
+    assert result.transaction_state == "TRANSACTION_COMPLETED"
+    assert result.create_time == "2026-01-01T00:00:00Z"
+    assert result.current_pre_tax_amount == {"currencyCode": "USD", "units": "1"}
+    assert result.original_pre_tax_amount == {"currencyCode": "USD", "units": "1"}
+    assert result.test_purchase is True
+    _ext(service).getexternaltransaction.assert_called_once_with(name=_NAME)
+
+
+def test_get_external_transaction_minimal():
+    service = MagicMock()
+    _ext(service).getexternaltransaction.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.get_external_transaction("com.example.app", "tx123")
+
+    assert result.external_transaction_id == "tx123"
+    assert result.transaction_state is None
+    assert result.test_purchase is False
+
+
+def test_get_external_transaction_http_error():
+    service = MagicMock()
+    _ext(service).getexternaltransaction.return_value.execute.side_effect = _make_http_error("nope")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to get external transaction"):
+        client.get_external_transaction("com.example.app", "tx123")
+
+
+# ---------------------------------------------------------------------------
+# Client: create_external_transaction
+# ---------------------------------------------------------------------------
+
+
+def test_create_external_transaction_success():
+    service = MagicMock()
+    _ext(service).createexternaltransaction.return_value.execute.return_value = {
+        "externalTransactionId": _NAME,
+        "transactionState": "TRANSACTION_COMPLETED",
+    }
+    client = _client(service)
+    body = {"originalPreTaxAmount": {"currencyCode": "USD", "units": "1"}}
+
+    result = client.create_external_transaction("com.example.app", "tx123", body)
+
+    assert result.external_transaction_id == "tx123"
+    assert result.transaction_state == "TRANSACTION_COMPLETED"
+    _ext(service).createexternaltransaction.assert_called_once_with(
+        parent=_PARENT, externalTransactionId="tx123", body=body
+    )
+
+
+def test_create_external_transaction_http_error():
+    service = MagicMock()
+    _ext(service).createexternaltransaction.return_value.execute.side_effect = _make_http_error(
+        "bad"
+    )
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create external transaction"):
+        client.create_external_transaction("com.example.app", "tx123", {})
+
+
+# ---------------------------------------------------------------------------
+# Client: refund_external_transaction
+# ---------------------------------------------------------------------------
+
+
+def test_refund_external_transaction_success():
+    service = MagicMock()
+    _ext(service).refundexternaltransaction.return_value.execute.return_value = {
+        "externalTransactionId": _NAME,
+        "transactionState": "TRANSACTION_CANCELED",
+    }
+    client = _client(service)
+    body = {"fullRefund": {}}
+
+    result = client.refund_external_transaction("com.example.app", "tx123", body)
+
+    assert result.external_transaction_id == "tx123"
+    assert result.transaction_state == "TRANSACTION_CANCELED"
+    _ext(service).refundexternaltransaction.assert_called_once_with(name=_NAME, body=body)
+
+
+def test_refund_external_transaction_http_error():
+    service = MagicMock()
+    _ext(service).refundexternaltransaction.return_value.execute.side_effect = _make_http_error(
+        "bad"
+    )
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to refund external transaction"):
+        client.refund_external_transaction("com.example.app", "tx123", {})
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_get_external_transaction(monkeypatch):
+    mc = MagicMock()
+    mc.get_external_transaction.return_value = ExternalTransaction(
+        package_name="com.example.app",
+        external_transaction_id="tx123",
+        transaction_state="TRANSACTION_COMPLETED",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.get_external_transaction("com.example.app", "tx123")
+
+    assert result["external_transaction_id"] == "tx123"
+    assert result["transaction_state"] == "TRANSACTION_COMPLETED"
+    mc.get_external_transaction.assert_called_once_with(
+        package_name="com.example.app", external_transaction_id="tx123"
+    )
+
+
+def test_tool_create_external_transaction(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_external_transaction.return_value = ExternalTransaction(
+        package_name="com.example.app", external_transaction_id="tx123"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+    body = {"originalPreTaxAmount": {"currencyCode": "USD", "units": "1"}}
+
+    result = server.create_external_transaction("com.example.app", "tx123", body)
+
+    assert result["external_transaction_id"] == "tx123"
+    mc.create_external_transaction.assert_called_once_with(
+        package_name="com.example.app", external_transaction_id="tx123", transaction=body
+    )
+
+
+def test_tool_refund_external_transaction(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.refund_external_transaction.return_value = ExternalTransaction(
+        package_name="com.example.app",
+        external_transaction_id="tx123",
+        transaction_state="TRANSACTION_CANCELED",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+    body = {"fullRefund": {}}
+
+    result = server.refund_external_transaction("com.example.app", "tx123", body)
+
+    assert result["transaction_state"] == "TRANSACTION_CANCELED"
+    mc.refund_external_transaction.assert_called_once_with(
+        package_name="com.example.app", external_transaction_id="tx123", refund=body
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -385,6 +385,22 @@ WRITE_TOOLS = [
             "requests": [{"offerId": "intro"}],
         },
     ),
+    (
+        "create_external_transaction",
+        {
+            "package_name": "com.example.app",
+            "external_transaction_id": "tx123",
+            "transaction": {"originalPreTaxAmount": {"currencyCode": "USD", "units": "1"}},
+        },
+    ),
+    (
+        "refund_external_transaction",
+        {
+            "package_name": "com.example.app",
+            "external_transaction_id": "tx123",
+            "refund": {"fullRefund": {}},
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `externaltransactions` (alternative-billing transaction reporting):

- **`get_external_transaction`** (read)
- **`create_external_transaction`** (write)
- **`refund_external_transaction`** (write)

Both writes are read-only-gated.

## Changes
- `models.py`: `ExternalTransaction`.
- `client.py`: 3 methods + `_parse_external_transaction`. These use google.api **resource-name** params (verified vs discovery rev 20260701): `getexternaltransaction(name=…)`, `createexternaltransaction(parent=…, externalTransactionId=…, body=…)`, `refundexternaltransaction(name=…, body=…)`; the client builds `applications/{pkg}/externalTransactions/{id}` internally. `test_purchase` maps the presence of the `testPurchase` object → bool.
- `server.py`: 3 tools (2 writes guard-first).
- Tests: `tests/test_external_transactions.py` + 2 `WRITE_TOOLS` entries.
- Docs updated.

## Validation
- `pytest` → **498 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2