### PR TITLE
feat: add system APK variants (get/list/create/download)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -136,6 +136,15 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`list_generated_apks`](tools/subscriptions.md#list_generated_apks) | List the APKs Google Play generated from an app bundle version |
 | [`download_generated_apk`](tools/subscriptions.md#download_generated_apk) | Download a single generated APK to a local file |
 
+## System APK Variants Tools
+
+| Tool | Description |
+|---|---|
+| [`get_system_apk_variant`](tools/subscriptions.md#get_system_apk_variant) | Get a previously created system APK variant |
+| [`list_system_apk_variants`](tools/subscriptions.md#list_system_apk_variants) | List previously created system APK variants for an app bundle version |
+| `create_system_apk_variant` | Create a system APK variant from an uploaded app bundle (write) |
+| [`download_system_apk_variant`](tools/subscriptions.md#download_system_apk_variant) | Download a system APK variant to a local file |
+
 ## App Management Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1431,3 +1431,93 @@ download_generated_apk(
     destination_path="/path/to/base-master.apk",
 )
 ```
+
+## System APK Variants
+
+Manage the APK variants Google Play generates from an app bundle for inclusion
+in a system image
+([systemapks.variants](https://developers.google.com/android-publisher/api-ref/rest/v3/systemapks.variants)).
+`get_system_apk_variant`, `list_system_apk_variants`, and
+`download_system_apk_variant` are read-only and available in
+[read-only mode](../configuration.md#read-only-mode) — `download_system_apk_variant`
+only writes a file to your local machine. `create_system_apk_variant` is a
+write and is disabled in read-only mode.
+
+### get_system_apk_variant
+
+Get a previously created system APK variant, including its `device_spec` and
+`options`. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+| `variant_id` | integer | Yes | ID of the system APK variant |
+
+```python
+get_system_apk_variant("com.example.myapp", version_code=42, variant_id=1)
+```
+
+### list_system_apk_variants
+
+List previously created system APK variants for an app bundle version, each with
+its `variant_id`, `device_spec`, and `options`. Read-only (available in
+read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+
+```python
+list_system_apk_variants("com.example.myapp", version_code=42)
+```
+
+### create_system_apk_variant
+
+Create a system APK variant from an already uploaded app bundle. Disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+| `variant` | object | Yes | Variant resource body (e.g. `deviceSpec` and `options`) |
+
+```python
+create_system_apk_variant(
+    package_name="com.example.myapp",
+    version_code=42,
+    variant={
+        "deviceSpec": {
+            "supportedAbis": ["arm64-v8a"],
+            "supportedLocales": ["en-US"],
+            "screenDensity": 480,
+        },
+        "options": {"uncompressedNativeLibraries": True},
+    },
+)
+```
+
+### download_system_apk_variant
+
+Download a previously created system APK variant to a local file, streaming the
+bytes to disk. Pass a `variant_id` obtained from `list_system_apk_variants`.
+Read-only with respect to Play (available in read-only mode); it writes to the
+local `destination_path`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `version_code` | integer | Yes | Version code of the app bundle |
+| `variant_id` | integer | Yes | ID of the system APK variant (from `list_system_apk_variants`) |
+| `destination_path` | string | Yes | Local path to write the APK bytes to |
+
+```python
+download_system_apk_variant(
+    package_name="com.example.myapp",
+    version_code=42,
+    variant_id=1,
+    destination_path="/path/to/system.apk",
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -50,6 +50,7 @@ from play_store_mcp.models import (
     SubscriptionOffer,
     SubscriptionProduct,
     SubscriptionPurchase,
+    SystemApkVariant,
     TesterInfo,
     TrackInfo,
     ValidationResult,
@@ -4677,3 +4678,197 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to download generated APK", error=str(e))
             raise PlayStoreClientError(f"Failed to download generated APK: {e.reason}") from e
+
+    # =========================================================================
+    # System APK Variants API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_system_apk_variant(
+        package_name: str,
+        version_code: int,
+        data: dict[str, Any],
+    ) -> SystemApkVariant:
+        """Parse a Variant API resource into a SystemApkVariant model."""
+        return SystemApkVariant(
+            package_name=package_name,
+            version_code=version_code,
+            variant_id=data.get("variantId"),
+            device_spec=data.get("deviceSpec"),
+            options=data.get("options"),
+        )
+
+    def get_system_apk_variant(
+        self,
+        package_name: str,
+        version_code: int,
+        variant_id: int,
+    ) -> SystemApkVariant:
+        """Get a previously created system APK variant.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+            variant_id: ID of the system APK variant.
+
+        Returns:
+            The system APK variant.
+        """
+        self._logger.info(
+            "Getting system APK variant",
+            package_name=package_name,
+            version_code=version_code,
+            variant_id=variant_id,
+        )
+        service = self._get_service()
+
+        try:
+            data = (
+                service.systemapks()
+                .variants()
+                .get(
+                    packageName=package_name,
+                    versionCode=version_code,
+                    variantId=variant_id,
+                )
+                .execute()
+            )
+            return self._parse_system_apk_variant(package_name, version_code, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to get system APK variant", error=str(e))
+            raise PlayStoreClientError(f"Failed to get system APK variant: {e.reason}") from e
+
+    def list_system_apk_variants(
+        self,
+        package_name: str,
+        version_code: int,
+    ) -> list[SystemApkVariant]:
+        """List previously created system APK variants for an app bundle version.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+
+        Returns:
+            List of system APK variants.
+        """
+        self._logger.info(
+            "Listing system APK variants",
+            package_name=package_name,
+            version_code=version_code,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.systemapks()
+                .variants()
+                .list(packageName=package_name, versionCode=version_code)
+                .execute()
+            )
+
+            return [
+                self._parse_system_apk_variant(package_name, version_code, variant_data)
+                for variant_data in result.get("variants", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list system APK variants", error=str(e))
+            raise PlayStoreClientError(f"Failed to list system APK variants: {e.reason}") from e
+
+    def create_system_apk_variant(
+        self,
+        package_name: str,
+        version_code: int,
+        variant: dict[str, Any],
+    ) -> SystemApkVariant:
+        """Create a system APK variant from an uploaded app bundle.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+            variant: Variant resource body (e.g. ``deviceSpec`` and ``options``).
+
+        Returns:
+            The created system APK variant.
+        """
+        self._logger.info(
+            "Creating system APK variant",
+            package_name=package_name,
+            version_code=version_code,
+        )
+        service = self._get_service()
+
+        try:
+            data = (
+                service.systemapks()
+                .variants()
+                .create(
+                    packageName=package_name,
+                    versionCode=version_code,
+                    body=variant,
+                )
+                .execute()
+            )
+            return self._parse_system_apk_variant(package_name, version_code, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create system APK variant", error=str(e))
+            raise PlayStoreClientError(f"Failed to create system APK variant: {e.reason}") from e
+
+    def download_system_apk_variant(
+        self,
+        package_name: str,
+        version_code: int,
+        variant_id: int,
+        destination_path: str,
+    ) -> DownloadResult:
+        """Download a previously created system APK variant to a local file.
+
+        Args:
+            package_name: App package name.
+            version_code: Version code of the app bundle.
+            variant_id: ID of the system APK variant (from
+                :meth:`list_system_apk_variants`).
+            destination_path: Local path to stream the APK bytes to.
+
+        Returns:
+            Download result with success status and destination path.
+        """
+        self._logger.info(
+            "Downloading system APK variant",
+            package_name=package_name,
+            version_code=version_code,
+            variant_id=variant_id,
+            destination_path=destination_path,
+        )
+        service = self._get_service()
+
+        try:
+            request = (
+                service.systemapks()
+                .variants()
+                .download(
+                    packageName=package_name,
+                    versionCode=version_code,
+                    variantId=variant_id,
+                    alt="media",
+                )
+            )
+
+            with Path(destination_path).open("wb") as fh:
+                downloader = MediaIoBaseDownload(fh, request)
+                done = False
+                while not done:
+                    _status, done = downloader.next_chunk()
+
+            return DownloadResult(
+                success=True,
+                destination_path=destination_path,
+                message=f"Downloaded system APK variant to {destination_path}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to download system APK variant", error=str(e))
+            raise PlayStoreClientError(f"Failed to download system APK variant: {e.reason}") from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -465,6 +465,18 @@ class GeneratedApksDownload(BaseModel):
     )
 
 
+class SystemApkVariant(BaseModel):
+    """A system APK variant (systemapks.variants resource)."""
+
+    package_name: str = Field(..., description="App package name")
+    version_code: int = Field(..., description="Version code of the App Bundle")
+    variant_id: int | None = Field(None, description="ID of the system APK variant")
+    device_spec: dict[str, Any] | None = Field(
+        None, description="Device spec used to generate the APK"
+    )
+    options: dict[str, Any] | None = Field(None, description="Options applied to the generated APK")
+
+
 class DownloadResult(BaseModel):
     """Result of downloading a file to a local path."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2805,6 +2805,119 @@ def download_generated_apk(
 
 
 # =============================================================================
+# System APK Variants Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_system_apk_variant(
+    package_name: str,
+    version_code: int,
+    variant_id: int,
+) -> dict[str, Any]:
+    """Get a previously created system APK variant.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+        variant_id: ID of the system APK variant
+
+    Returns:
+        System APK variant details including device spec and options
+    """
+    client = get_client_from_context()
+
+    variant = client.get_system_apk_variant(
+        package_name=package_name,
+        version_code=version_code,
+        variant_id=variant_id,
+    )
+    return variant.model_dump()
+
+
+@mcp.tool()
+def list_system_apk_variants(
+    package_name: str,
+    version_code: int,
+) -> list[dict[str, Any]]:
+    """List previously created system APK variants for an app bundle version.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+
+    Returns:
+        List of system APK variants with their IDs, device specs, and options
+    """
+    client = get_client_from_context()
+
+    variants = client.list_system_apk_variants(
+        package_name=package_name,
+        version_code=version_code,
+    )
+    return [variant.model_dump() for variant in variants]
+
+
+@mcp.tool()
+def create_system_apk_variant(
+    package_name: str,
+    version_code: int,
+    variant: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a system APK variant from an uploaded app bundle.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+        variant: Variant resource body (e.g. `deviceSpec` and `options`)
+
+    Returns:
+        The created system APK variant
+    """
+    if blocked := _read_only_block("create_system_apk_variant"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_system_apk_variant(
+        package_name=package_name,
+        version_code=version_code,
+        variant=variant,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def download_system_apk_variant(
+    package_name: str,
+    version_code: int,
+    variant_id: int,
+    destination_path: str,
+) -> dict[str, Any]:
+    """Download a previously created system APK variant to a local file.
+
+    Args:
+        package_name: App package name
+        version_code: Version code of the app bundle
+        variant_id: ID of the system APK variant (from `list_system_apk_variants`)
+        destination_path: Local path to write the APK bytes to
+
+    Returns:
+        Download result with success status and destination path
+    """
+    client = get_client_from_context()
+
+    result = client.download_system_apk_variant(
+        package_name=package_name,
+        version_code=version_code,
+        variant_id=variant_id,
+        destination_path=destination_path,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Expansion Files Tools
 # =============================================================================
 

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -438,6 +438,14 @@ WRITE_TOOLS = [
             "targeting": {"targetingUpdate": {"allUsers": {}}},
         },
     ),
+    (
+        "create_system_apk_variant",
+        {
+            "package_name": "com.example.app",
+            "version_code": 42,
+            "variant": {"deviceSpec": {"screenDensity": 480}},
+        },
+    ),
 ]
 
 

--- a/tests/test_system_apks.py
+++ b/tests/test_system_apks.py
@@ -1,0 +1,289 @@
+"""Tests for system APK variant tools (systemapks.variants resource)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.client as client_module
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import DownloadResult, SystemApkVariant
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_system_apk_variant_defaults():
+    variant = SystemApkVariant(package_name="com.example.app", version_code=42)
+    assert variant.package_name == "com.example.app"
+    assert variant.version_code == 42
+    assert variant.variant_id is None
+    assert variant.device_spec is None
+    assert variant.options is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _variants(service: MagicMock) -> MagicMock:
+    return service.systemapks.return_value.variants.return_value
+
+
+_VARIANT_RESPONSE = {
+    "variantId": 1,
+    "deviceSpec": {
+        "supportedAbis": ["arm64-v8a"],
+        "supportedLocales": ["en-US"],
+        "screenDensity": 480,
+    },
+    "options": {"uncompressedNativeLibraries": True, "rotated": False},
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: get_system_apk_variant
+# ---------------------------------------------------------------------------
+
+
+def test_get_system_apk_variant_success():
+    service = MagicMock()
+    _variants(service).get.return_value.execute.return_value = _VARIANT_RESPONSE
+    client = _client(service)
+
+    result = client.get_system_apk_variant("com.example.app", 42, 1)
+
+    assert isinstance(result, SystemApkVariant)
+    assert result.package_name == "com.example.app"
+    assert result.version_code == 42
+    assert result.variant_id == 1
+    assert result.device_spec == _VARIANT_RESPONSE["deviceSpec"]
+    assert result.options == _VARIANT_RESPONSE["options"]
+    _variants(service).get.assert_called_once_with(
+        packageName="com.example.app", versionCode=42, variantId=1
+    )
+
+
+def test_get_system_apk_variant_http_error():
+    service = MagicMock()
+    _variants(service).get.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to get system APK variant"):
+        client.get_system_apk_variant("com.example.app", 42, 1)
+
+
+# ---------------------------------------------------------------------------
+# Client: list_system_apk_variants
+# ---------------------------------------------------------------------------
+
+
+def test_list_system_apk_variants_success():
+    service = MagicMock()
+    _variants(service).list.return_value.execute.return_value = {
+        "variants": [
+            _VARIANT_RESPONSE,
+            {"variantId": 2},
+        ]
+    }
+    client = _client(service)
+
+    result = client.list_system_apk_variants("com.example.app", 42)
+
+    assert all(isinstance(v, SystemApkVariant) for v in result)
+    assert [v.variant_id for v in result] == [1, 2]
+    assert result[1].device_spec is None
+    assert result[1].options is None
+    _variants(service).list.assert_called_once_with(packageName="com.example.app", versionCode=42)
+
+
+def test_list_system_apk_variants_empty():
+    service = MagicMock()
+    _variants(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.list_system_apk_variants("com.example.app", 42)
+
+    assert result == []
+
+
+def test_list_system_apk_variants_http_error():
+    service = MagicMock()
+    _variants(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list system APK variants"):
+        client.list_system_apk_variants("com.example.app", 42)
+
+
+# ---------------------------------------------------------------------------
+# Client: create_system_apk_variant
+# ---------------------------------------------------------------------------
+
+
+def test_create_system_apk_variant_success():
+    service = MagicMock()
+    _variants(service).create.return_value.execute.return_value = _VARIANT_RESPONSE
+    client = _client(service)
+
+    body = {"deviceSpec": {"screenDensity": 480}}
+    result = client.create_system_apk_variant("com.example.app", 42, body)
+
+    assert isinstance(result, SystemApkVariant)
+    assert result.variant_id == 1
+    assert result.version_code == 42
+    _variants(service).create.assert_called_once_with(
+        packageName="com.example.app",
+        versionCode=42,
+        body=body,
+    )
+
+
+def test_create_system_apk_variant_http_error():
+    service = MagicMock()
+    _variants(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create system APK variant"):
+        client.create_system_apk_variant("com.example.app", 42, {"deviceSpec": {}})
+
+
+# ---------------------------------------------------------------------------
+# Client: download_system_apk_variant
+# ---------------------------------------------------------------------------
+
+
+def test_download_system_apk_variant_success(monkeypatch, tmp_path):
+    service = MagicMock()
+    request = MagicMock()
+    _variants(service).download.return_value = request
+    client = _client(service)
+
+    downloader_instance = MagicMock()
+    downloader_instance.next_chunk.return_value = (MagicMock(), True)
+    downloader_cls = MagicMock(return_value=downloader_instance)
+    monkeypatch.setattr(client_module, "MediaIoBaseDownload", downloader_cls)
+
+    destination = tmp_path / "variant.apk"
+    result = client.download_system_apk_variant("com.example.app", 42, 1, str(destination))
+
+    assert isinstance(result, DownloadResult)
+    assert result.success is True
+    assert result.destination_path == str(destination)
+    assert result.error is None
+    assert destination.exists()
+
+    _variants(service).download.assert_called_once_with(
+        packageName="com.example.app",
+        versionCode=42,
+        variantId=1,
+        alt="media",
+    )
+    assert downloader_cls.call_args.args[1] is request
+    downloader_instance.next_chunk.assert_called_once_with()
+
+
+def test_download_system_apk_variant_http_error(monkeypatch, tmp_path):
+    service = MagicMock()
+    _variants(service).download.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    monkeypatch.setattr(client_module, "MediaIoBaseDownload", MagicMock())
+
+    with pytest.raises(PlayStoreClientError, match="Failed to download system APK variant"):
+        client.download_system_apk_variant("com.example.app", 42, 1, str(tmp_path / "variant.apk"))
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_get_system_apk_variant(monkeypatch):
+    mc = MagicMock()
+    mc.get_system_apk_variant.return_value = SystemApkVariant(
+        package_name="com.example.app", version_code=42, variant_id=1
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.get_system_apk_variant("com.example.app", 42, 1)
+
+    assert result["variant_id"] == 1
+    mc.get_system_apk_variant.assert_called_once_with(
+        package_name="com.example.app", version_code=42, variant_id=1
+    )
+
+
+def test_tool_list_system_apk_variants(monkeypatch):
+    mc = MagicMock()
+    mc.list_system_apk_variants.return_value = [
+        SystemApkVariant(package_name="com.example.app", version_code=42, variant_id=1)
+    ]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_system_apk_variants("com.example.app", 42)
+
+    assert result[0]["variant_id"] == 1
+    mc.list_system_apk_variants.assert_called_once_with(
+        package_name="com.example.app", version_code=42
+    )
+
+
+def test_tool_create_system_apk_variant(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_system_apk_variant.return_value = SystemApkVariant(
+        package_name="com.example.app", version_code=42, variant_id=1
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"deviceSpec": {"screenDensity": 480}}
+    result = server.create_system_apk_variant("com.example.app", 42, body)
+
+    assert result["variant_id"] == 1
+    mc.create_system_apk_variant.assert_called_once_with(
+        package_name="com.example.app",
+        version_code=42,
+        variant=body,
+    )
+
+
+def test_tool_download_system_apk_variant(monkeypatch):
+    mc = MagicMock()
+    mc.download_system_apk_variant.return_value = DownloadResult(
+        success=True,
+        destination_path="out/variant.apk",
+        message="done",
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.download_system_apk_variant("com.example.app", 42, 1, "out/variant.apk")
+
+    assert result["success"] is True
+    assert result["destination_path"] == "out/variant.apk"
+    mc.download_system_apk_variant.assert_called_once_with(
+        package_name="com.example.app",
+        version_code=42,
+        variant_id=1,
+        destination_path="out/variant.apk",
+    )


### PR DESCRIPTION
## Summary

Adds `systemapks.variants` (system APK variants for preloaded/system apps):

- **`get_system_apk_variant`**, **`list_system_apk_variants`** (reads)
- **`create_system_apk_variant`** (write, read-only-gated)
- **`download_system_apk_variant`** (read; streams to a local file via `MediaIoBaseDownload`)

## Changes
- `models.py`: `SystemApkVariant` (reuses `DownloadResult`).
- `client.py`: 4 methods + `_parse_system_apk_variant`. Verified vs discovery rev 20260701: chain `systemapks().variants()`, list envelope `variants`, Variant fields (variantId/deviceSpec/options), `download(..., alt="media")`.
- `server.py`: 4 tools (create guard-first).
- Tests: `tests/test_system_apks.py` (12; download mocks `MediaIoBaseDownload`) + 1 `WRITE_TOOLS` entry.
- Docs updated.

## Validation
- `pytest` → **563 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2