### PR TITLE
feat: add device tier configs (get/list/create)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -121,6 +121,14 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | `create_external_transaction` | Create an external transaction (write) |
 | `refund_external_transaction` | Refund an external transaction (write) |
 
+## Device Tier Config Tools
+
+| Tool | Description |
+|---|---|
+| [`get_device_tier_config`](tools/subscriptions.md#get_device_tier_config) | Get a device tier config |
+| [`list_device_tier_configs`](tools/subscriptions.md#list_device_tier_configs) | List device tier configs for an app |
+| `create_device_tier_config` | Create a device tier config (write) |
+
 ## Testers Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1212,3 +1212,71 @@ refund_external_transaction(
     refund={"refundTime": "2026-01-02T00:00:00Z", "fullRefund": {}},
 )
 ```
+
+## Device Tier Configs
+
+Manage device tier configs
+([applications.deviceTierConfigs](https://developers.google.com/android-publisher/api-ref/rest/v3/applications.deviceTierConfigs)).
+A device tier config groups devices (by RAM, system features, etc.) and assigns
+them to tiers so you can ship device-targeted content. `get_device_tier_config`
+and `list_device_tier_configs` are read-only; `create_device_tier_config` is a
+write and is disabled in [read-only mode](../configuration.md#read-only-mode).
+
+The `config` parameter is a
+[DeviceTierConfig](https://developers.google.com/android-publisher/api-ref/rest/v3/applications.deviceTierConfigs#DeviceTierConfig)
+resource body (`deviceGroups`, `deviceTierSet`, `userCountrySets`). Device tier
+configs are immutable and cannot be updated or deleted once created — create a
+new one to make changes.
+
+### get_device_tier_config
+
+Get a device tier config. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `device_tier_config_id` | string | Yes | Device tier config ID |
+
+```python
+get_device_tier_config("com.example.myapp", device_tier_config_id="12345")
+```
+
+### list_device_tier_configs
+
+List device tier configs for an app. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+
+```python
+list_device_tier_configs("com.example.myapp")
+```
+
+### create_device_tier_config
+
+Create a device tier config. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `config` | object | Yes | — | DeviceTierConfig resource body (`deviceGroups`, `deviceTierSet`, `userCountrySets`) |
+| `allow_unknown_devices` | boolean | No | `false` | Accept device IDs unknown to Play's catalog rather than rejecting them |
+
+```python
+create_device_tier_config(
+    package_name="com.example.myapp",
+    config={
+        "deviceGroups": [
+            {
+                "name": "high_ram",
+                "deviceSelectors": [{"deviceRam": {"minBytes": "6000000000"}}],
+            }
+        ],
+        "deviceTierSet": {
+            "deviceTiers": [{"level": 1, "deviceGroupNames": ["high_ram"]}]
+        },
+    },
+    allow_unknown_devices=False,
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -22,6 +22,7 @@ from play_store_mcp.models import (
     AppDetails,
     BatchDeploymentResult,
     DeploymentResult,
+    DeviceTierConfig,
     ExpansionFile,
     ExternalTransaction,
     InAppProduct,
@@ -4207,3 +4208,116 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to refund external transaction", error=str(e))
             raise PlayStoreClientError(f"Failed to refund external transaction: {e.reason}") from e
+
+    # =========================================================================
+    # Device Tier Configs API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_device_tier_config(package_name: str, data: dict[str, Any]) -> DeviceTierConfig:
+        """Parse a DeviceTierConfig API resource into a DeviceTierConfig model."""
+        return DeviceTierConfig(
+            package_name=package_name,
+            device_tier_config_id=data.get("deviceTierConfigId"),
+            device_groups=data.get("deviceGroups", []),
+            device_tier_set=data.get("deviceTierSet"),
+            user_country_sets=data.get("userCountrySets", []),
+        )
+
+    def get_device_tier_config(
+        self,
+        package_name: str,
+        device_tier_config_id: str,
+    ) -> DeviceTierConfig:
+        """Get a device tier config.
+
+        Args:
+            package_name: App package name.
+            device_tier_config_id: Device tier config ID.
+
+        Returns:
+            The device tier config.
+        """
+        self._logger.info(
+            "Getting device tier config",
+            package_name=package_name,
+            device_tier_config_id=device_tier_config_id,
+        )
+        service = self._get_service()
+
+        try:
+            data = (
+                service.applications()
+                .deviceTierConfigs()
+                .get(packageName=package_name, deviceTierConfigId=device_tier_config_id)
+                .execute()
+            )
+            return self._parse_device_tier_config(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to get device tier config", error=str(e))
+            raise PlayStoreClientError(f"Failed to get device tier config: {e.reason}") from e
+
+    def list_device_tier_configs(self, package_name: str) -> list[DeviceTierConfig]:
+        """List device tier configs for an app.
+
+        Args:
+            package_name: App package name.
+
+        Returns:
+            List of device tier configs.
+        """
+        self._logger.info("Listing device tier configs", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            result = (
+                service.applications().deviceTierConfigs().list(packageName=package_name).execute()
+            )
+
+            return [
+                self._parse_device_tier_config(package_name, config_data)
+                for config_data in result.get("deviceTierConfigs", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list device tier configs", error=str(e))
+            raise PlayStoreClientError(f"Failed to list device tier configs: {e.reason}") from e
+
+    def create_device_tier_config(
+        self,
+        package_name: str,
+        config: dict[str, Any],
+        allow_unknown_devices: bool = False,
+    ) -> DeviceTierConfig:
+        """Create a new device tier config.
+
+        Args:
+            package_name: App package name.
+            config: DeviceTierConfig resource body (deviceGroups, deviceTierSet,
+                userCountrySets).
+            allow_unknown_devices: If True, accept device IDs unknown to Play's
+                catalog rather than rejecting them.
+
+        Returns:
+            The created device tier config.
+        """
+        self._logger.info("Creating device tier config", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            data = (
+                service.applications()
+                .deviceTierConfigs()
+                .create(
+                    packageName=package_name,
+                    allowUnknownDevices=allow_unknown_devices,
+                    body=config,
+                )
+                .execute()
+            )
+            return self._parse_device_tier_config(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create device tier config", error=str(e))
+            raise PlayStoreClientError(f"Failed to create device tier config: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -402,3 +402,19 @@ class ExternalTransaction(BaseModel):
         None, description="Original transaction amount before tax (Price)"
     )
     test_purchase: bool = Field(False, description="Whether this is a test purchase")
+
+
+class DeviceTierConfig(BaseModel):
+    """Device tier config (applications.deviceTierConfigs resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    device_tier_config_id: str | None = Field(None, description="Device tier config ID")
+    device_groups: list[dict[str, Any]] = Field(
+        default_factory=list, description="Device group definitions"
+    )
+    device_tier_set: dict[str, Any] | None = Field(
+        None, description="Set of device tiers for the app"
+    )
+    user_country_sets: list[dict[str, Any]] = Field(
+        default_factory=list, description="User country set definitions"
+    )

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2501,6 +2501,82 @@ def refund_external_transaction(
 
 
 # =============================================================================
+# Device Tier Config Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_device_tier_config(
+    package_name: str,
+    device_tier_config_id: str,
+) -> dict[str, Any]:
+    """Get a device tier config.
+
+    Args:
+        package_name: App package name
+        device_tier_config_id: Device tier config ID
+
+    Returns:
+        Device tier config details including device groups, tier set, and country sets
+    """
+    client = get_client_from_context()
+
+    config = client.get_device_tier_config(
+        package_name=package_name,
+        device_tier_config_id=device_tier_config_id,
+    )
+    return config.model_dump()
+
+
+@mcp.tool()
+def list_device_tier_configs(package_name: str) -> list[dict[str, Any]]:
+    """List all device tier configs for an app.
+
+    Args:
+        package_name: App package name
+
+    Returns:
+        List of device tier configs with device groups, tier set, and country sets
+    """
+    client = get_client_from_context()
+
+    configs = client.list_device_tier_configs(package_name)
+    return [config.model_dump() for config in configs]
+
+
+@mcp.tool()
+def create_device_tier_config(
+    package_name: str,
+    config: dict[str, Any],
+    allow_unknown_devices: bool = False,
+) -> dict[str, Any]:
+    """Create a new device tier config.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        config: DeviceTierConfig resource body (deviceGroups, deviceTierSet,
+            userCountrySets)
+        allow_unknown_devices: Accept device IDs unknown to Play's catalog rather
+            than rejecting them (default: False)
+
+    Returns:
+        The created device tier config
+    """
+    if blocked := _read_only_block("create_device_tier_config"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_device_tier_config(
+        package_name=package_name,
+        config=config,
+        allow_unknown_devices=allow_unknown_devices,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_device_tier_configs.py
+++ b/tests/test_device_tier_configs.py
@@ -1,0 +1,228 @@
+"""Tests for device tier config tools (applications.deviceTierConfigs)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import DeviceTierConfig
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_device_tier_config_defaults():
+    config = DeviceTierConfig(package_name="com.example.app")
+    assert config.device_tier_config_id is None
+    assert config.device_groups == []
+    assert config.device_tier_set is None
+    assert config.user_country_sets == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _dtc(service: MagicMock) -> MagicMock:
+    return service.applications.return_value.deviceTierConfigs.return_value
+
+
+_CONFIG_RESPONSE = {
+    "deviceTierConfigId": "12345",
+    "deviceGroups": [{"name": "high_ram", "deviceSelectors": [{"deviceRam": {"minBytes": "1"}}]}],
+    "deviceTierSet": {"deviceTiers": [{"level": 1, "deviceGroupNames": ["high_ram"]}]},
+    "userCountrySets": [{"name": "europe", "countryCodes": ["DE", "FR"]}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: get_device_tier_config
+# ---------------------------------------------------------------------------
+
+
+def test_get_device_tier_config_success():
+    service = MagicMock()
+    _dtc(service).get.return_value.execute.return_value = _CONFIG_RESPONSE
+    client = _client(service)
+
+    result = client.get_device_tier_config("com.example.app", "12345")
+
+    assert isinstance(result, DeviceTierConfig)
+    assert result.package_name == "com.example.app"
+    assert result.device_tier_config_id == "12345"
+    assert result.device_groups == _CONFIG_RESPONSE["deviceGroups"]
+    assert result.device_tier_set == _CONFIG_RESPONSE["deviceTierSet"]
+    assert result.user_country_sets == _CONFIG_RESPONSE["userCountrySets"]
+    _dtc(service).get.assert_called_once_with(
+        packageName="com.example.app", deviceTierConfigId="12345"
+    )
+
+
+def test_get_device_tier_config_http_error():
+    service = MagicMock()
+    _dtc(service).get.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to get device tier config"):
+        client.get_device_tier_config("com.example.app", "12345")
+
+
+# ---------------------------------------------------------------------------
+# Client: list_device_tier_configs
+# ---------------------------------------------------------------------------
+
+
+def test_list_device_tier_configs_success():
+    service = MagicMock()
+    _dtc(service).list.return_value.execute.return_value = {
+        "deviceTierConfigs": [
+            _CONFIG_RESPONSE,
+            {"deviceTierConfigId": "67890"},
+        ]
+    }
+    client = _client(service)
+
+    result = client.list_device_tier_configs("com.example.app")
+
+    assert [c.device_tier_config_id for c in result] == ["12345", "67890"]
+    assert result[1].device_groups == []
+    assert result[1].device_tier_set is None
+    _dtc(service).list.assert_called_once_with(packageName="com.example.app")
+
+
+def test_list_device_tier_configs_empty():
+    service = MagicMock()
+    _dtc(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_device_tier_configs("com.example.app")
+
+    assert result == []
+
+
+def test_list_device_tier_configs_http_error():
+    service = MagicMock()
+    _dtc(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list device tier configs"):
+        client.list_device_tier_configs("com.example.app")
+
+
+# ---------------------------------------------------------------------------
+# Client: create_device_tier_config
+# ---------------------------------------------------------------------------
+
+
+def test_create_device_tier_config_success_defaults():
+    service = MagicMock()
+    _dtc(service).create.return_value.execute.return_value = _CONFIG_RESPONSE
+    client = _client(service)
+
+    body = {"deviceGroups": [{"name": "high_ram"}]}
+    result = client.create_device_tier_config("com.example.app", body)
+
+    assert isinstance(result, DeviceTierConfig)
+    assert result.device_tier_config_id == "12345"
+    _dtc(service).create.assert_called_once_with(
+        packageName="com.example.app",
+        allowUnknownDevices=False,
+        body=body,
+    )
+
+
+def test_create_device_tier_config_allow_unknown_devices_true():
+    service = MagicMock()
+    _dtc(service).create.return_value.execute.return_value = _CONFIG_RESPONSE
+    client = _client(service)
+
+    body = {"deviceGroups": [{"name": "high_ram"}]}
+    client.create_device_tier_config("com.example.app", body, allow_unknown_devices=True)
+
+    _dtc(service).create.assert_called_once_with(
+        packageName="com.example.app",
+        allowUnknownDevices=True,
+        body=body,
+    )
+
+
+def test_create_device_tier_config_http_error():
+    service = MagicMock()
+    _dtc(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create device tier config"):
+        client.create_device_tier_config("com.example.app", {"deviceGroups": []})
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_get_device_tier_config(monkeypatch):
+    mc = MagicMock()
+    mc.get_device_tier_config.return_value = DeviceTierConfig(
+        package_name="com.example.app", device_tier_config_id="12345"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.get_device_tier_config("com.example.app", "12345")
+
+    assert result["device_tier_config_id"] == "12345"
+    mc.get_device_tier_config.assert_called_once_with(
+        package_name="com.example.app", device_tier_config_id="12345"
+    )
+
+
+def test_tool_list_device_tier_configs(monkeypatch):
+    mc = MagicMock()
+    mc.list_device_tier_configs.return_value = [
+        DeviceTierConfig(package_name="com.example.app", device_tier_config_id="12345")
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_device_tier_configs("com.example.app")
+
+    assert result[0]["device_tier_config_id"] == "12345"
+    mc.list_device_tier_configs.assert_called_once_with("com.example.app")
+
+
+def test_tool_create_device_tier_config(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_device_tier_config.return_value = DeviceTierConfig(
+        package_name="com.example.app", device_tier_config_id="12345"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"deviceGroups": [{"name": "high_ram"}]}
+    result = server.create_device_tier_config("com.example.app", body, allow_unknown_devices=True)
+
+    assert result["device_tier_config_id"] == "12345"
+    mc.create_device_tier_config.assert_called_once_with(
+        package_name="com.example.app",
+        config=body,
+        allow_unknown_devices=True,
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -401,6 +401,13 @@ WRITE_TOOLS = [
             "refund": {"fullRefund": {}},
         },
     ),
+    (
+        "create_device_tier_config",
+        {
+            "package_name": "com.example.app",
+            "config": {"deviceGroups": [{"name": "high"}]},
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `applications.deviceTierConfigs` (device-targeted delivery configs):

- **`get_device_tier_config`** / **`list_device_tier_configs`** (reads)
- **`create_device_tier_config`** (write, `allow_unknown_devices`) — device tier configs are immutable (no update/delete in the API)

`create` is read-only-gated.

## Changes
- `models.py`: `DeviceTierConfig`.
- `client.py`: 3 methods + `_parse_device_tier_config`. Verified vs discovery rev 20260701: chain `applications().deviceTierConfigs()`, list envelope `deviceTierConfigs`, create `allowUnknownDevices`.
- `server.py`: 3 tools (create guard-first).
- Tests: `tests/test_device_tier_configs.py` + 1 `WRITE_TOOLS` entry.
- Docs updated.

## Validation
- `pytest` → **511 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2