### PR TITLE
feat: add app data safety labels (set_data_safety)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -129,6 +129,12 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`list_device_tier_configs`](tools/subscriptions.md#list_device_tier_configs) | List device tier configs for an app |
 | `create_device_tier_config` | Create a device tier config (write) |
 
+## App Management Tools
+
+| Tool | Description |
+|---|---|
+| `set_data_safety` | Write an app's data safety labels declaration (write) |
+
 ## Testers Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1280,3 +1280,21 @@ create_device_tier_config(
     allow_unknown_devices=False,
 )
 ```
+
+## Data Safety
+
+### set_data_safety
+
+Write the data safety labels declaration of an app. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `safety_labels` | object | Yes | `SafetyLabelsUpdateRequest` body containing a `safetyLabels` string with the contents of the Data Safety CSV file |
+
+```python
+set_data_safety(
+    package_name="com.example.myapp",
+    safety_labels={"safetyLabels": "<contents of Data Safety CSV>"},
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -21,6 +21,7 @@ from googleapiclient.http import MediaFileUpload
 from play_store_mcp.models import (
     AppDetails,
     BatchDeploymentResult,
+    DataSafetyResult,
     DeploymentResult,
     DeviceTierConfig,
     ExpansionFile,
@@ -4321,3 +4322,40 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to create device tier config", error=str(e))
             raise PlayStoreClientError(f"Failed to create device tier config: {e.reason}") from e
+
+    # =========================================================================
+    # Data Safety API
+    # =========================================================================
+
+    def set_data_safety(
+        self,
+        package_name: str,
+        safety_labels: dict[str, Any],
+    ) -> DataSafetyResult:
+        """Write the data safety labels declaration of an app.
+
+        Args:
+            package_name: App package name.
+            safety_labels: SafetyLabelsUpdateRequest resource body. Contains a
+                ``safetyLabels`` string with the contents of the Data Safety CSV.
+
+        Returns:
+            The result of the update.
+        """
+        self._logger.info("Setting data safety labels", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            service.applications().dataSafety(
+                packageName=package_name,
+                body=safety_labels,
+            ).execute()
+            return DataSafetyResult(
+                success=True,
+                package_name=package_name,
+                message="Data safety labels updated",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to update data safety labels", error=str(e))
+            raise PlayStoreClientError(f"Failed to update data safety labels: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -418,3 +418,12 @@ class DeviceTierConfig(BaseModel):
     user_country_sets: list[dict[str, Any]] = Field(
         default_factory=list, description="User country set definitions"
     )
+
+
+class DataSafetyResult(BaseModel):
+    """Result of updating an app's data safety labels (applications.dataSafety)."""
+
+    success: bool = Field(..., description="Whether the update succeeded")
+    package_name: str = Field(..., description="App package name")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2577,6 +2577,39 @@ def create_device_tier_config(
 
 
 # =============================================================================
+# Data Safety Tools
+# =============================================================================
+
+
+@mcp.tool()
+def set_data_safety(
+    package_name: str,
+    safety_labels: dict[str, Any],
+) -> dict[str, Any]:
+    """Write the data safety labels declaration of an app.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        safety_labels: SafetyLabelsUpdateRequest resource body. Contains a
+            `safetyLabels` string with the contents of the Data Safety CSV
+
+    Returns:
+        The result of the update
+    """
+    if blocked := _read_only_block("set_data_safety"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.set_data_safety(
+        package_name=package_name,
+        safety_labels=safety_labels,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_data_safety.py
+++ b/tests/test_data_safety.py
@@ -1,0 +1,108 @@
+"""Tests for data safety tools (applications.dataSafety)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import DataSafetyResult
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_data_safety_result_defaults():
+    result = DataSafetyResult(
+        success=True,
+        package_name="com.example.app",
+        message="Data safety labels updated",
+    )
+    assert result.success is True
+    assert result.package_name == "com.example.app"
+    assert result.message == "Data safety labels updated"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Client: set_data_safety
+# ---------------------------------------------------------------------------
+
+
+def test_set_data_safety_success():
+    service = MagicMock()
+    service.applications.return_value.dataSafety.return_value.execute.return_value = {}
+    client = _client(service)
+
+    safety_labels = {"safetyLabels": "col1,col2\nval1,val2"}
+    result = client.set_data_safety("com.example.app", safety_labels)
+
+    assert isinstance(result, DataSafetyResult)
+    assert result.success is True
+    assert result.package_name == "com.example.app"
+    assert result.message == "Data safety labels updated"
+    assert result.error is None
+    service.applications.return_value.dataSafety.assert_called_once_with(
+        packageName="com.example.app", body=safety_labels
+    )
+
+
+def test_set_data_safety_http_error():
+    service = MagicMock()
+    service.applications.return_value.dataSafety.return_value.execute.side_effect = (
+        _make_http_error("bad")
+    )
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to update data safety labels"):
+        client.set_data_safety("com.example.app", {"safetyLabels": "csv"})
+
+
+# ---------------------------------------------------------------------------
+# MCP tool
+# ---------------------------------------------------------------------------
+
+
+def test_tool_set_data_safety(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.set_data_safety.return_value = DataSafetyResult(
+        success=True,
+        package_name="com.example.app",
+        message="Data safety labels updated",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    safety_labels = {"safetyLabels": "col1,col2\nval1,val2"}
+    result = server.set_data_safety("com.example.app", safety_labels)
+
+    assert result["success"] is True
+    assert result["package_name"] == "com.example.app"
+    mc.set_data_safety.assert_called_once_with(
+        package_name="com.example.app",
+        safety_labels=safety_labels,
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -408,6 +408,13 @@ WRITE_TOOLS = [
             "config": {"deviceGroups": [{"name": "high"}]},
         },
     ),
+    (
+        "set_data_safety",
+        {
+            "package_name": "com.example.app",
+            "safety_labels": {"safetyLabels": "csv"},
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `applications.dataSafety` — **`set_data_safety`** (write, read-only-gated) to update an app's Data Safety labels.

## Changes
- `models.py`: `DataSafetyResult`.
- `client.py`: `set_data_safety(package_name, safety_labels)` — `service.applications().dataSafety(packageName=…, body=…)` (verified vs discovery rev 20260701: method directly on `applications`, `SafetyLabelsUpdateRequest` body pass-through, empty response).
- `server.py`: 1 write tool (guard-first).
- Tests: `tests/test_data_safety.py` + 1 `WRITE_TOOLS` entry.
- Docs updated.

## Validation
- `pytest` → **516 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2