### PR TITLE
feat: add Play Console account access (users & grants)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -133,6 +133,18 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 | [`list_device_tier_configs`](tools/subscriptions.md#list_device_tier_configs) | List device tier configs for an app |
 | `create_device_tier_config` | Create a device tier config (write) |
 
+## Account Access Tools
+
+| Tool | Description |
+|---|---|
+| [`list_users`](tools/subscriptions.md#list_users) | List users with access to a developer account |
+| `create_user` | Grant a user access to a developer account (write) |
+| `update_user` | Update a user's account access (write) |
+| `delete_user` | Remove a user's access to a developer account (write) |
+| `create_grant` | Grant a user app-level access (write) |
+| `update_grant` | Update a user's app-level access (write) |
+| `delete_grant` | Remove a user's app-level access (write) |
+
 ## Generated APKs Tools
 
 | Tool | Description |

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -1281,6 +1281,150 @@ create_device_tier_config(
 )
 ```
 
+## Account Access (Users & Grants)
+
+Manage Play Console account access
+([users](https://developers.google.com/android-publisher/api-ref/rest/v3/users)
+and [grants](https://developers.google.com/android-publisher/api-ref/rest/v3/grants)).
+These are **account-level** resources: they are addressed by
+[resource names](https://google.aip.dev/122) under
+`developers/{developerId}` rather than by an app package name. A **user** is a
+person invited to the developer account (with account-wide
+`developerAccountPermissions`); a **grant** gives that user app-level access to a
+single package (`appLevelPermissions`). `list_users` is read-only; every other
+tool here is a write and is disabled in
+[read-only mode](../configuration.md#read-only-mode).
+
+Resource names are built from the parameters you pass:
+
+- User: `developers/{developer_id}/users/{email}`
+- Grant: `developers/{developer_id}/users/{email}/grants/{package_name}`
+
+### list_users
+
+List users with access to a developer account. Read-only (available in read-only mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+
+```python
+list_users("1234567890")
+```
+
+### create_user
+
+Grant a user access to a developer account. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `user` | object | Yes | [User](https://developers.google.com/android-publisher/api-ref/rest/v3/users#User) resource body (`email`, `developerAccountPermissions`, `expirationTime`, `grants`) |
+
+```python
+create_user(
+    developer_id="1234567890",
+    user={
+        "email": "teammate@example.com",
+        "developerAccountPermissions": ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"],
+    },
+)
+```
+
+### update_user
+
+Update a user's account access. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `email` | string | Yes | Email of the user to update |
+| `user` | object | Yes | User resource body with the fields to update |
+| `update_mask` | string | Yes | Comma-separated list of fields to update (e.g. `developerAccountPermissions,expirationTime`) |
+
+```python
+update_user(
+    developer_id="1234567890",
+    email="teammate@example.com",
+    user={"developerAccountPermissions": ["CAN_MANAGE_ORDERS_GLOBAL"]},
+    update_mask="developerAccountPermissions",
+)
+```
+
+### delete_user
+
+Remove a user's access to a developer account. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `email` | string | Yes | Email of the user to remove |
+
+```python
+delete_user(developer_id="1234567890", email="teammate@example.com")
+```
+
+### create_grant
+
+Grant a user app-level access. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `email` | string | Yes | Email of the user to grant access to |
+| `grant` | object | Yes | [Grant](https://developers.google.com/android-publisher/api-ref/rest/v3/grants#Grant) resource body (`packageName`, `appLevelPermissions`) |
+
+```python
+create_grant(
+    developer_id="1234567890",
+    email="teammate@example.com",
+    grant={
+        "packageName": "com.example.myapp",
+        "appLevelPermissions": ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"],
+    },
+)
+```
+
+### update_grant
+
+Update a user's app-level access. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `email` | string | Yes | Email of the user the grant belongs to |
+| `package_name` | string | Yes | App package name the grant applies to |
+| `grant` | object | Yes | Grant resource body with the fields to update |
+| `update_mask` | string | Yes | Comma-separated list of fields to update (e.g. `appLevelPermissions`) |
+
+```python
+update_grant(
+    developer_id="1234567890",
+    email="teammate@example.com",
+    package_name="com.example.myapp",
+    grant={"appLevelPermissions": ["CAN_VIEW_APP_QUALITY_GLOBAL"]},
+    update_mask="appLevelPermissions",
+)
+```
+
+### delete_grant
+
+Remove a user's app-level access. **Write.** Disabled in [read-only mode](../configuration.md#read-only-mode).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | Yes | Developer account ID |
+| `email` | string | Yes | Email of the user the grant belongs to |
+| `package_name` | string | Yes | App package name the grant applies to |
+
+```python
+delete_grant(
+    developer_id="1234567890",
+    email="teammate@example.com",
+    package_name="com.example.myapp",
+)
+```
+
 ## Data Safety
 
 ### set_data_safety

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -19,6 +19,7 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
 from play_store_mcp.models import (
+    AccessResult,
     Apk,
     AppDetails,
     AppImage,
@@ -34,6 +35,7 @@ from play_store_mcp.models import (
     ExpansionFile,
     ExternalTransaction,
     GeneratedApksDownload,
+    Grant,
     ImageDeleteResult,
     InAppProduct,
     InAppProductActionResult,
@@ -59,6 +61,7 @@ from play_store_mcp.models import (
     SystemApkVariant,
     TesterInfo,
     TrackInfo,
+    User,
     ValidationResult,
     VitalsMetric,
     VitalsOverview,
@@ -4799,6 +4802,243 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to create device tier config", error=str(e))
             raise PlayStoreClientError(f"Failed to create device tier config: {e.reason}") from e
+
+    # =========================================================================
+    # Account Access API (users & grants)
+    # =========================================================================
+
+    @staticmethod
+    def _parse_user(developer_id: str, data: dict[str, Any]) -> User:
+        """Parse a User API resource into a User model.
+
+        The email is preferred from the response body; if absent it is derived
+        from the resource name suffix (developers/{developerId}/users/{email}).
+        """
+        email = data.get("email")
+        if email is None and (name := data.get("name")):
+            email = name.rsplit("/", 1)[-1]
+        return User(
+            developer_id=developer_id,
+            email=email,
+            access_state=data.get("accessState"),
+            expiration_time=data.get("expirationTime"),
+            developer_account_permissions=data.get("developerAccountPermissions", []),
+        )
+
+    @staticmethod
+    def _parse_grant(developer_id: str, email: str, data: dict[str, Any]) -> Grant:
+        """Parse a Grant API resource into a Grant model.
+
+        The package name is preferred from the response body; if absent it is
+        derived from the resource name suffix
+        (developers/{developerId}/users/{email}/grants/{packageName}).
+        """
+        package_name = data.get("packageName")
+        if package_name is None and (name := data.get("name")):
+            package_name = name.rsplit("/", 1)[-1]
+        return Grant(
+            developer_id=developer_id,
+            email=email,
+            package_name=package_name,
+            app_level_permissions=data.get("appLevelPermissions", []),
+        )
+
+    def list_users(self, developer_id: str) -> list[User]:
+        """List users with access to a developer account.
+
+        Args:
+            developer_id: Developer account ID.
+
+        Returns:
+            List of users.
+        """
+        self._logger.info("Listing users", developer_id=developer_id)
+        service = self._get_service()
+        parent = f"developers/{developer_id}"
+
+        try:
+            result = service.users().list(parent=parent).execute()
+
+            return [
+                self._parse_user(developer_id, user_data) for user_data in result.get("users", [])
+            ]
+
+        except HttpError as e:
+            self._logger.exception("Failed to list users", error=str(e))
+            raise PlayStoreClientError(f"Failed to list users: {e.reason}") from e
+
+    def create_user(self, developer_id: str, user: dict[str, Any]) -> User:
+        """Grant a user access to a developer account.
+
+        Args:
+            developer_id: Developer account ID.
+            user: User resource body (email, developerAccountPermissions,
+                expirationTime, grants).
+
+        Returns:
+            The created user.
+        """
+        self._logger.info("Creating user", developer_id=developer_id)
+        service = self._get_service()
+        parent = f"developers/{developer_id}"
+
+        try:
+            data = service.users().create(parent=parent, body=user).execute()
+            return self._parse_user(developer_id, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create user", error=str(e))
+            raise PlayStoreClientError(f"Failed to create user: {e.reason}") from e
+
+    def update_user(
+        self,
+        developer_id: str,
+        email: str,
+        user: dict[str, Any],
+        update_mask: str,
+    ) -> User:
+        """Update a user's account access.
+
+        Args:
+            developer_id: Developer account ID.
+            email: Email of the user to update.
+            user: User resource body with the fields to update.
+            update_mask: Comma-separated list of fields to update (e.g.
+                "developerAccountPermissions,expirationTime").
+
+        Returns:
+            The updated user.
+        """
+        self._logger.info("Updating user", developer_id=developer_id, email=email)
+        service = self._get_service()
+        name = f"developers/{developer_id}/users/{email}"
+
+        try:
+            data = service.users().patch(name=name, updateMask=update_mask, body=user).execute()
+            return self._parse_user(developer_id, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to update user", error=str(e))
+            raise PlayStoreClientError(f"Failed to update user: {e.reason}") from e
+
+    def delete_user(self, developer_id: str, email: str) -> AccessResult:
+        """Remove a user's access to a developer account.
+
+        Args:
+            developer_id: Developer account ID.
+            email: Email of the user to remove.
+
+        Returns:
+            Access result with success status.
+        """
+        self._logger.info("Deleting user", developer_id=developer_id, email=email)
+        service = self._get_service()
+        name = f"developers/{developer_id}/users/{email}"
+
+        try:
+            service.users().delete(name=name).execute()
+
+            return AccessResult(
+                success=True,
+                message=f"User {email} removed successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete user", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete user: {e.reason}") from e
+
+    def create_grant(self, developer_id: str, email: str, grant: dict[str, Any]) -> Grant:
+        """Grant a user app-level access.
+
+        Args:
+            developer_id: Developer account ID.
+            email: Email of the user to grant access to.
+            grant: Grant resource body (packageName, appLevelPermissions).
+
+        Returns:
+            The created grant.
+        """
+        self._logger.info("Creating grant", developer_id=developer_id, email=email)
+        service = self._get_service()
+        parent = f"developers/{developer_id}/users/{email}"
+
+        try:
+            data = service.grants().create(parent=parent, body=grant).execute()
+            return self._parse_grant(developer_id, email, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to create grant", error=str(e))
+            raise PlayStoreClientError(f"Failed to create grant: {e.reason}") from e
+
+    def update_grant(
+        self,
+        developer_id: str,
+        email: str,
+        package_name: str,
+        grant: dict[str, Any],
+        update_mask: str,
+    ) -> Grant:
+        """Update a user's app-level access.
+
+        Args:
+            developer_id: Developer account ID.
+            email: Email of the user the grant belongs to.
+            package_name: App package name the grant applies to.
+            grant: Grant resource body with the fields to update.
+            update_mask: Comma-separated list of fields to update (e.g.
+                "appLevelPermissions").
+
+        Returns:
+            The updated grant.
+        """
+        self._logger.info(
+            "Updating grant",
+            developer_id=developer_id,
+            email=email,
+            package_name=package_name,
+        )
+        service = self._get_service()
+        name = f"developers/{developer_id}/users/{email}/grants/{package_name}"
+
+        try:
+            data = service.grants().patch(name=name, updateMask=update_mask, body=grant).execute()
+            return self._parse_grant(developer_id, email, data)
+
+        except HttpError as e:
+            self._logger.exception("Failed to update grant", error=str(e))
+            raise PlayStoreClientError(f"Failed to update grant: {e.reason}") from e
+
+    def delete_grant(self, developer_id: str, email: str, package_name: str) -> AccessResult:
+        """Remove a user's app-level access.
+
+        Args:
+            developer_id: Developer account ID.
+            email: Email of the user the grant belongs to.
+            package_name: App package name the grant applies to.
+
+        Returns:
+            Access result with success status.
+        """
+        self._logger.info(
+            "Deleting grant",
+            developer_id=developer_id,
+            email=email,
+            package_name=package_name,
+        )
+        service = self._get_service()
+        name = f"developers/{developer_id}/users/{email}/grants/{package_name}"
+
+        try:
+            service.grants().delete(name=name).execute()
+
+            return AccessResult(
+                success=True,
+                message=f"Grant for {package_name} removed successfully",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete grant", error=str(e))
+            raise PlayStoreClientError(f"Failed to delete grant: {e.reason}") from e
 
     # =========================================================================
     # Data Safety API

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -474,6 +474,41 @@ class DeviceTierConfig(BaseModel):
     )
 
 
+class User(BaseModel):
+    """A Play Console user with account access (users resource)."""
+
+    developer_id: str = Field(..., description="Developer account ID")
+    email: str | None = Field(None, description="User's email address")
+    access_state: str | None = Field(
+        None, description="Current access state (e.g. INVITED, ACCESS_GRANTED)"
+    )
+    expiration_time: str | None = Field(
+        None, description="Time the user's access expires (RFC3339)"
+    )
+    developer_account_permissions: list[str] = Field(
+        default_factory=list, description="Account-wide permissions granted to the user"
+    )
+
+
+class Grant(BaseModel):
+    """An app-level access grant for a user (grants resource)."""
+
+    developer_id: str = Field(..., description="Developer account ID")
+    email: str = Field(..., description="Email of the user the grant belongs to")
+    package_name: str | None = Field(None, description="App package name the grant applies to")
+    app_level_permissions: list[str] = Field(
+        default_factory=list, description="App-level permissions granted to the user"
+    )
+
+
+class AccessResult(BaseModel):
+    """Result of a user/grant write that returns an empty response (delete)."""
+
+    success: bool = Field(..., description="Whether the operation succeeded")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
 class DataSafetyResult(BaseModel):
     """Result of updating an app's data safety labels (applications.dataSafety)."""
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2577,6 +2577,189 @@ def create_device_tier_config(
 
 
 # =============================================================================
+# Account Access Tools (Users & Grants)
+# =============================================================================
+
+
+@mcp.tool()
+def list_users(developer_id: str) -> list[dict[str, Any]]:
+    """List users with access to a developer account.
+
+    Args:
+        developer_id: Developer account ID
+
+    Returns:
+        List of users with their access state and account-level permissions
+    """
+    client = get_client_from_context()
+
+    users = client.list_users(developer_id)
+    return [user.model_dump() for user in users]
+
+
+@mcp.tool()
+def create_user(developer_id: str, user: dict[str, Any]) -> dict[str, Any]:
+    """Grant a user access to a developer account.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        user: User resource body (email, developerAccountPermissions,
+            expirationTime, grants)
+
+    Returns:
+        The created user
+    """
+    if blocked := _read_only_block("create_user"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_user(developer_id=developer_id, user=user)
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_user(
+    developer_id: str,
+    email: str,
+    user: dict[str, Any],
+    update_mask: str,
+) -> dict[str, Any]:
+    """Update a user's account access.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        email: Email of the user to update
+        user: User resource body with the fields to update
+        update_mask: Comma-separated list of fields to update (e.g.
+            "developerAccountPermissions,expirationTime")
+
+    Returns:
+        The updated user
+    """
+    if blocked := _read_only_block("update_user"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.update_user(
+        developer_id=developer_id,
+        email=email,
+        user=user,
+        update_mask=update_mask,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_user(developer_id: str, email: str) -> dict[str, Any]:
+    """Remove a user's access to a developer account.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        email: Email of the user to remove
+
+    Returns:
+        Access result with success status
+    """
+    if blocked := _read_only_block("delete_user"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_user(developer_id=developer_id, email=email)
+    return result.model_dump()
+
+
+@mcp.tool()
+def create_grant(developer_id: str, email: str, grant: dict[str, Any]) -> dict[str, Any]:
+    """Grant a user app-level access.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        email: Email of the user to grant access to
+        grant: Grant resource body (packageName, appLevelPermissions)
+
+    Returns:
+        The created grant
+    """
+    if blocked := _read_only_block("create_grant"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.create_grant(developer_id=developer_id, email=email, grant=grant)
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_grant(
+    developer_id: str,
+    email: str,
+    package_name: str,
+    grant: dict[str, Any],
+    update_mask: str,
+) -> dict[str, Any]:
+    """Update a user's app-level access.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        email: Email of the user the grant belongs to
+        package_name: App package name the grant applies to
+        grant: Grant resource body with the fields to update
+        update_mask: Comma-separated list of fields to update (e.g.
+            "appLevelPermissions")
+
+    Returns:
+        The updated grant
+    """
+    if blocked := _read_only_block("update_grant"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.update_grant(
+        developer_id=developer_id,
+        email=email,
+        package_name=package_name,
+        grant=grant,
+        update_mask=update_mask,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_grant(developer_id: str, email: str, package_name: str) -> dict[str, Any]:
+    """Remove a user's app-level access.
+
+    Disabled in read-only mode.
+
+    Args:
+        developer_id: Developer account ID
+        email: Email of the user the grant belongs to
+        package_name: App package name the grant applies to
+
+    Returns:
+        Access result with success status
+    """
+    if blocked := _read_only_block("delete_grant"):
+        return blocked
+    client = get_client_from_context()
+
+    result = client.delete_grant(
+        developer_id=developer_id,
+        email=email,
+        package_name=package_name,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Data Safety Tools
 # =============================================================================
 

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -490,6 +490,35 @@ WRITE_TOOLS = [
             "image_type": "phoneScreenshots",
         },
     ),
+    ("create_user", {"developer_id": "dev123", "user": {"email": "a@b.com"}}),
+    (
+        "update_user",
+        {
+            "developer_id": "dev123",
+            "email": "a@b.com",
+            "user": {"developerAccountPermissions": []},
+            "update_mask": "developerAccountPermissions",
+        },
+    ),
+    ("delete_user", {"developer_id": "dev123", "email": "a@b.com"}),
+    (
+        "create_grant",
+        {"developer_id": "dev123", "email": "a@b.com", "grant": {"packageName": "com.example.app"}},
+    ),
+    (
+        "update_grant",
+        {
+            "developer_id": "dev123",
+            "email": "a@b.com",
+            "package_name": "com.example.app",
+            "grant": {"appLevelPermissions": []},
+            "update_mask": "appLevelPermissions",
+        },
+    ),
+    (
+        "delete_grant",
+        {"developer_id": "dev123", "email": "a@b.com", "package_name": "com.example.app"},
+    ),
 ]
 
 

--- a/tests/test_users_grants.py
+++ b/tests/test_users_grants.py
@@ -1,0 +1,457 @@
+"""Tests for account access tools (users & grants)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.server as server
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.models import AccessResult, Grant, User
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_user_defaults():
+    user = User(developer_id="dev123")
+    assert user.email is None
+    assert user.access_state is None
+    assert user.expiration_time is None
+    assert user.developer_account_permissions == []
+
+
+def test_user_full():
+    user = User(
+        developer_id="dev123",
+        email="a@b.com",
+        access_state="ACCESS_GRANTED",
+        expiration_time="2027-01-01T00:00:00Z",
+        developer_account_permissions=["CAN_VIEW_FINANCIAL_DATA_GLOBAL"],
+    )
+    assert user.email == "a@b.com"
+    assert user.access_state == "ACCESS_GRANTED"
+    assert user.expiration_time == "2027-01-01T00:00:00Z"
+    assert user.developer_account_permissions == ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"]
+
+
+def test_grant_defaults():
+    grant = Grant(developer_id="dev123", email="a@b.com")
+    assert grant.package_name is None
+    assert grant.app_level_permissions == []
+
+
+def test_grant_full():
+    grant = Grant(
+        developer_id="dev123",
+        email="a@b.com",
+        package_name="com.example.app",
+        app_level_permissions=["CAN_MANAGE_PUBLIC_APKS_GLOBAL"],
+    )
+    assert grant.package_name == "com.example.app"
+    assert grant.app_level_permissions == ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"]
+
+
+def test_access_result():
+    result = AccessResult(success=True, message="ok")
+    assert result.success is True
+    assert result.message == "ok"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_error(reason: str = "boom") -> HttpError:
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = reason
+    err = HttpError(resp, b"{}")
+    err.reason = reason
+    return err
+
+
+def _client(service: MagicMock) -> PlayStoreClient:
+    client = PlayStoreClient(credentials_json={"type": "service_account"})
+    client._service = service
+    return client
+
+
+def _users(service: MagicMock) -> MagicMock:
+    return service.users.return_value
+
+
+def _grants(service: MagicMock) -> MagicMock:
+    return service.grants.return_value
+
+
+_USER_RESPONSE = {
+    "name": "developers/dev123/users/a@b.com",
+    "email": "a@b.com",
+    "accessState": "ACCESS_GRANTED",
+    "expirationTime": "2027-01-01T00:00:00Z",
+    "developerAccountPermissions": ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"],
+}
+
+_GRANT_RESPONSE = {
+    "name": "developers/dev123/users/a@b.com/grants/com.example.app",
+    "packageName": "com.example.app",
+    "appLevelPermissions": ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Client: list_users
+# ---------------------------------------------------------------------------
+
+
+def test_list_users_success():
+    service = MagicMock()
+    _users(service).list.return_value.execute.return_value = {
+        "users": [_USER_RESPONSE, {"name": "developers/dev123/users/c@d.com"}]
+    }
+    client = _client(service)
+
+    result = client.list_users("dev123")
+
+    assert [u.email for u in result] == ["a@b.com", "c@d.com"]
+    assert result[0].access_state == "ACCESS_GRANTED"
+    assert result[0].developer_account_permissions == ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"]
+    assert result[1].email == "c@d.com"
+    assert result[1].developer_account_permissions == []
+    _users(service).list.assert_called_once_with(parent="developers/dev123")
+
+
+def test_list_users_empty():
+    service = MagicMock()
+    _users(service).list.return_value.execute.return_value = {}
+    client = _client(service)
+
+    assert client.list_users("dev123") == []
+
+
+def test_list_users_http_error():
+    service = MagicMock()
+    _users(service).list.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to list users"):
+        client.list_users("dev123")
+
+
+# ---------------------------------------------------------------------------
+# Client: create_user
+# ---------------------------------------------------------------------------
+
+
+def test_create_user_success():
+    service = MagicMock()
+    _users(service).create.return_value.execute.return_value = _USER_RESPONSE
+    client = _client(service)
+
+    body = {"email": "a@b.com", "developerAccountPermissions": ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"]}
+    result = client.create_user("dev123", body)
+
+    assert isinstance(result, User)
+    assert result.developer_id == "dev123"
+    assert result.email == "a@b.com"
+    _users(service).create.assert_called_once_with(parent="developers/dev123", body=body)
+
+
+def test_create_user_http_error():
+    service = MagicMock()
+    _users(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create user"):
+        client.create_user("dev123", {"email": "a@b.com"})
+
+
+# ---------------------------------------------------------------------------
+# Client: update_user
+# ---------------------------------------------------------------------------
+
+
+def test_update_user_success():
+    service = MagicMock()
+    _users(service).patch.return_value.execute.return_value = _USER_RESPONSE
+    client = _client(service)
+
+    body = {"developerAccountPermissions": ["CAN_VIEW_FINANCIAL_DATA_GLOBAL"]}
+    result = client.update_user(
+        "dev123", "a@b.com", body, update_mask="developerAccountPermissions"
+    )
+
+    assert isinstance(result, User)
+    assert result.email == "a@b.com"
+    _users(service).patch.assert_called_once_with(
+        name="developers/dev123/users/a@b.com",
+        updateMask="developerAccountPermissions",
+        body=body,
+    )
+
+
+def test_update_user_http_error():
+    service = MagicMock()
+    _users(service).patch.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to update user"):
+        client.update_user("dev123", "a@b.com", {}, update_mask="expirationTime")
+
+
+# ---------------------------------------------------------------------------
+# Client: delete_user
+# ---------------------------------------------------------------------------
+
+
+def test_delete_user_success():
+    service = MagicMock()
+    _users(service).delete.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.delete_user("dev123", "a@b.com")
+
+    assert isinstance(result, AccessResult)
+    assert result.success is True
+    assert "a@b.com" in result.message
+    _users(service).delete.assert_called_once_with(name="developers/dev123/users/a@b.com")
+
+
+def test_delete_user_http_error():
+    service = MagicMock()
+    _users(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete user"):
+        client.delete_user("dev123", "a@b.com")
+
+
+# ---------------------------------------------------------------------------
+# Client: create_grant
+# ---------------------------------------------------------------------------
+
+
+def test_create_grant_success():
+    service = MagicMock()
+    _grants(service).create.return_value.execute.return_value = _GRANT_RESPONSE
+    client = _client(service)
+
+    body = {
+        "packageName": "com.example.app",
+        "appLevelPermissions": ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"],
+    }
+    result = client.create_grant("dev123", "a@b.com", body)
+
+    assert isinstance(result, Grant)
+    assert result.developer_id == "dev123"
+    assert result.email == "a@b.com"
+    assert result.package_name == "com.example.app"
+    assert result.app_level_permissions == ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"]
+    _grants(service).create.assert_called_once_with(
+        parent="developers/dev123/users/a@b.com", body=body
+    )
+
+
+def test_create_grant_package_name_from_name_suffix():
+    service = MagicMock()
+    _grants(service).create.return_value.execute.return_value = {
+        "name": "developers/dev123/users/a@b.com/grants/com.example.app"
+    }
+    client = _client(service)
+
+    result = client.create_grant("dev123", "a@b.com", {})
+
+    assert result.package_name == "com.example.app"
+    assert result.app_level_permissions == []
+
+
+def test_create_grant_http_error():
+    service = MagicMock()
+    _grants(service).create.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to create grant"):
+        client.create_grant("dev123", "a@b.com", {})
+
+
+# ---------------------------------------------------------------------------
+# Client: update_grant
+# ---------------------------------------------------------------------------
+
+
+def test_update_grant_success():
+    service = MagicMock()
+    _grants(service).patch.return_value.execute.return_value = _GRANT_RESPONSE
+    client = _client(service)
+
+    body = {"appLevelPermissions": ["CAN_MANAGE_PUBLIC_APKS_GLOBAL"]}
+    result = client.update_grant(
+        "dev123", "a@b.com", "com.example.app", body, update_mask="appLevelPermissions"
+    )
+
+    assert isinstance(result, Grant)
+    assert result.package_name == "com.example.app"
+    _grants(service).patch.assert_called_once_with(
+        name="developers/dev123/users/a@b.com/grants/com.example.app",
+        updateMask="appLevelPermissions",
+        body=body,
+    )
+
+
+def test_update_grant_http_error():
+    service = MagicMock()
+    _grants(service).patch.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to update grant"):
+        client.update_grant(
+            "dev123", "a@b.com", "com.example.app", {}, update_mask="appLevelPermissions"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client: delete_grant
+# ---------------------------------------------------------------------------
+
+
+def test_delete_grant_success():
+    service = MagicMock()
+    _grants(service).delete.return_value.execute.return_value = {}
+    client = _client(service)
+
+    result = client.delete_grant("dev123", "a@b.com", "com.example.app")
+
+    assert isinstance(result, AccessResult)
+    assert result.success is True
+    assert "com.example.app" in result.message
+    _grants(service).delete.assert_called_once_with(
+        name="developers/dev123/users/a@b.com/grants/com.example.app"
+    )
+
+
+def test_delete_grant_http_error():
+    service = MagicMock()
+    _grants(service).delete.return_value.execute.side_effect = _make_http_error("bad")
+    client = _client(service)
+
+    with pytest.raises(PlayStoreClientError, match="Failed to delete grant"):
+        client.delete_grant("dev123", "a@b.com", "com.example.app")
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_tool_list_users(monkeypatch):
+    mc = MagicMock()
+    mc.list_users.return_value = [User(developer_id="dev123", email="a@b.com")]
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.list_users("dev123")
+
+    assert result[0]["email"] == "a@b.com"
+    mc.list_users.assert_called_once_with("dev123")
+
+
+def test_tool_create_user(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_user.return_value = User(developer_id="dev123", email="a@b.com")
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"email": "a@b.com"}
+    result = server.create_user("dev123", body)
+
+    assert result["email"] == "a@b.com"
+    mc.create_user.assert_called_once_with(developer_id="dev123", user=body)
+
+
+def test_tool_update_user(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.update_user.return_value = User(developer_id="dev123", email="a@b.com")
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"developerAccountPermissions": []}
+    result = server.update_user(
+        "dev123", "a@b.com", body, update_mask="developerAccountPermissions"
+    )
+
+    assert result["email"] == "a@b.com"
+    mc.update_user.assert_called_once_with(
+        developer_id="dev123",
+        email="a@b.com",
+        user=body,
+        update_mask="developerAccountPermissions",
+    )
+
+
+def test_tool_delete_user(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_user.return_value = AccessResult(success=True, message="removed")
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_user("dev123", "a@b.com")
+
+    assert result["success"] is True
+    mc.delete_user.assert_called_once_with(developer_id="dev123", email="a@b.com")
+
+
+def test_tool_create_grant(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.create_grant.return_value = Grant(
+        developer_id="dev123", email="a@b.com", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"packageName": "com.example.app"}
+    result = server.create_grant("dev123", "a@b.com", body)
+
+    assert result["package_name"] == "com.example.app"
+    mc.create_grant.assert_called_once_with(developer_id="dev123", email="a@b.com", grant=body)
+
+
+def test_tool_update_grant(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.update_grant.return_value = Grant(
+        developer_id="dev123", email="a@b.com", package_name="com.example.app"
+    )
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    body = {"appLevelPermissions": []}
+    result = server.update_grant(
+        "dev123", "a@b.com", "com.example.app", body, update_mask="appLevelPermissions"
+    )
+
+    assert result["package_name"] == "com.example.app"
+    mc.update_grant.assert_called_once_with(
+        developer_id="dev123",
+        email="a@b.com",
+        package_name="com.example.app",
+        grant=body,
+        update_mask="appLevelPermissions",
+    )
+
+
+def test_tool_delete_grant(monkeypatch):
+    monkeypatch.setattr(server, "READ_ONLY", False)
+    mc = MagicMock()
+    mc.delete_grant.return_value = AccessResult(success=True, message="removed")
+    monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
+
+    result = server.delete_grant("dev123", "a@b.com", "com.example.app")
+
+    assert result["success"] is True
+    mc.delete_grant.assert_called_once_with(
+        developer_id="dev123", email="a@b.com", package_name="com.example.app"
+    )


### PR DESCRIPTION
## Summary

Adds account-level access management via the `users` and `grants` resources (the final audited subsystem):

- **`list_users`** (read)
- **`create_user`**, **`update_user`**, **`delete_user`** (writes)
- **`create_grant`**, **`update_grant`**, **`delete_grant`** (writes)

All 6 writes are read-only-gated.

## Changes
- `models.py`: `User`, `Grant`, `AccessResult`.
- `client.py`: 7 methods + `_parse_user`/`_parse_grant`. These use google.api **resource-name** params under `developers/{id}` (verified vs discovery rev 20260701): `users().list(parent="developers/{id}")` → `users[]`, `patch(name="developers/{id}/users/{email}", updateMask, …)`, `grants().patch(name=".../grants/{packageName}", …)`, etc.; the client builds the resource names internally.
- `server.py`: 7 tools (6 writes guard-first).
- Tests: `tests/test_users_grants.py` (28) + 6 `WRITE_TOOLS` entries.
- Docs updated.

## Validation
- `pytest` → **660 passed, 18 skipped**; 100% new-code coverage.
- `ruff` + `ruff format` + `mypy` clean.
- Independent agent review: **SHIP** (no findings).

This completes the Android Publisher v3 API-coverage backlog from the original audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtR3xYVpG3HwYJMASGbus2