### PR TITLE
feat: add generated APKs (list + download)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -129,6 +129,13 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`list_device_tier_configs`](tools/subscriptions.md#list_device_tier_configs) | List device tier configs for an app |
 | `create_device_tier_config` | Create a device tier config (write) |
 
+## Generated APKs Tools
+
+| Tool | Description |
+|---|---|
+| [`list_generated_apks`](tools/subscriptions.md#list_generated_apks) | List the APKs Google Play generated from an app bundle version |
+| [`download_generated_apk`](tools/subscriptions.md#download_generated_apk) | Download a single generated APK to a local file |
+
 ## App Management Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1384,3 +1384,50 @@ add_app_recovery_targeting(
     targeting={"targetingUpdate": {"allUsers": {}}},
 )
 ```
+
+## Generated APKs
+
+Read the APKs Google Play generates from an uploaded app bundle
+([generatedapks](https://developers.google.com/android-publisher/api-ref/rest/v3/generatedapks)).
+Both tools are read-only and available in
+[read-only mode](../configuration.md#read-only-mode) — `download_generated_apk`
+only writes a file to your local machine, it does not change any Play state.
+
+### list_generated_apks
+
+List the downloadable APKs generated from an app bundle version. Google Play
+produces split, standalone, universal, asset-pack-slice, and recovery APKs; this
+flattens the per-signing-key response into one entry per downloadable APK, each
+with a `download_id` and an `apk_type` (`split`, `standalone`, `universal`,
+`asset_pack_slice`, or `recovery`). Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+
+```python
+list_generated_apks("com.example.myapp", version_code=42)
+```
+
+### download_generated_apk
+
+Download a single generated APK to a local file, streaming the bytes to disk.
+Pass a `download_id` obtained from `list_generated_apks`. Read-only with respect
+to Play (available in read-only mode); it writes to the local `destination_path`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+| `download_id` | string | Yes | Download ID of the generated APK (from `list_generated_apks`) |
+| `destination_path` | string | Yes | Local path to write the APK bytes to |
+
+```python
+download_generated_apk(
+    package_name="com.example.myapp",
+    version_code=42,
+    download_id="split-1",
+    destination_path="/path/to/base-master.apk",
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -16,7 +16,7 @@ import structlog
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaFileUpload
+from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
 from play_store_mcp.models import (
     AppDetails,
@@ -26,8 +26,10 @@ from play_store_mcp.models import (
     DataSafetyResult,
     DeploymentResult,
     DeviceTierConfig,
+    DownloadResult,
     ExpansionFile,
     ExternalTransaction,
+    GeneratedApksDownload,
     InAppProduct,
     InAppProductActionResult,
     Listing,
@@ -4543,3 +4545,135 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to add app recovery targeting", error=str(e))
             raise PlayStoreClientError(f"Failed to add app recovery targeting: {e.reason}") from e
+
+    # =========================================================================
+    # Generated APKs API
+    # =========================================================================
+
+    def list_generated_apks(
+        self,
+        package_name: str,
+        version_code: int,
+    ) -> list[GeneratedApksDownload]:
+        """List the downloadable APKs generated from an app bundle version.
+
+        Google Play generates split, standalone, universal, asset-pack-slice,
+        and recovery APKs from an uploaded app bundle. This flattens the
+        per-signing-key response into one item per downloadable APK.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+
+        Returns:
+            List of downloadable generated APKs, each with its download ID and type.
+        """
+        self._logger.info(
+            "Listing generated APKs",
+            package_name=package_name,
+            version_code=version_code,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.generatedapks()
+                .list(packageName=package_name, versionCode=version_code)
+                .execute()
+            )
+
+            downloads: list[GeneratedApksDownload] = []
+            for entry in result.get("generatedApks", []):
+                # Each signing-key entry holds several sub-lists (plus optional
+                # unprotected variants) and a single universal APK object; every
+                # sub-entry carries a "downloadId". Flatten them all.
+                list_fields: list[tuple[str, str]] = [
+                    ("generatedSplitApks", "split"),
+                    ("unprotectedGeneratedSplitApks", "split"),
+                    ("generatedStandaloneApks", "standalone"),
+                    ("unprotectedGeneratedStandaloneApks", "standalone"),
+                    ("generatedAssetPackSlices", "asset_pack_slice"),
+                    ("generatedRecoveryModules", "recovery"),
+                ]
+                for field_name, apk_type in list_fields:
+                    for sub in entry.get(field_name, []):
+                        download_id = sub.get("downloadId")
+                        if download_id:
+                            downloads.append(
+                                GeneratedApksDownload(
+                                    package_name=package_name,
+                                    version_code=version_code,
+                                    download_id=download_id,
+                                    apk_type=apk_type,
+                                )
+                            )
+
+                universal = entry.get("generatedUniversalApk") or {}
+                universal_download_id = universal.get("downloadId")
+                if universal_download_id:
+                    downloads.append(
+                        GeneratedApksDownload(
+                            package_name=package_name,
+                            version_code=version_code,
+                            download_id=universal_download_id,
+                            apk_type="universal",
+                        )
+                    )
+
+            return downloads
+
+        except HttpError as e:
+            self._logger.exception("Failed to list generated APKs", error=str(e))
+            raise PlayStoreClientError(f"Failed to list generated APKs: {e.reason}") from e
+
+    def download_generated_apk(
+        self,
+        package_name: str,
+        version_code: int,
+        download_id: str,
+        destination_path: str,
+    ) -> DownloadResult:
+        """Download a single generated APK to a local file.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+            download_id: Download ID identifying the generated APK (from
+                :meth:`list_generated_apks`).
+            destination_path: Local path to stream the APK bytes to.
+
+        Returns:
+            Download result with success status and destination path.
+        """
+        self._logger.info(
+            "Downloading generated APK",
+            package_name=package_name,
+            version_code=version_code,
+            download_id=download_id,
+            destination_path=destination_path,
+        )
+        service = self._get_service()
+
+        try:
+            request = service.generatedapks().download(
+                packageName=package_name,
+                versionCode=version_code,
+                downloadId=download_id,
+                alt="media",
+            )
+
+            with Path(destination_path).open("wb") as fh:
+                downloader = MediaIoBaseDownload(fh, request)
+                done = False
+                while not done:
+                    _status, done = downloader.next_chunk()
+
+            return DownloadResult(
+                success=True,
+                destination_path=destination_path,
+                message=f"Downloaded generated APK to {destination_path}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to download generated APK", error=str(e))
+            raise PlayStoreClientError(f"Failed to download generated APK: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -449,3 +449,26 @@ class AppRecoveryResult(BaseModel):
     app_recovery_id: str | None = Field(None, description="App recovery action ID")
     message: str = Field(..., description="Status message")
     error: str | None = Field(None, description="Error details if failed")
+
+
+class GeneratedApksDownload(BaseModel):
+    """A single downloadable generated APK (generatedapks resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    version_code: int = Field(..., description="Bundle version code the APK was generated from")
+    download_id: str = Field(..., description="Download ID identifying the generated APK")
+    apk_type: str = Field(
+        ...,
+        description=(
+            "Kind of generated APK: split, standalone, universal, asset_pack_slice, or recovery"
+        ),
+    )
+
+
+class DownloadResult(BaseModel):
+    """Result of downloading a file to a local path."""
+
+    success: bool = Field(..., description="Whether the download succeeded")
+    destination_path: str = Field(..., description="Local path the file was written to")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2744,6 +2744,67 @@ def add_app_recovery_targeting(
 
 
 # =============================================================================
+# Generated APKs Tools
+# =============================================================================
+
+
+@mcp.tool()
+def list_generated_apks(
+    package_name: str,
+    version_code: int,
+) -> list[dict[str, Any]]:
+    """List the APKs Google Play generated from an app bundle version.
+
+    Returns one entry per downloadable generated APK (split, standalone,
+    universal, asset pack slice, or recovery), each with a download ID that can
+    be passed to `download_generated_apk`.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+
+    Returns:
+        List of downloadable generated APKs with their download IDs and types
+    """
+    client = get_client_from_context()
+
+    downloads = client.list_generated_apks(
+        package_name=package_name,
+        version_code=version_code,
+    )
+    return [download.model_dump() for download in downloads]
+
+
+@mcp.tool()
+def download_generated_apk(
+    package_name: str,
+    version_code: int,
+    download_id: str,
+    destination_path: str,
+) -> dict[str, Any]:
+    """Download a single generated APK to a local file.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+        download_id: Download ID of the generated APK (from `list_generated_apks`)
+        destination_path: Local path to write the APK bytes to
+
+    Returns:
+        Download result with success status and destination path
+    """
+    client = get_client_from_context()
+
+    result = client.download_generated_apk(
+        package_name=package_name,
+        version_code=version_code,
+        download_id=download_id,
+        destination_path=destination_path,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_generated_apks.py
+++ b/tests/test_generated_apks.py
@@ -1,0 +1,252 @@
+"""Tests for generated APK tools (generatedapks resource)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.client as client_module
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import DownloadResult, GeneratedApksDownload
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_generated_apks_download_model():
+    item = GeneratedApksDownload(
+        package_name="com.example.app",
+        version_code=42,
+        download_id="abc123",
+        apk_type="split",
+    )
+    assert item.package_name == "com.example.app"
+    assert item.version_code == 42
+    assert item.download_id == "abc123"
+    assert item.apk_type == "split"
+
+
+def test_download_result_model_defaults():
+    result = DownloadResult(
+        success=True,
+        destination_path="out/app.apk",
+        message="done",
+    )
+    assert result.success is True
+    assert result.destination_path == "out/app.apk"
+    assert result.message == "done"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _gak(service: MagicMock) -> MagicMock:
+    return service.generatedapks.return_value
+
+
+# A realistic per-signing-key response with download IDs across several sub-lists.
+_LIST_RESPONSE = {
+    "generatedApks": [
+        {
+            "certificateSha256Hash": "deadbeef",
+            "generatedSplitApks": [
+                {"downloadId": "split-1", "splitId": "", "moduleName": "base"},
+                {"downloadId": "split-2", "splitId": "config.arm64", "moduleName": "base"},
+            ],
+            "generatedStandaloneApks": [
+                {"downloadId": "standalone-1", "variantId": 0},
+            ],
+            "generatedAssetPackSlices": [
+                {"downloadId": "slice-1", "sliceId": "0", "moduleName": "assets"},
+            ],
+            "generatedRecoveryModules": [
+                {"downloadId": "recovery-1", "recoveryId": "1", "moduleName": "base"},
+            ],
+            "generatedUniversalApk": {"downloadId": "universal-1"},
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: list_generated_apks
+# ---------------------------------------------------------------------------
+
+
+def test_list_generated_apks_success():
+    service = MagicMock()
+    _gak(service).list.return_value.execute.return_value = _LIST_RESPONSE
+    client = _client(service)
+
+    result = client.list_generated_apks("com.example.app", 42)
+
+    assert all(isinstance(item, GeneratedApksDownload) for item in result)
+    assert all(item.package_name == "com.example.app" for item in result)
+    assert all(item.version_code == 42 for item in result)
+
+    by_id = {item.download_id: item.apk_type for item in result}
+    assert by_id == {
+        "split-1": "split",
+        "split-2": "split",
+        "standalone-1": "standalone",
+        "slice-1": "asset_pack_slice",
+        "recovery-1": "recovery",
+        "universal-1": "universal",
+    }
+    _gak(service).list.assert_called_once_with(packageName="com.example.app", versionCode=42)
+
+
+def test_list_generated_apks_unprotected_variants_and_missing_ids():
+    service = MagicMock()
+    _gak(service).list.return_value.execute.return_value = {
+        "generatedApks": [
+            {
+                "unprotectedGeneratedSplitApks": [{"downloadId": "usplit-1"}],
+                "unprotectedGeneratedStandaloneApks": [{"downloadId": "ustandalone-1"}],
+                # Entry with no downloadId is skipped.
+                "generatedSplitApks": [{"splitId": "no-id"}],
+                # Universal present but without a downloadId is skipped.
+                "generatedUniversalApk": {},
+            }
+        ]
+    }
+    client = _client(service)
+
+    result = client.list_generated_apks("com.example.app", 7)
+
+    by_id = {item.download_id: item.apk_type for item in result}
+    assert by_id == {"usplit-1": "split", "ustandalone-1": "standalone"}
+
+
+def test_list_generated_apks_empty():
+    service = MagicMock()
+    _gak(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_generated_apks("com.example.app", 42)
+
+    assert result == []
+
+
+def test_list_generated_apks_http_error():
+    service = MagicMock()
+    _gak(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list generated APKs"):
+        client.list_generated_apks("com.example.app", 42)
+
+
+# ---------------------------------------------------------------------------
+# Client: download_generated_apk
+# ---------------------------------------------------------------------------
+
+
+def test_download_generated_apk_success(monkeypatch, tmp_path):
+    service = MagicMock()
+    request = MagicMock()
+    _gak(service).download.return_value = request
+    client = _client(service)
+
+    downloader_instance = MagicMock()
+    downloader_instance.next_chunk.return_value = (MagicMock(), True)
+    downloader_cls = MagicMock(return_value=downloader_instance)
+    monkeypatch.setattr(client_module, "MediaIoBaseDownload", downloader_cls)
+
+    destination = tmp_path / "app.apk"
+    result = client.download_generated_apk("com.example.app", 42, "split-1", str(destination))
+
+    assert isinstance(result, DownloadResult)
+    assert result.success is True
+    assert result.destination_path == str(destination)
+    assert result.error is None
+    # The destination file was created/opened for writing.
+    assert destination.exists()
+
+    _gak(service).download.assert_called_once_with(
+        packageName="com.example.app",
+        versionCode=42,
+        downloadId="split-1",
+        alt="media",
+    )
+    # MediaIoBaseDownload was constructed with the request and driven to completion.
+    assert downloader_cls.call_args.args[1] is request
+    downloader_instance.next_chunk.assert_called_once_with()
+
+
+def test_download_generated_apk_http_error(monkeypatch, tmp_path):
+    service = MagicMock()
+    _gak(service).download.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    monkeypatch.setattr(client_module, "MediaIoBaseDownload", MagicMock())
+
+    with pytest.raises(PlayStoreClientError, match="Failed to download generated APK"):
+        client.download_generated_apk("com.example.app", 42, "split-1", str(tmp_path / "app.apk"))
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_list_generated_apks(monkeypatch):
+    mc = MagicMock()
+    mc.list_generated_apks.return_value = [
+        GeneratedApksDownload(
+            package_name="com.example.app",
+            version_code=42,
+            download_id="split-1",
+            apk_type="split",
+        )
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_generated_apks("com.example.app", 42)
+
+    assert result[0]["download_id"] == "split-1"
+    assert result[0]["apk_type"] == "split"
+    mc.list_generated_apks.assert_called_once_with(package_name="com.example.app", version_code=42)
+
+
+def test_tool_download_generated_apk(monkeypatch):
+    mc = MagicMock()
+    mc.download_generated_apk.return_value = DownloadResult(
+        success=True,
+        destination_path="out/app.apk",
+        message="done",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.download_generated_apk("com.example.app", 42, "split-1", "out/app.apk")
+
+    assert result["success"] is True
+    assert result["destination_path"] == "out/app.apk"
+    mc.download_generated_apk.assert_called_once_with(
+        package_name="com.example.app",
+        version_code=42,
+        download_id="split-1",
+        destination_path="out/app.apk",
+    )


### PR DESCRIPTION
## Summary

Adds `generatedapks` (download signed APKs generated from an app bundle) — both reads:

- **`list_generated_apks`** — flattens all generated sub-APKs (split / standalone / universal / asset-pack-slice / recovery, incl. unprotected variants) into one item per `download_id` with an `apk_type`.
- **`download_generated_apk`** — streams the APK to a local `destination_path` via `MediaIoBaseDownload`.

Both are reads (download only writes a local file, not Play state) → not read-only-gated.

## Changes
- `models.py`: `GeneratedApksDownload`, `DownloadResult`.
- `client.py`: 2 methods; added `MediaIoBaseDownload` import. Verified vs discovery rev 20260701: envelope `generatedApks`, `downloadId` per sub-entry, `download(..., alt="media")` with `supportsMediaDownload`.
- `server.py`: 2 read tools.
- Tests: `tests/test_generated_apks.py` (10) — media download tested by patching `MediaIoBaseDownload` (no network).
- Docs updated.

## Validation
- `pytest` → **548 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2