### PR TITLE
feat: add internal app sharing uploads (apk/bundle)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -145,6 +145,13 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | `create_system_apk_variant` | Create a system APK variant from an uploaded app bundle (write) |
 | [`download_system_apk_variant`](tools/subscriptions.md#download_system_apk_variant) | Download a system APK variant to a local file |
 
+## Internal App Sharing Tools
+
+| Tool | Description |
+|---|---|
+| `upload_internal_app_sharing_apk` | Upload an APK to internal app sharing (write) |
+| `upload_internal_app_sharing_bundle` | Upload an app bundle (.aab) to internal app sharing (write) |
+
 ## App Management Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1521,3 +1521,45 @@ download_system_apk_variant(
     destination_path="/path/to/system.apk",
 )
 ```
+
+## Internal App Sharing
+
+Upload artifacts to
+[internal app sharing](https://developers.google.com/android-publisher/api-ref/rest/v3/internalappsharingartifacts),
+which returns a shareable download URL for testing. Both tools are writes and
+are disabled in [read-only mode](../configuration.md#read-only-mode).
+
+Each returns an artifact with `download_url`, `certificate_fingerprint`, and
+`sha256`.
+
+### upload_internal_app_sharing_apk
+
+Upload an APK to internal app sharing. **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `apk_path` | string | Yes | Local path to the APK file |
+
+```python
+upload_internal_app_sharing_apk(
+    package_name="com.example.myapp",
+    apk_path="/path/to/app.apk",
+)
+```
+
+### upload_internal_app_sharing_bundle
+
+Upload an app bundle (`.aab`) to internal app sharing. **Write.**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `bundle_path` | string | Yes | Local path to the app bundle (`.aab`) file |
+
+```python
+upload_internal_app_sharing_bundle(
+    package_name="com.example.myapp",
+    bundle_path="/path/to/app.aab",
+)
+```

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -32,6 +32,7 @@ from play_store_mcp.models import (
     GeneratedApksDownload,
     InAppProduct,
     InAppProductActionResult,
+    InternalAppSharingArtifact,
     Listing,
     ListingUpdateResult,
     OneTimeProduct,
@@ -4872,3 +4873,100 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to download system APK variant", error=str(e))
             raise PlayStoreClientError(f"Failed to download system APK variant: {e.reason}") from e
+
+    # =========================================================================
+    # Internal App Sharing API
+    # =========================================================================
+
+    @staticmethod
+    def _parse_internal_app_sharing_artifact(
+        package_name: str,
+        data: dict[str, Any],
+    ) -> InternalAppSharingArtifact:
+        """Parse an InternalAppSharingArtifact API resource into a model."""
+        return InternalAppSharingArtifact(
+            package_name=package_name,
+            download_url=data.get("downloadUrl"),
+            certificate_fingerprint=data.get("certificateFingerprint"),
+            sha256=data.get("sha256"),
+        )
+
+    def upload_internal_app_sharing_apk(
+        self,
+        package_name: str,
+        apk_path: str,
+    ) -> InternalAppSharingArtifact:
+        """Upload an APK to internal app sharing.
+
+        Args:
+            package_name: App package name.
+            apk_path: Local path to the APK file.
+
+        Returns:
+            The uploaded internal app sharing artifact.
+        """
+        self._logger.info(
+            "Uploading internal app sharing APK",
+            package_name=package_name,
+            apk_path=apk_path,
+        )
+        service = self._get_service()
+
+        try:
+            media = MediaFileUpload(
+                apk_path,
+                mimetype="application/vnd.android.package-archive",
+                resumable=True,
+            )
+            data = (
+                service.internalappsharingartifacts()
+                .uploadapk(packageName=package_name, media_body=media)
+                .execute()
+            )
+            return self._parse_internal_app_sharing_artifact(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to upload internal app sharing APK", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to upload internal app sharing APK: {e.reason}"
+            ) from e
+
+    def upload_internal_app_sharing_bundle(
+        self,
+        package_name: str,
+        bundle_path: str,
+    ) -> InternalAppSharingArtifact:
+        """Upload an app bundle (.aab) to internal app sharing.
+
+        Args:
+            package_name: App package name.
+            bundle_path: Local path to the app bundle (.aab) file.
+
+        Returns:
+            The uploaded internal app sharing artifact.
+        """
+        self._logger.info(
+            "Uploading internal app sharing bundle",
+            package_name=package_name,
+            bundle_path=bundle_path,
+        )
+        service = self._get_service()
+
+        try:
+            media = MediaFileUpload(
+                bundle_path,
+                mimetype="application/octet-stream",
+                resumable=True,
+            )
+            data = (
+                service.internalappsharingartifacts()
+                .uploadbundle(packageName=package_name, media_body=media)
+                .execute()
+            )
+            return self._parse_internal_app_sharing_artifact(package_name, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to upload internal app sharing bundle", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to upload internal app sharing bundle: {e.reason}"
+            ) from e

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -484,3 +484,14 @@ class DownloadResult(BaseModel):
     destination_path: str = Field(..., description="Local path the file was written to")
     message: str = Field(..., description="Status message")
     error: str | None = Field(None, description="Error details if failed")
+
+
+class InternalAppSharingArtifact(BaseModel):
+    """An uploaded internal app sharing artifact (internalappsharingartifacts)."""
+
+    package_name: str = Field(..., description="App package name")
+    download_url: str | None = Field(None, description="Download URL for the uploaded artifact")
+    certificate_fingerprint: str | None = Field(
+        None, description="SHA-256 fingerprint of the signing certificate"
+    )
+    sha256: str | None = Field(None, description="SHA-256 hash of the artifact")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -3070,6 +3070,65 @@ def batch_deploy(
 
 
 # =============================================================================
+# Internal App Sharing Tools
+# =============================================================================
+
+
+@mcp.tool()
+def upload_internal_app_sharing_apk(
+    package_name: str,
+    apk_path: str,
+) -> dict[str, Any]:
+    """Upload an APK to internal app sharing.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        apk_path: Local path to the APK file
+
+    Returns:
+        The uploaded artifact with download URL, certificate fingerprint, and sha256
+    """
+    if blocked := _read_only_block("upload_internal_app_sharing_apk"):
+        return blocked
+    client = get_client_from_context()
+
+    artifact = client.upload_internal_app_sharing_apk(
+        package_name=package_name,
+        apk_path=apk_path,
+    )
+    return artifact.model_dump()
+
+
+@mcp.tool()
+def upload_internal_app_sharing_bundle(
+    package_name: str,
+    bundle_path: str,
+) -> dict[str, Any]:
+    """Upload an app bundle (.aab) to internal app sharing.
+
+    Disabled in read-only mode.
+
+    Args:
+        package_name: App package name
+        bundle_path: Local path to the app bundle (.aab) file
+
+    Returns:
+        The uploaded artifact with download URL, certificate fingerprint, and sha256
+    """
+    if blocked := _read_only_block("upload_internal_app_sharing_bundle"):
+        return blocked
+    client = get_client_from_context()
+
+    artifact = client.upload_internal_app_sharing_bundle(
+        package_name=package_name,
+        bundle_path=bundle_path,
+    )
+    return artifact.model_dump()
+
+
+# =============================================================================
 # HTTP Endpoints for Streamable Transport
 # =============================================================================
 

--- a/tests/test_internal_app_sharing.py
+++ b/tests/test_internal_app_sharing.py
@@ -1,0 +1,175 @@
+"""Tests for internal app sharing tools (internalappsharingartifacts)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.client as client_module
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import InternalAppSharingArtifact
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_internal_app_sharing_artifact_defaults():
+    artifact = InternalAppSharingArtifact(package_name="com.example.app")
+    assert artifact.package_name == "com.example.app"
+    assert artifact.download_url is None
+    assert artifact.certificate_fingerprint is None
+    assert artifact.sha256 is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _iasa(service: MagicMock) -> MagicMock:
+    return service.internalappsharingartifacts.return_value
+
+
+_ARTIFACT_RESPONSE = {
+    "downloadUrl": "https://play.google.com/apps/test/abc123",
+    "certificateFingerprint": "AA:BB:CC",
+    "sha256": "deadbeef",
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: upload_internal_app_sharing_apk
+# ---------------------------------------------------------------------------
+
+
+def test_upload_internal_app_sharing_apk_success(monkeypatch):
+    service = MagicMock()
+    _iasa(service).uploadapk.return_value.execute.return_value = _ARTIFACT_RESPONSE
+    fake_media = MagicMock(name="media")
+    media_ctor = MagicMock(return_value=fake_media)
+    monkeypatch.setattr(client_module, "MediaFileUpload", media_ctor)
+    client = _client(service)
+
+    result = client.upload_internal_app_sharing_apk("com.example.app", "app.apk")
+
+    assert isinstance(result, InternalAppSharingArtifact)
+    assert result.package_name == "com.example.app"
+    assert result.download_url == "https://play.google.com/apps/test/abc123"
+    assert result.certificate_fingerprint == "AA:BB:CC"
+    assert result.sha256 == "deadbeef"
+    media_ctor.assert_called_once_with(
+        "app.apk",
+        mimetype="application/vnd.android.package-archive",
+        resumable=True,
+    )
+    _iasa(service).uploadapk.assert_called_once_with(
+        packageName="com.example.app", media_body=fake_media
+    )
+
+
+def test_upload_internal_app_sharing_apk_http_error(monkeypatch):
+    service = MagicMock()
+    _iasa(service).uploadapk.return_value.execute.side_effect = _make_http_error("bad")
+    monkeypatch.setattr(client_module, "MediaFileUpload", MagicMock())
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to upload internal app sharing APK"):
+        client.upload_internal_app_sharing_apk("com.example.app", "app.apk")
+
+
+# ---------------------------------------------------------------------------
+# Client: upload_internal_app_sharing_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_upload_internal_app_sharing_bundle_success(monkeypatch):
+    service = MagicMock()
+    _iasa(service).uploadbundle.return_value.execute.return_value = _ARTIFACT_RESPONSE
+    fake_media = MagicMock(name="media")
+    media_ctor = MagicMock(return_value=fake_media)
+    monkeypatch.setattr(client_module, "MediaFileUpload", media_ctor)
+    client = _client(service)
+
+    result = client.upload_internal_app_sharing_bundle("com.example.app", "app.aab")
+
+    assert isinstance(result, InternalAppSharingArtifact)
+    assert result.package_name == "com.example.app"
+    assert result.download_url == "https://play.google.com/apps/test/abc123"
+    assert result.certificate_fingerprint == "AA:BB:CC"
+    assert result.sha256 == "deadbeef"
+    media_ctor.assert_called_once_with(
+        "app.aab",
+        mimetype="application/octet-stream",
+        resumable=True,
+    )
+    _iasa(service).uploadbundle.assert_called_once_with(
+        packageName="com.example.app", media_body=fake_media
+    )
+
+
+def test_upload_internal_app_sharing_bundle_http_error(monkeypatch):
+    service = MagicMock()
+    _iasa(service).uploadbundle.return_value.execute.side_effect = _make_http_error("bad")
+    monkeypatch.setattr(client_module, "MediaFileUpload", MagicMock())
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to upload internal app sharing bundle"):
+        client.upload_internal_app_sharing_bundle("com.example.app", "app.aab")
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_upload_internal_app_sharing_apk(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.upload_internal_app_sharing_apk.return_value = InternalAppSharingArtifact(
+        package_name="com.example.app", download_url="https://dl/x", sha256="abc"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.upload_internal_app_sharing_apk("com.example.app", "app.apk")
+
+    assert result["download_url"] == "https://dl/x"
+    assert result["sha256"] == "abc"
+    mc.upload_internal_app_sharing_apk.assert_called_once_with(
+        package_name="com.example.app", apk_path="app.apk"
+    )
+
+
+def test_tool_upload_internal_app_sharing_bundle(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.upload_internal_app_sharing_bundle.return_value = InternalAppSharingArtifact(
+        package_name="com.example.app", download_url="https://dl/y", sha256="def"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.upload_internal_app_sharing_bundle("com.example.app", "app.aab")
+
+    assert result["download_url"] == "https://dl/y"
+    assert result["sha256"] == "def"
+    mc.upload_internal_app_sharing_bundle.assert_called_once_with(
+        package_name="com.example.app", bundle_path="app.aab"
+    )

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -446,6 +446,14 @@ WRITE_TOOLS = [
             "variant": {"deviceSpec": {"screenDensity": 480}},
         },
     ),
+    (
+        "upload_internal_app_sharing_apk",
+        {"package_name": "com.example.app", "apk_path": "app.apk"},
+    ),
+    (
+        "upload_internal_app_sharing_bundle",
+        {"package_name": "com.example.app", "bundle_path": "app.aab"},
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `internalappsharingartifacts` — media-upload writes that produce shareable internal-testing links:

- **`upload_internal_app_sharing_apk`** (write)
- **`upload_internal_app_sharing_bundle`** (write)

Both are read-only-gated.

## Changes
- `models.py`: `InternalAppSharingArtifact` (download_url / certificate_fingerprint / sha256).
- `client.py`: 2 methods + `_parse_internal_app_sharing_artifact`. Build `MediaFileUpload(path, mimetype, resumable=True)` → `uploadapk`/`uploadbundle(packageName, media_body=…)`. Verified vs discovery rev 20260701 (top-level resource, `supportsMediaUpload`, response fields).
- `server.py`: 2 write tools (guard-first).
- Tests: `tests/test_internal_app_sharing.py` (7; upload tested via patched `MediaFileUpload`, no file/network) + 2 `WRITE_TOOLS` entries.
- Docs updated.

## Validation
- `pytest` → **572 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (1 pre-existing docs NIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2