### PR TITLE
feat: add app recovery actions (list/create/deploy/cancel/addTargeting)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -134,6 +134,11 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | Tool | Description |
 |---|---|
 | `set_data_safety` | Write an app's data safety labels declaration (write) |
+| [`list_app_recoveries`](tools/subscriptions.md#list_app_recoveries) | List app recovery actions for an app |
+| `create_app_recovery` | Create a draft app recovery action (write) |
+| `deploy_app_recovery` | Deploy an app recovery action to users (write) |
+| `cancel_app_recovery` | Cancel an app recovery action (write) |
+| `add_app_recovery_targeting` | Add targeting to an app recovery action (write) |
 
 ## Testers Tools
 

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1298,3 +1298,89 @@ set_data_safety(
     safety_labels={"safetyLabels": "<contents of Data Safety CSV>"},
 )
 ```
+
+## App Recovery
+
+Manage app recovery actions
+([applications.appRecoveries](https://developers.google.com/android-publisher/api-ref/rest/v3/applications.appRecoveries)).
+An app recovery action lets you push a Remote In-App Update to devices already
+running a released version, so you can recover from a bad rollout without
+shipping a new release. `list_app_recoveries` is read-only; `create_app_recovery`,
+`deploy_app_recovery`, `cancel_app_recovery`, and `add_app_recovery_targeting`
+are writes and are disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+### list_app_recoveries
+
+List app recovery actions for an app. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+
+```python
+list_app_recoveries("com.example.myapp")
+```
+
+### create_app_recovery
+
+Create a draft app recovery action. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `recovery` | object | Yes | `CreateDraftAppRecoveryRequest` body (e.g. `remoteInAppUpdate` plus `targeting`) |
+
+```python
+create_app_recovery(
+    package_name="com.example.myapp",
+    recovery={
+        "remoteInAppUpdate": {"isRemoteInAppUpdateRequested": True},
+        "targeting": {"allUsers": {}},
+    },
+)
+```
+
+### deploy_app_recovery
+
+Deploy an app recovery action to users. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `app_recovery_id` | string | Yes | App recovery action ID |
+
+```python
+deploy_app_recovery(package_name="com.example.myapp", app_recovery_id="123")
+```
+
+### cancel_app_recovery
+
+Cancel an app recovery action. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `app_recovery_id` | string | Yes | App recovery action ID |
+
+```python
+cancel_app_recovery(package_name="com.example.myapp", app_recovery_id="123")
+```
+
+### add_app_recovery_targeting
+
+Add targeting to an app recovery action. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `app_recovery_id` | string | Yes | App recovery action ID |
+| `targeting` | object | Yes | `AddTargetingRequest` body (e.g. a `targetingUpdate` object) |
+
+```python
+add_app_recovery_targeting(
+    package_name="com.example.myapp",
+    app_recovery_id="123",
+    targeting={"targetingUpdate": {"allUsers": {}}},
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -20,6 +20,8 @@ from googleapiclient.http import MediaFileUpload
 
 from play_store_mcp.models import (
     AppDetails,
+    AppRecovery,
+    AppRecoveryResult,
     BatchDeploymentResult,
     DataSafetyResult,
     DeploymentResult,
@@ -4359,3 +4361,185 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to update data safety labels", error=str(e))
             raise PlayStoreClientError(f"Failed to update data safety labels: {e.reason}") from e
+
+    # =========================================================================
+    # App Recovery API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_app_recovery(package_name: str, data: dict[str, Any]) -> AppRecovery:
+        """Parse an AppRecoveryAction API resource into an AppRecovery model."""
+        return AppRecovery(
+            package_name=package_name,
+            app_recovery_id=data.get("recoveryId") or data.get("appRecoveryId"),
+            status=data.get("recoveryStatus") or data.get("status"),
+            targeting=data.get("targeting"),
+            create_time=data.get("createTime"),
+        )
+
+    def list_app_recoveries(self, package_name: str) -> list[AppRecovery]:
+        """List app recovery actions for an app.
+
+        Args:
+            package_name: App package name.
+
+        Returns:
+            List of app recovery actions.
+        """
+        self._logger.info("Listing app recoveries", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            result = service.apprecovery().list(packageName=package_name).execute()
+
+            return [
+                self._parse_app_recovery(package_name, recovery_data)
+                for recovery_data in result.get("recoveryActions", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list app recoveries", error=str(e))
+            raise PlayStoreClientError(f"Failed to list app recoveries: {e.reason}") from e
+
+    def create_app_recovery(
+        self,
+        package_name: str,
+        recovery: dict[str, Any],
+    ) -> AppRecovery:
+        """Create a draft app recovery action.
+
+        Args:
+            package_name: App package name.
+            recovery: CreateDraftAppRecoveryRequest resource body (e.g.
+                ``remoteInAppUpdate`` plus ``targeting``).
+
+        Returns:
+            The created app recovery action.
+        """
+        self._logger.info("Creating app recovery", package_name=package_name)
+        service = self._get_service()
+
+        try:
+            data = service.apprecovery().create(packageName=package_name, body=recovery).execute()
+            return self._parse_app_recovery(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create app recovery", error=str(e))
+            raise PlayStoreClientError(f"Failed to create app recovery: {e.reason}") from e
+
+    def deploy_app_recovery(
+        self,
+        package_name: str,
+        app_recovery_id: str,
+    ) -> AppRecoveryResult:
+        """Deploy an app recovery action to users.
+
+        Args:
+            package_name: App package name.
+            app_recovery_id: App recovery action ID.
+
+        Returns:
+            The result of the deploy action.
+        """
+        self._logger.info(
+            "Deploying app recovery",
+            package_name=package_name,
+            app_recovery_id=app_recovery_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.apprecovery().deploy(
+                packageName=package_name,
+                appRecoveryId=app_recovery_id,
+                body={},
+            ).execute()
+            return AppRecoveryResult(
+                success=True,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+                message="App recovery deployed",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to deploy app recovery", error=str(e))
+            raise PlayStoreClientError(f"Failed to deploy app recovery: {e.reason}") from e
+
+    def cancel_app_recovery(
+        self,
+        package_name: str,
+        app_recovery_id: str,
+    ) -> AppRecoveryResult:
+        """Cancel an app recovery action.
+
+        Args:
+            package_name: App package name.
+            app_recovery_id: App recovery action ID.
+
+        Returns:
+            The result of the cancel action.
+        """
+        self._logger.info(
+            "Canceling app recovery",
+            package_name=package_name,
+            app_recovery_id=app_recovery_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.apprecovery().cancel(
+                packageName=package_name,
+                appRecoveryId=app_recovery_id,
+                body={},
+            ).execute()
+            return AppRecoveryResult(
+                success=True,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+                message="App recovery canceled",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to cancel app recovery", error=str(e))
+            raise PlayStoreClientError(f"Failed to cancel app recovery: {e.reason}") from e
+
+    def add_app_recovery_targeting(
+        self,
+        package_name: str,
+        app_recovery_id: str,
+        targeting: dict[str, Any],
+    ) -> AppRecoveryResult:
+        """Add targeting to an app recovery action.
+
+        Args:
+            package_name: App package name.
+            app_recovery_id: App recovery action ID.
+            targeting: AddTargetingRequest resource body (e.g. a
+                ``targetingUpdate`` object).
+
+        Returns:
+            The result of the add-targeting action.
+        """
+        self._logger.info(
+            "Adding app recovery targeting",
+            package_name=package_name,
+            app_recovery_id=app_recovery_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.apprecovery().addTargeting(
+                packageName=package_name,
+                appRecoveryId=app_recovery_id,
+                body=targeting,
+            ).execute()
+            return AppRecoveryResult(
+                success=True,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+                message="App recovery targeting added",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to add app recovery targeting", error=str(e))
+            raise PlayStoreClientError(f"Failed to add app recovery targeting: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -427,3 +427,25 @@ class DataSafetyResult(BaseModel):
     package_name: str = Field(..., description="App package name")
     message: str = Field(..., description="Status message")
     error: str | None = Field(None, description="Error details if failed")
+
+
+class AppRecovery(BaseModel):
+    """App recovery action (applications.appRecoveries resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    app_recovery_id: str | None = Field(None, description="App recovery action ID")
+    status: str | None = Field(None, description="Recovery action status")
+    targeting: dict[str, Any] | None = Field(
+        None, description="Targeting criteria for the recovery action"
+    )
+    create_time: str | None = Field(None, description="Time the recovery action was created")
+
+
+class AppRecoveryResult(BaseModel):
+    """Result of a deploy/cancel/add-targeting action on an app recovery action."""
+
+    success: bool = Field(..., description="Whether the action succeeded")
+    package_name: str = Field(..., description="App package name")
+    app_recovery_id: str | None = Field(None, description="App recovery action ID")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2610,6 +2610,140 @@ def set_data_safety(
 
 
 # =============================================================================
+# App Recovery Tools
+# =============================================================================
+
+
+@mcp.tool()
+def list_app_recoveries(package_name: str) -> list[dict[str, Any]]:
+    """List all app recovery actions for an app.
+
+    Args:
+        package_name: App package name
+
+    Returns:
+        List of app recovery actions with ID, status, targeting, and create time
+    """
+    client = get_client_from_context()
+
+    recoveries = client.list_app_recoveries(package_name)
+    return [recovery.model_dump() for recovery in recoveries]
+
+
+@mcp.tool()
+def create_app_recovery(
+    package_name: str,
+    recovery: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a draft app recovery action.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        recovery: CreateDraftAppRecoveryRequest resource body (e.g.
+            `remoteInAppUpdate` plus `targeting`)
+
+    Returns:
+        The created app recovery action
+    """
+    if blocked := _read_only_block("create_app_recovery"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_app_recovery(
+        package_name=package_name,
+        recovery=recovery,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def deploy_app_recovery(
+    package_name: str,
+    app_recovery_id: str,
+) -> dict[str, Any]:
+    """Deploy an app recovery action to users.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        app_recovery_id: App recovery action ID
+
+    Returns:
+        The result of the deploy action
+    """
+    if blocked := _read_only_block("deploy_app_recovery"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.deploy_app_recovery(
+        package_name=package_name,
+        app_recovery_id=app_recovery_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def cancel_app_recovery(
+    package_name: str,
+    app_recovery_id: str,
+) -> dict[str, Any]:
+    """Cancel an app recovery action.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        app_recovery_id: App recovery action ID
+
+    Returns:
+        The result of the cancel action
+    """
+    if blocked := _read_only_block("cancel_app_recovery"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.cancel_app_recovery(
+        package_name=package_name,
+        app_recovery_id=app_recovery_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def add_app_recovery_targeting(
+    package_name: str,
+    app_recovery_id: str,
+    targeting: dict[str, Any],
+) -> dict[str, Any]:
+    """Add targeting to an app recovery action.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        app_recovery_id: App recovery action ID
+        targeting: AddTargetingRequest resource body (e.g. a `targetingUpdate`
+            object)
+
+    Returns:
+        The result of the add-targeting action
+    """
+    if blocked := _read_only_block("add_app_recovery_targeting"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.add_app_recovery_targeting(
+        package_name=package_name,
+        app_recovery_id=app_recovery_id,
+        targeting=targeting,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_app_recovery.py
+++ b/tests/test_app_recovery.py
@@ -1,0 +1,339 @@
+"""Tests for app recovery tools (applications.appRecoveries)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import AppRecovery, AppRecoveryResult
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_app_recovery_defaults():
+    recovery = AppRecovery(package_name="com.example.app")
+    assert recovery.app_recovery_id is None
+    assert recovery.status is None
+    assert recovery.targeting is None
+    assert recovery.create_time is None
+
+
+def test_app_recovery_result_defaults():
+    result = AppRecoveryResult(
+        success=True,
+        package_name="com.example.app",
+        message="ok",
+    )
+    assert result.success is True
+    assert result.package_name == "com.example.app"
+    assert result.app_recovery_id is None
+    assert result.message == "ok"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _rec(service: MagicMock) -> MagicMock:
+    return service.apprecovery.return_value
+
+
+_ACTION_RESPONSE = {
+    "appRecoveryId": "123",
+    "status": "RECOVERY_STATUS_DRAFT",
+    "targeting": {"allUsers": {}},
+    "createTime": "2026-01-01T00:00:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: list_app_recoveries
+# ---------------------------------------------------------------------------
+
+
+def test_list_app_recoveries_success():
+    service = MagicMock()
+    _rec(service).list.return_value.execute.return_value = {
+        "recoveryActions": [
+            _ACTION_RESPONSE,
+            {"appRecoveryId": "456"},
+        ]
+    }
+    client = _client(service)
+
+    result = client.list_app_recoveries("com.example.app")
+
+    assert [r.app_recovery_id for r in result] == ["123", "456"]
+    assert result[0].status == "RECOVERY_STATUS_DRAFT"
+    assert result[0].targeting == {"allUsers": {}}
+    assert result[0].create_time == "2026-01-01T00:00:00Z"
+    assert result[1].status is None
+    assert result[1].targeting is None
+    _rec(service).list.assert_called_once_with(packageName="com.example.app")
+
+
+def test_list_app_recoveries_empty():
+    service = MagicMock()
+    _rec(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_app_recoveries("com.example.app")
+
+    assert result == []
+
+
+def test_list_app_recoveries_http_error():
+    service = MagicMock()
+    _rec(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list app recoveries"):
+        client.list_app_recoveries("com.example.app")
+
+
+# ---------------------------------------------------------------------------
+# Client: create_app_recovery
+# ---------------------------------------------------------------------------
+
+
+def test_create_app_recovery_success():
+    service = MagicMock()
+    _rec(service).create.return_value.execute.return_value = _ACTION_RESPONSE
+    client = _client(service)
+    body = {"remoteInAppUpdate": {"isRemoteInAppUpdateRequested": True}}
+
+    result = client.create_app_recovery("com.example.app", body)
+
+    assert isinstance(result, AppRecovery)
+    assert result.app_recovery_id == "123"
+    assert result.status == "RECOVERY_STATUS_DRAFT"
+    _rec(service).create.assert_called_once_with(packageName="com.example.app", body=body)
+
+
+def test_create_app_recovery_http_error():
+    service = MagicMock()
+    _rec(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create app recovery"):
+        client.create_app_recovery("com.example.app", {})
+
+
+# ---------------------------------------------------------------------------
+# Client: deploy_app_recovery
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_app_recovery_success():
+    service = MagicMock()
+    _rec(service).deploy.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.deploy_app_recovery("com.example.app", "123")
+
+    assert isinstance(result, AppRecoveryResult)
+    assert result.success is True
+    assert result.app_recovery_id == "123"
+    assert result.message == "App recovery deployed"
+    assert result.error is None
+    _rec(service).deploy.assert_called_once_with(
+        packageName="com.example.app", appRecoveryId="123", body={}
+    )
+
+
+def test_deploy_app_recovery_http_error():
+    service = MagicMock()
+    _rec(service).deploy.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to deploy app recovery"):
+        client.deploy_app_recovery("com.example.app", "123")
+
+
+# ---------------------------------------------------------------------------
+# Client: cancel_app_recovery
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_app_recovery_success():
+    service = MagicMock()
+    _rec(service).cancel.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.cancel_app_recovery("com.example.app", "123")
+
+    assert isinstance(result, AppRecoveryResult)
+    assert result.success is True
+    assert result.app_recovery_id == "123"
+    assert result.message == "App recovery canceled"
+    _rec(service).cancel.assert_called_once_with(
+        packageName="com.example.app", appRecoveryId="123", body={}
+    )
+
+
+def test_cancel_app_recovery_http_error():
+    service = MagicMock()
+    _rec(service).cancel.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to cancel app recovery"):
+        client.cancel_app_recovery("com.example.app", "123")
+
+
+# ---------------------------------------------------------------------------
+# Client: add_app_recovery_targeting
+# ---------------------------------------------------------------------------
+
+
+def test_add_app_recovery_targeting_success():
+    service = MagicMock()
+    _rec(service).addTargeting.return_value.execute.return_value = {}
+    client = _client(service)
+    body = {"targetingUpdate": {"allUsers": {}}}
+
+    result = client.add_app_recovery_targeting("com.example.app", "123", body)
+
+    assert isinstance(result, AppRecoveryResult)
+    assert result.success is True
+    assert result.app_recovery_id == "123"
+    assert result.message == "App recovery targeting added"
+    _rec(service).addTargeting.assert_called_once_with(
+        packageName="com.example.app", appRecoveryId="123", body=body
+    )
+
+
+def test_add_app_recovery_targeting_http_error():
+    service = MagicMock()
+    _rec(service).addTargeting.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to add app recovery targeting"):
+        client.add_app_recovery_targeting("com.example.app", "123", {})
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_list_app_recoveries(monkeypatch):
+    mc = MagicMock()
+    mc.list_app_recoveries.return_value = [
+        AppRecovery(
+            package_name="com.example.app",
+            app_recovery_id="123",
+            status="RECOVERY_STATUS_DRAFT",
+        )
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_app_recoveries("com.example.app")
+
+    assert result == [
+        {
+            "package_name": "com.example.app",
+            "app_recovery_id": "123",
+            "status": "RECOVERY_STATUS_DRAFT",
+            "targeting": None,
+            "create_time": None,
+        }
+    ]
+    mc.list_app_recoveries.assert_called_once_with("com.example.app")
+
+
+def test_tool_create_app_recovery(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_app_recovery.return_value = AppRecovery(
+        package_name="com.example.app",
+        app_recovery_id="123",
+        status="RECOVERY_STATUS_DRAFT",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+    body = {"remoteInAppUpdate": {"isRemoteInAppUpdateRequested": True}}
+
+    result = server.create_app_recovery("com.example.app", body)
+
+    assert result["app_recovery_id"] == "123"
+    mc.create_app_recovery.assert_called_once_with(package_name="com.example.app", recovery=body)
+
+
+def test_tool_deploy_app_recovery(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.deploy_app_recovery.return_value = AppRecoveryResult(
+        success=True,
+        package_name="com.example.app",
+        app_recovery_id="123",
+        message="App recovery deployed",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.deploy_app_recovery("com.example.app", "123")
+
+    assert result["success"] is True
+    mc.deploy_app_recovery.assert_called_once_with(
+        package_name="com.example.app", app_recovery_id="123"
+    )
+
+
+def test_tool_cancel_app_recovery(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.cancel_app_recovery.return_value = AppRecoveryResult(
+        success=True,
+        package_name="com.example.app",
+        app_recovery_id="123",
+        message="App recovery canceled",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.cancel_app_recovery("com.example.app", "123")
+
+    assert result["success"] is True
+    mc.cancel_app_recovery.assert_called_once_with(
+        package_name="com.example.app", app_recovery_id="123"
+    )
+
+
+def test_tool_add_app_recovery_targeting(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.add_app_recovery_targeting.return_value = AppRecoveryResult(
+        success=True,
+        package_name="com.example.app",
+        app_recovery_id="123",
+        message="App recovery targeting added",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+    body = {"targetingUpdate": {"allUsers": {}}}
+
+    result = server.add_app_recovery_targeting("com.example.app", "123", body)
+
+    assert result["success"] is True
+    mc.add_app_recovery_targeting.assert_called_once_with(
+        package_name="com.example.app", app_recovery_id="123", targeting=body
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -415,6 +415,29 @@ WRITE_TOOLS = [
             "safety_labels": {"safetyLabels": "csv"},
         },
     ),
+    (
+        "create_app_recovery",
+        {
+            "package_name": "com.example.app",
+            "recovery": {"remoteInAppUpdate": {"isRemoteInAppUpdateRequested": True}},
+        },
+    ),
+    (
+        "deploy_app_recovery",
+        {"package_name": "com.example.app", "app_recovery_id": "123"},
+    ),
+    (
+        "cancel_app_recovery",
+        {"package_name": "com.example.app", "app_recovery_id": "123"},
+    ),
+    (
+        "add_app_recovery_targeting",
+        {
+            "package_name": "com.example.app",
+            "app_recovery_id": "123",
+            "targeting": {"targetingUpdate": {"allUsers": {}}},
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `apprecovery` (staged recovery / kill-switch actions):

- **`list_app_recoveries`** (read)
- **`create_app_recovery`**, **`deploy_app_recovery`**, **`cancel_app_recovery`**, **`add_app_recovery_targeting`** (writes, read-only-gated)

## Changes
- `models.py`: `AppRecovery`, `AppRecoveryResult`.
- `client.py`: 5 methods + `_parse_app_recovery`. Verified vs discovery rev 20260701: resource `apprecovery`, list envelope `recoveryActions`, kwarg `appRecoveryId`, empty bodies for deploy/cancel.
- `server.py`: 5 tools (4 writes guard-first).
- Tests: `tests/test_app_recovery.py` (18) + 4 `WRITE_TOOLS` entries.
- Docs updated.

## Validation
- `pytest` → **538 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (2 cosmetic NITs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app recovery tools for listing, creating, deploying, canceling, and updating recovery targeting.
  * Expanded the client and server to support these recovery workflows end to end.

* **Documentation**
  * Updated the tools reference and subscriptions docs with the new app recovery section, including usage details and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->