### PR TITLE
fix: remediate audit findings (retry, error-handling, credential hardening, deps/CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -54,7 +54,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -86,7 +86,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -122,7 +122,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   packages: write
   security-events: write
   id-token: write

--- a/.github/workflows/qlty-coverage.yml
+++ b/.github/workflows/qlty-coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build Package
+  test:
+    name: Test Before Release
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -23,7 +23,44 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13.2"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Run ruff format check
+        run: uv run ruff format --check src/ tests/
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+      - name: Run tests
+        run: uv run pytest -q
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "latest"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5
 WORKDIR /build
 
 # Install uv for fast dependency resolution
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.26@sha256:3d868e555f8f1dbc324afa005066cd11e1053fc4743b9808ca8025283e65efa5 /uv /usr/local/bin/uv
 
 COPY pyproject.toml uv.lock README.md ./
 COPY src/ src/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ docker run -p 8000:8000 \
 | `GOOGLE_PLAY_STORE_CREDENTIALS` | Inline JSON credentials string | Alternative to file path | — |
 | `PLAY_STORE_MCP_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | No | `INFO` |
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
+| `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
 
 ## HTTP Transport

--- a/docs/remote-credentials.md
+++ b/docs/remote-credentials.md
@@ -138,6 +138,9 @@ else:
 3. **Network isolation**: Run the server in a private network or use VPN
 4. **Credential rotation**: Regularly rotate service account keys and the admin token
 5. **Audit logging**: Monitor credential update requests
+6. **Use a strong token and rate-limit**: Generate a high-entropy token (e.g.
+   `openssl rand -hex 32`) and throttle repeated invalid `Authorization` attempts at the
+   reverse proxy (e.g. nginx `limit_req`), since the endpoint itself does not rate-limit.
 
 ### Example with Authentication
 

--- a/docs/remote-credentials.md
+++ b/docs/remote-credentials.md
@@ -28,7 +28,13 @@ play-store-mcp
 
 The server exposes a `/credentials` endpoint that accepts POST requests with credentials in various formats.
 
-> **Note:** The `/credentials` endpoint only accepts requests from localhost (loopback addresses).
+> **Access control:** By default the `/credentials` endpoint only accepts requests from
+> localhost (loopback addresses). **Behind a reverse proxy this loopback check is not
+> sufficient** — proxied requests arrive from the proxy (a loopback address), so the
+> check would pass for every remote client. When exposing the endpoint through a proxy,
+> set the `PLAY_STORE_MCP_ADMIN_TOKEN` environment variable: with it set, the endpoint
+> requires an `Authorization: Bearer <token>` header (compared in constant time) and
+> accepts authenticated requests from any host.
 
 #### Method 1: Send Credentials JSON Object
 
@@ -125,30 +131,40 @@ else:
 ### Security Considerations
 
 1. **Use HTTPS in production**: Always use HTTPS when sending credentials over the network
-2. **Restrict endpoint access**: Use a reverse proxy (nginx, Apache) to add authentication
+2. **Authenticate the endpoint**: Behind a reverse proxy the built-in localhost check is
+   bypassed (the peer is the proxy), so set `PLAY_STORE_MCP_ADMIN_TOKEN` and require an
+   `Authorization: Bearer` header. Proxy-level auth (e.g. `auth_basic`) is a useful extra
+   layer but must not be the *only* gate.
 3. **Network isolation**: Run the server in a private network or use VPN
-4. **Credential rotation**: Regularly rotate service account keys
+4. **Credential rotation**: Regularly rotate service account keys and the admin token
 5. **Audit logging**: Monitor credential update requests
 
 ### Example with Authentication
 
-Use a reverse proxy like nginx to add basic authentication:
+Set an admin token on the server:
 
-```nginx
-location /credentials {
-    auth_basic "Restricted";
-    auth_basic_user_file /etc/nginx/.htpasswd;
-    proxy_pass http://localhost:8000;
-}
+```bash
+export PLAY_STORE_MCP_ADMIN_TOKEN="$(openssl rand -hex 32)"
+play-store-mcp --transport streamable-http --host 127.0.0.1 --port 8000
 ```
 
-Then update credentials with authentication:
+Then send it with each request:
 
 ```bash
 curl -X POST https://your-server.com/credentials \
-  -u username:password \
+  -H "Authorization: Bearer $PLAY_STORE_MCP_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d @credentials.json
+```
+
+Behind nginx, forward the `Authorization` header to the app (optionally layering
+`auth_basic` on top for defence in depth):
+
+```nginx
+location /credentials {
+    proxy_set_header Authorization $http_authorization;
+    proxy_pass http://localhost:8000;
+}
 ```
 
 ### Troubleshooting

--- a/examples/update_credentials.py
+++ b/examples/update_credentials.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from pathlib import Path
 
 import requests
 
@@ -18,7 +19,7 @@ def update_credentials_from_file(server_url: str, credentials_path: str) -> None
         server_url: Base URL of the MCP server (e.g., http://localhost:8000)
         credentials_path: Path to the service account JSON file
     """
-    with open(credentials_path) as f:
+    with Path(credentials_path).open() as f:
         credentials = json.load(f)
 
     update_credentials_from_json(server_url, credentials)
@@ -67,7 +68,7 @@ def main():
     # update_credentials_from_file(server_url, credentials_file)
     
     # Option 2: Send credentials JSON directly (more secure for remote servers)
-    with open(credentials_file) as f:
+    with Path(credentials_file).open() as f:
         credentials = json.load(f)
     
     update_credentials_from_json(server_url, credentials)

--- a/examples/update_credentials.py
+++ b/examples/update_credentials.py
@@ -2,13 +2,30 @@
 """Example script demonstrating how to update credentials remotely via HTTP."""
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import requests
 
 
-def update_credentials_from_file(server_url: str, credentials_path: str) -> None:
+def _auth_headers(token: str | None = None) -> dict[str, str]:
+    """Build request headers, adding an admin bearer token when configured.
+
+    Uses the given token or the PLAY_STORE_MCP_ADMIN_TOKEN environment variable,
+    matching the server's optional /credentials authentication (required when
+    the server is exposed through a reverse proxy).
+    """
+    token = token or os.environ.get("PLAY_STORE_MCP_ADMIN_TOKEN")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def update_credentials_from_file(
+    server_url: str, credentials_path: str, token: str | None = None
+) -> None:
     """Update server credentials from a local service account JSON file.
 
     The /credentials endpoint accepts credential *contents* ("credentials" or
@@ -18,23 +35,28 @@ def update_credentials_from_file(server_url: str, credentials_path: str) -> None
     Args:
         server_url: Base URL of the MCP server (e.g., http://localhost:8000)
         credentials_path: Path to the service account JSON file
+        token: Optional admin token (falls back to PLAY_STORE_MCP_ADMIN_TOKEN)
     """
     with Path(credentials_path).open() as f:
         credentials = json.load(f)
 
-    update_credentials_from_json(server_url, credentials)
+    update_credentials_from_json(server_url, credentials, token=token)
 
 
-def update_credentials_from_json(server_url: str, credentials_json: dict) -> None:
+def update_credentials_from_json(
+    server_url: str, credentials_json: dict, token: str | None = None
+) -> None:
     """Update server credentials using a credentials JSON object.
-    
+
     Args:
         server_url: Base URL of the MCP server (e.g., http://localhost:8000)
         credentials_json: Service account credentials as a dictionary
+        token: Optional admin token (falls back to PLAY_STORE_MCP_ADMIN_TOKEN)
     """
     response = requests.post(
         f"{server_url}/credentials",
         json={"credentials": credentials_json},
+        headers=_auth_headers(token),
         timeout=10,
     )
     

--- a/examples/update_credentials.py
+++ b/examples/update_credentials.py
@@ -8,25 +8,20 @@ import requests
 
 
 def update_credentials_from_file(server_url: str, credentials_path: str) -> None:
-    """Update server credentials using a credentials file path.
-    
+    """Update server credentials from a local service account JSON file.
+
+    The /credentials endpoint accepts credential *contents* ("credentials" or
+    "credentials_base64"), not a server-side file path, so this loads the file
+    locally and sends its contents.
+
     Args:
         server_url: Base URL of the MCP server (e.g., http://localhost:8000)
         credentials_path: Path to the service account JSON file
     """
-    response = requests.post(
-        f"{server_url}/credentials",
-        json={"credentials_path": credentials_path},
-        timeout=10,
-    )
-    
-    if response.status_code == 200:
-        print("✓ Credentials updated successfully")
-        print(f"  Response: {response.json()}")
-    else:
-        print(f"✗ Failed to update credentials: {response.status_code}")
-        print(f"  Error: {response.json()}")
-        sys.exit(1)
+    with open(credentials_path) as f:
+        credentials = json.load(f)
+
+    update_credentials_from_json(server_url, credentials)
 
 
 def update_credentials_from_json(server_url: str, credentials_json: dict) -> None:
@@ -68,7 +63,7 @@ def main():
     print(f"Using credentials file: {credentials_file}")
     print()
     
-    # Option 1: Send file path (server must have access to the file)
+    # Option 1: Load the file locally and send its contents
     # update_credentials_from_file(server_url, credentials_file)
     
     # Option 2: Send credentials JSON directly (more secure for remote servers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
     "google-auth>=2.40.0",
     "pydantic>=2.10.0",
     "structlog>=25.0.0",
+    # pyjwt is a transitive dependency (via mcp). Declared directly with a
+    # secure floor so the CVE-2026-32597 fix ships in published metadata,
+    # not just in this repo's lockfile/uv resolution.
+    "pyjwt[crypto]>=2.12.0",
 ]
 
 [project.optional-dependencies]
@@ -190,10 +194,6 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.uv]
-constraint-dependencies = [
-    "pyjwt>=2.12.0",  # CVE-2026-32597: Insufficient Verification of Data Authenticity
-]
 [tool.bandit]
 skips = ["B101"]
 exclude_dirs = ["tests"]

--- a/src/play_store_mcp/__init__.py
+++ b/src/play_store_mcp/__init__.py
@@ -1,6 +1,13 @@
 """Play Store MCP Server - Google Play Developer API integration via MCP."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from play_store_mcp.server import main
 
-__version__ = "0.2.0"
+try:
+    # Single source of truth: the version declared in pyproject.toml.
+    __version__ = version("play-store-mcp")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0+unknown"
+
 __all__ = ["__version__", "main"]

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -5302,20 +5302,26 @@ class PlayStoreClient:
             create_time=data.get("createTime"),
         )
 
-    def list_app_recoveries(self, package_name: str) -> list[AppRecovery]:
-        """List app recovery actions for an app.
+    def list_app_recoveries(self, package_name: str, version_code: int) -> list[AppRecovery]:
+        """List app recovery actions for an app version.
 
         Args:
             package_name: App package name.
+            version_code: App version code the recovery actions target (required
+                by the API).
 
         Returns:
             List of app recovery actions.
         """
-        self._logger.info("Listing app recoveries", package_name=package_name)
+        self._logger.info(
+            "Listing app recoveries", package_name=package_name, version_code=version_code
+        )
         service = self._get_service()
 
         try:
-            result = self._execute(service.apprecovery().list(packageName=package_name))
+            result = self._execute(
+                service.apprecovery().list(packageName=package_name, versionCode=version_code)
+            )
 
             return [
                 self._parse_app_recovery(package_name, recovery_data)

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -106,6 +106,20 @@ def _parse_timestamp(value: dict[str, Any] | None) -> datetime | None:
         return None
 
 
+def _parse_rfc3339(value: str | None) -> datetime | None:
+    """Parse an RFC3339 timestamp string (e.g. "2024-10-02T15:01:23Z") to datetime.
+
+    The subscriptions v2 API returns RFC3339 strings rather than the protobuf
+    {seconds, nanos} form handled by ``_parse_timestamp``.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _parse_review(review_data: dict[str, Any]) -> Review | None:
     """Parse a Reviews API resource into a Review, or None if it has no user comment."""
     user_comment = None
@@ -172,6 +186,13 @@ def retry_with_backoff(func):  # type: ignore[no-untyped-def]
                     raise
             except Exception:
                 raise
+
+        # The loop above always returns or raises while MAX_RETRIES >= 1.
+        # This guards against a misconfigured MAX_RETRIES so a decorated call
+        # can never fall through and implicitly return None.
+        raise PlayStoreClientError(  # pragma: no cover - only reachable if MAX_RETRIES <= 0
+            "Retry attempts exhausted without a result"
+        )
 
     return wrapper
 
@@ -383,6 +404,17 @@ class PlayStoreClient:
             self._logger.exception("Failed to initialize API client", error=str(e))
             raise PlayStoreClientError(f"Failed to initialize API client: {e}") from e
 
+    @retry_with_backoff
+    def _execute(self, request: Any) -> Any:
+        """Execute a googleapiclient request with retry/backoff.
+
+        All Play API calls go through here so that transient 429/500/503
+        errors are retried with exponential backoff (see ``retry_with_backoff``).
+        Non-transient errors (e.g. 400/403/404) are re-raised immediately for
+        each caller's own ``except HttpError`` handling.
+        """
+        return request.execute()
+
     def _create_edit(self, package_name: str) -> str:
         """Create a new edit for the package.
 
@@ -393,7 +425,11 @@ class PlayStoreClient:
             Edit ID.
         """
         service = self._get_service()
-        result = service.edits().insert(packageName=package_name, body={}).execute()
+        try:
+            result = self._execute(service.edits().insert(packageName=package_name, body={}))
+        except HttpError as e:
+            self._logger.exception("Failed to create edit", error=str(e))
+            raise PlayStoreClientError(f"Failed to create edit: {e.reason}") from e
         edit_id: str = result["id"]
         self._logger.debug("Created edit", package_name=package_name, edit_id=edit_id)
         return edit_id
@@ -406,7 +442,7 @@ class PlayStoreClient:
             edit_id: Edit ID to commit.
         """
         service = self._get_service()
-        service.edits().commit(packageName=package_name, editId=edit_id).execute()
+        self._execute(service.edits().commit(packageName=package_name, editId=edit_id))
         self._logger.debug("Committed edit", package_name=package_name, edit_id=edit_id)
 
     def _delete_edit(self, package_name: str, edit_id: str) -> None:
@@ -418,7 +454,7 @@ class PlayStoreClient:
         """
         service = self._get_service()
         try:
-            service.edits().delete(packageName=package_name, editId=edit_id).execute()
+            self._execute(service.edits().delete(packageName=package_name, editId=edit_id))
             self._logger.debug("Deleted edit", package_name=package_name, edit_id=edit_id)
         except HttpError as e:
             # Edit may have already been committed or expired
@@ -442,8 +478,8 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = (
-                service.edits().tracks().list(packageName=package_name, editId=edit_id).execute()
+            result = self._execute(
+                service.edits().tracks().list(packageName=package_name, editId=edit_id)
             )
 
             tracks: list[TrackInfo] = []
@@ -475,6 +511,9 @@ class PlayStoreClient:
                 )
 
             return tracks
+        except HttpError as e:
+            self._logger.exception("Failed to fetch releases", error=str(e))
+            raise PlayStoreClientError(f"Failed to fetch releases: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -524,7 +563,7 @@ class PlayStoreClient:
 
         try:
             # Determine content type and upload method
-            is_bundle = file_path.endswith(".aab")
+            is_bundle = file_path.lower().endswith(".aab")
             content_type = (
                 "application/octet-stream"
                 if is_bundle
@@ -534,18 +573,16 @@ class PlayStoreClient:
             media = MediaFileUpload(file_path, mimetype=content_type, resumable=True)
 
             if is_bundle:
-                upload_response = (
+                upload_response = self._execute(
                     service.edits()
                     .bundles()
                     .upload(packageName=package_name, editId=edit_id, media_body=media)
-                    .execute()
                 )
             else:
-                upload_response = (
+                upload_response = self._execute(
                     service.edits()
                     .apks()
                     .upload(packageName=package_name, editId=edit_id, media_body=media)
-                    .execute()
                 )
 
             uploaded_version_code = int(upload_response.get("versionCode", 0))
@@ -577,12 +614,16 @@ class PlayStoreClient:
 
             # Update track
             track_body = {"releases": [release_body]}
-            service.edits().tracks().update(
-                packageName=package_name,
-                editId=edit_id,
-                track=track,
-                body=track_body,
-            ).execute()
+            self._execute(
+                service.edits()
+                .tracks()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    track=track,
+                    body=track_body,
+                )
+            )
 
             # Commit
             self._commit_edit(package_name, edit_id)
@@ -650,11 +691,10 @@ class PlayStoreClient:
 
         try:
             # Get source track info
-            source_track = (
+            source_track = self._execute(
                 service.edits()
                 .tracks()
                 .get(packageName=package_name, editId=edit_id, track=from_track)
-                .execute()
             )
 
             # Find the release with matching version code
@@ -666,6 +706,7 @@ class PlayStoreClient:
                     break
 
             if not source_release:
+                self._delete_edit(package_name, edit_id)
                 return DeploymentResult(
                     success=False,
                     package_name=package_name,
@@ -688,12 +729,16 @@ class PlayStoreClient:
                 new_release["status"] = "completed"
 
             # Update target track
-            service.edits().tracks().update(
-                packageName=package_name,
-                editId=edit_id,
-                track=to_track,
-                body={"releases": [new_release]},
-            ).execute()
+            self._execute(
+                service.edits()
+                .tracks()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    track=to_track,
+                    body={"releases": [new_release]},
+                )
+            )
 
             self._commit_edit(package_name, edit_id)
 
@@ -752,11 +797,8 @@ class PlayStoreClient:
 
         try:
             # Get current track info
-            current_track = (
-                service.edits()
-                .tracks()
-                .get(packageName=package_name, editId=edit_id, track=track)
-                .execute()
+            current_track = self._execute(
+                service.edits().tracks().get(packageName=package_name, editId=edit_id, track=track)
             )
 
             # Find and update the release
@@ -770,6 +812,7 @@ class PlayStoreClient:
                     break
 
             if not updated:
+                self._delete_edit(package_name, edit_id)
                 return DeploymentResult(
                     success=False,
                     package_name=package_name,
@@ -780,12 +823,16 @@ class PlayStoreClient:
                 )
 
             # Update track
-            service.edits().tracks().update(
-                packageName=package_name,
-                editId=edit_id,
-                track=track,
-                body={"releases": releases},
-            ).execute()
+            self._execute(
+                service.edits()
+                .tracks()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    track=track,
+                    body={"releases": releases},
+                )
+            )
 
             self._commit_edit(package_name, edit_id)
 
@@ -852,11 +899,8 @@ class PlayStoreClient:
 
         try:
             # Get current track info
-            current_track = (
-                service.edits()
-                .tracks()
-                .get(packageName=package_name, editId=edit_id, track=track)
-                .execute()
+            current_track = self._execute(
+                service.edits().tracks().get(packageName=package_name, editId=edit_id, track=track)
             )
 
             # Find and update the release
@@ -875,6 +919,7 @@ class PlayStoreClient:
                     break
 
             if not updated:
+                self._delete_edit(package_name, edit_id)
                 return DeploymentResult(
                     success=False,
                     package_name=package_name,
@@ -885,12 +930,16 @@ class PlayStoreClient:
                 )
 
             # Update track
-            service.edits().tracks().update(
-                packageName=package_name,
-                editId=edit_id,
-                track=track,
-                body={"releases": releases},
-            ).execute()
+            self._execute(
+                service.edits()
+                .tracks()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    track=track,
+                    body={"releases": releases},
+                )
+            )
 
             self._commit_edit(package_name, edit_id)
 
@@ -942,17 +991,16 @@ class PlayStoreClient:
 
         try:
             # Get app details
-            details = (
-                service.edits().details().get(packageName=package_name, editId=edit_id).execute()
+            details = self._execute(
+                service.edits().details().get(packageName=package_name, editId=edit_id)
             )
 
             # Get listings for the specified language
             try:
-                listing = (
+                listing = self._execute(
                     service.edits()
                     .listings()
                     .get(packageName=package_name, editId=edit_id, language=language)
-                    .execute()
                 )
             except HttpError:
                 listing = {}
@@ -967,6 +1015,9 @@ class PlayStoreClient:
                 developer_email=details.get("contactEmail"),
                 developer_website=details.get("contactWebsite"),
             )
+        except HttpError as e:
+            self._logger.exception("Failed to fetch app details", error=str(e))
+            raise PlayStoreClientError(f"Failed to fetch app details: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -1003,7 +1054,7 @@ class PlayStoreClient:
                 kwargs["translationLanguage"] = translation_language
             request = service.reviews().list(**kwargs)
 
-            result = request.execute()
+            result = self._execute(request)
 
             reviews: list[Review] = []
             for review_data in result.get("reviews", []):
@@ -1040,7 +1091,7 @@ class PlayStoreClient:
             kwargs: dict[str, Any] = {"packageName": package_name, "reviewId": review_id}
             if translation_language:
                 kwargs["translationLanguage"] = translation_language
-            result = service.reviews().get(**kwargs).execute()
+            result = self._execute(service.reviews().get(**kwargs))
 
             review = _parse_review(result)
             if review is None:
@@ -1075,11 +1126,13 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.reviews().reply(
-                packageName=package_name,
-                reviewId=review_id,
-                body={"replyText": reply_text},
-            ).execute()
+            self._execute(
+                service.reviews().reply(
+                    packageName=package_name,
+                    reviewId=review_id,
+                    body={"replyText": reply_text},
+                )
+            )
 
             return ReviewReplyResult(
                 success=True,
@@ -1113,16 +1166,24 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = service.monetization().subscriptions().list(packageName=package_name).execute()
-
-            subscriptions = [
-                SubscriptionProduct(
-                    product_id=sub_data.get("productId", ""),
-                    package_name=package_name,
-                    base_plans=sub_data.get("basePlans", []),
+            subscriptions: list[SubscriptionProduct] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {"packageName": package_name}
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(service.monetization().subscriptions().list(**kwargs))
+                subscriptions.extend(
+                    SubscriptionProduct(
+                        product_id=sub_data.get("productId", ""),
+                        package_name=package_name,
+                        base_plans=sub_data.get("basePlans", []),
+                    )
+                    for sub_data in result.get("subscriptions", [])
                 )
-                for sub_data in result.get("subscriptions", [])
-            ]
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
 
             return subscriptions
 
@@ -1155,11 +1216,8 @@ class PlayStoreClient:
 
         try:
             # Use v2 API for subscriptions
-            result = (
-                service.purchases()
-                .subscriptionsv2()
-                .get(packageName=package_name, token=token)
-                .execute()
+            result = self._execute(
+                service.purchases().subscriptionsv2().get(packageName=package_name, token=token)
             )
 
             line_items = result.get("lineItems", [])
@@ -1169,12 +1227,25 @@ class PlayStoreClient:
                 for item in line_items
             )
 
+            # Expiry is per line item; use the one for this subscription, falling
+            # back to the first line item's expiry if the product id isn't matched.
+            expiry_raw = next(
+                (
+                    item.get("expiryTime")
+                    for item in line_items
+                    if item.get("productId") == subscription_id
+                ),
+                line_items[0].get("expiryTime") if line_items else None,
+            )
+
             return SubscriptionPurchase(
                 package_name=package_name,
                 subscription_id=subscription_id,
                 purchase_token=token,
                 order_id=result.get("latestOrderId"),
                 auto_renewing=auto_renewing,
+                start_time=_parse_rfc3339(result.get("startTime")),
+                expiry_time=_parse_rfc3339(expiry_raw),
             )
 
         except HttpError as e:
@@ -1199,11 +1270,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.purchases()
                 .voidedpurchases()
                 .list(packageName=package_name, maxResults=max_results)
-                .execute()
             )
 
             voided = [
@@ -1250,11 +1320,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.purchases()
                 .products()
                 .get(packageName=package_name, productId=product_id, token=token)
-                .execute()
             )
 
             purchase_time = (
@@ -1307,12 +1376,16 @@ class PlayStoreClient:
         body = {"developerPayload": developer_payload} if developer_payload else {}
 
         try:
-            service.purchases().products().acknowledge(
-                packageName=package_name,
-                productId=product_id,
-                token=token,
-                body=body,
-            ).execute()
+            self._execute(
+                service.purchases()
+                .products()
+                .acknowledge(
+                    packageName=package_name,
+                    productId=product_id,
+                    token=token,
+                    body=body,
+                )
+            )
 
             return ProductPurchaseActionResult(
                 success=True,
@@ -1349,11 +1422,15 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.purchases().products().consume(
-                packageName=package_name,
-                productId=product_id,
-                token=token,
-            ).execute()
+            self._execute(
+                service.purchases()
+                .products()
+                .consume(
+                    packageName=package_name,
+                    productId=product_id,
+                    token=token,
+                )
+            )
 
             return ProductPurchaseActionResult(
                 success=True,
@@ -1388,9 +1465,9 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.orders().refund(
-                packageName=package_name, orderId=order_id, revoke=revoke
-            ).execute()
+            self._execute(
+                service.orders().refund(packageName=package_name, orderId=order_id, revoke=revoke)
+            )
 
             message = "Order refunded successfully"
             if revoke:
@@ -1428,11 +1505,15 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.purchases().subscriptionsv2().cancel(
-                packageName=package_name,
-                token=token,
-                body={"cancellationContext": {"cancellationType": cancellation_type}},
-            ).execute()
+            self._execute(
+                service.purchases()
+                .subscriptionsv2()
+                .cancel(
+                    packageName=package_name,
+                    token=token,
+                    body={"cancellationContext": {"cancellationType": cancellation_type}},
+                )
+            )
 
             return SubscriptionActionResult(
                 success=True,
@@ -1468,7 +1549,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.purchases()
                 .subscriptionsv2()
                 .defer(
@@ -1476,7 +1557,6 @@ class PlayStoreClient:
                     token=token,
                     body={"deferralContext": {"deferDuration": defer_duration, "etag": etag}},
                 )
-                .execute()
             )
 
             return SubscriptionActionResult(
@@ -1511,14 +1591,23 @@ class PlayStoreClient:
         self._logger.info(
             "Revoking subscription purchase", package_name=package_name, refund_type=refund_type
         )
+        if refund_type not in _REVOCATION_CONTEXTS:
+            raise PlayStoreClientError(
+                f"Invalid refund_type '{refund_type}'; must be one of: "
+                f"{', '.join(sorted(_REVOCATION_CONTEXTS))}"
+            )
         service = self._get_service()
 
         try:
-            service.purchases().subscriptionsv2().revoke(
-                packageName=package_name,
-                token=token,
-                body={"revocationContext": _REVOCATION_CONTEXTS[refund_type]},
-            ).execute()
+            self._execute(
+                service.purchases()
+                .subscriptionsv2()
+                .revoke(
+                    packageName=package_name,
+                    token=token,
+                    body={"revocationContext": _REVOCATION_CONTEXTS[refund_type]},
+                )
+            )
 
             return SubscriptionActionResult(
                 success=True,
@@ -1550,11 +1639,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.purchases()
                 .productsv2()
                 .getproductpurchasev2(packageName=package_name, token=token)
-                .execute()
             )
 
             return ProductPurchaseV2(
@@ -1722,7 +1810,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = service.inappproducts().list(packageName=package_name).execute()
+            result = self._execute(service.inappproducts().list(packageName=package_name))
 
             return [
                 self._parse_in_app_product(package_name, product_data)
@@ -1747,7 +1835,9 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            product_data = service.inappproducts().get(packageName=package_name, sku=sku).execute()
+            product_data = self._execute(
+                service.inappproducts().get(packageName=package_name, sku=sku)
+            )
             return self._parse_in_app_product(package_name, product_data)
 
         except HttpError as e:
@@ -1791,8 +1881,8 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.inappproducts().insert(packageName=package_name, body=product).execute()
+            result = self._execute(
+                service.inappproducts().insert(packageName=package_name, body=product)
             )
             return self._parse_in_app_product(package_name, result)
 
@@ -1823,15 +1913,13 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.inappproducts()
-                .update(
+            result = self._execute(
+                service.inappproducts().update(
                     packageName=package_name,
                     sku=sku,
                     autoConvertMissingPrices=auto_convert_missing_prices,
                     body=product,
                 )
-                .execute()
             )
             return self._parse_in_app_product(package_name, result)
 
@@ -1856,10 +1944,8 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.inappproducts()
-                .patch(packageName=package_name, sku=sku, body=product)
-                .execute()
+            result = self._execute(
+                service.inappproducts().patch(packageName=package_name, sku=sku, body=product)
             )
             return self._parse_in_app_product(package_name, result)
 
@@ -1881,7 +1967,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.inappproducts().delete(packageName=package_name, sku=sku).execute()
+            self._execute(service.inappproducts().delete(packageName=package_name, sku=sku))
 
             return InAppProductActionResult(
                 success=True,
@@ -1910,7 +1996,9 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = service.inappproducts().batchGet(packageName=package_name, sku=skus).execute()
+            result = self._execute(
+                service.inappproducts().batchGet(packageName=package_name, sku=skus)
+            )
 
             return [
                 self._parse_in_app_product(package_name, product_data)
@@ -1939,10 +2027,12 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.inappproducts().batchDelete(
-                packageName=package_name,
-                body={"requests": [{"packageName": package_name, "sku": s} for s in skus]},
-            ).execute()
+            self._execute(
+                service.inappproducts().batchDelete(
+                    packageName=package_name,
+                    body={"requests": [{"packageName": package_name, "sku": s} for s in skus]},
+                )
+            )
 
             return InAppProductActionResult(
                 success=True,
@@ -1987,11 +2077,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .get(packageName=package_name, productId=product_id)
-                .execute()
             )
             return self._parse_one_time_product(package_name, data)
 
@@ -2012,14 +2101,22 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.monetization().onetimeproducts().list(packageName=package_name).execute()
-            )
+            products: list[OneTimeProduct] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {"packageName": package_name}
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(service.monetization().onetimeproducts().list(**kwargs))
+                products.extend(
+                    self._parse_one_time_product(package_name, data)
+                    for data in result.get("oneTimeProducts", [])
+                )
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
 
-            return [
-                self._parse_one_time_product(package_name, data)
-                for data in result.get("oneTimeProducts", [])
-            ]
+            return products
 
         except HttpError as e:
             self._logger.exception("Failed to list one-time products", error=str(e))
@@ -2043,11 +2140,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .batchGet(packageName=package_name, productIds=product_ids)
-                .execute()
             )
 
             return [
@@ -2085,7 +2181,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .patch(
@@ -2095,7 +2191,6 @@ class PlayStoreClient:
                     regionsVersion_version=regions_version,
                     body=product,
                 )
-                .execute()
             )
             return self._parse_one_time_product(package_name, result)
 
@@ -2121,9 +2216,11 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().onetimeproducts().delete(
-                packageName=package_name, productId=product_id
-            ).execute()
+            self._execute(
+                service.monetization()
+                .onetimeproducts()
+                .delete(packageName=package_name, productId=product_id)
+            )
 
             return OneTimeProductActionResult(
                 success=True,
@@ -2154,11 +2251,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .batchUpdate(packageName=package_name, body={"requests": requests})
-                .execute()
             )
 
             return [
@@ -2190,9 +2286,11 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().onetimeproducts().batchDelete(
-                packageName=package_name, body={"requests": requests}
-            ).execute()
+            self._execute(
+                service.monetization()
+                .onetimeproducts()
+                .batchDelete(packageName=package_name, body={"requests": requests})
+            )
 
             return OneTimeProductActionResult(
                 success=True,
@@ -2233,11 +2331,16 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().onetimeproducts().purchaseOptions().batchDelete(
-                packageName=package_name,
-                productId=product_id,
-                body={"requests": requests},
-            ).execute()
+            self._execute(
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .batchDelete(
+                    packageName=package_name,
+                    productId=product_id,
+                    body={"requests": requests},
+                )
+            )
 
             return OneTimeProductActionResult(
                 success=True,
@@ -2275,7 +2378,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2284,7 +2387,6 @@ class PlayStoreClient:
                     productId=product_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
 
             return [
@@ -2339,22 +2441,32 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.monetization()
-                .onetimeproducts()
-                .purchaseOptions()
-                .offers()
-                .list(
-                    packageName=package_name,
-                    productId=product_id,
-                    purchaseOptionId=purchase_option_id,
+            offers: list[OneTimeProductOffer] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {
+                    "packageName": package_name,
+                    "productId": product_id,
+                    "purchaseOptionId": purchase_option_id,
+                }
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(
+                    service.monetization()
+                    .onetimeproducts()
+                    .purchaseOptions()
+                    .offers()
+                    .list(**kwargs)
                 )
-                .execute()
-            )
-            return [
-                self._parse_one_time_product_offer(offer)
-                for offer in result.get("oneTimeProductOffers", [])
-            ]
+                offers.extend(
+                    self._parse_one_time_product_offer(offer)
+                    for offer in result.get("oneTimeProductOffers", [])
+                )
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
+
+            return offers
 
         except HttpError as e:
             self._logger.exception("Failed to list purchase option offers", error=str(e))
@@ -2388,7 +2500,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2399,7 +2511,6 @@ class PlayStoreClient:
                     purchaseOptionId=purchase_option_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_one_time_product_offer(offer)
@@ -2436,7 +2547,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2453,7 +2564,6 @@ class PlayStoreClient:
                         "offerId": offer_id,
                     },
                 )
-                .execute()
             )
             return self._parse_one_time_product_offer(result)
 
@@ -2487,7 +2597,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2504,7 +2614,6 @@ class PlayStoreClient:
                         "offerId": offer_id,
                     },
                 )
-                .execute()
             )
             return self._parse_one_time_product_offer(result)
 
@@ -2538,7 +2647,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2555,7 +2664,6 @@ class PlayStoreClient:
                         "offerId": offer_id,
                     },
                 )
-                .execute()
             )
             return self._parse_one_time_product_offer(result)
 
@@ -2591,7 +2699,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2602,7 +2710,6 @@ class PlayStoreClient:
                     purchaseOptionId=purchase_option_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_one_time_product_offer(offer)
@@ -2644,7 +2751,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .onetimeproducts()
                 .purchaseOptions()
@@ -2655,7 +2762,6 @@ class PlayStoreClient:
                     purchaseOptionId=purchase_option_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_one_time_product_offer(offer)
@@ -2698,12 +2804,18 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().onetimeproducts().purchaseOptions().offers().batchDelete(
-                packageName=package_name,
-                productId=product_id,
-                purchaseOptionId=purchase_option_id,
-                body={"requests": requests},
-            ).execute()
+            self._execute(
+                service.monetization()
+                .onetimeproducts()
+                .purchaseOptions()
+                .offers()
+                .batchDelete(
+                    packageName=package_name,
+                    productId=product_id,
+                    purchaseOptionId=purchase_option_id,
+                    body={"requests": requests},
+                )
+            )
 
             return OneTimeProductActionResult(
                 success=True,
@@ -2746,11 +2858,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.monetization()
                 .subscriptions()
                 .get(packageName=package_name, productId=product_id)
-                .execute()
             )
             return self._parse_subscription(package_name, data)
 
@@ -2780,7 +2891,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .create(
@@ -2789,7 +2900,6 @@ class PlayStoreClient:
                     regionsVersion_version=regions_version,
                     body=subscription,
                 )
-                .execute()
             )
             return self._parse_subscription(package_name, result)
 
@@ -2821,7 +2931,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .patch(
@@ -2831,7 +2941,6 @@ class PlayStoreClient:
                     regionsVersion_version=regions_version,
                     body=subscription,
                 )
-                .execute()
             )
             return self._parse_subscription(package_name, result)
 
@@ -2853,9 +2962,11 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().subscriptions().delete(
-                packageName=package_name, productId=product_id
-            ).execute()
+            self._execute(
+                service.monetization()
+                .subscriptions()
+                .delete(packageName=package_name, productId=product_id)
+            )
 
             return SubscriptionCatalogResult(
                 success=True,
@@ -2886,11 +2997,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .batchGet(packageName=package_name, productIds=product_ids)
-                .execute()
             )
 
             return [
@@ -2920,11 +3030,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .batchUpdate(packageName=package_name, body={"requests": requests})
-                .execute()
             )
 
             return [
@@ -2962,7 +3071,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -2976,7 +3085,6 @@ class PlayStoreClient:
                         "basePlanId": base_plan_id,
                     },
                 )
-                .execute()
             )
             return self._parse_subscription(package_name, result)
 
@@ -3006,7 +3114,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3020,7 +3128,6 @@ class PlayStoreClient:
                         "basePlanId": base_plan_id,
                     },
                 )
-                .execute()
             )
             return self._parse_subscription(package_name, result)
 
@@ -3050,11 +3157,16 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().subscriptions().basePlans().delete(
-                packageName=package_name,
-                productId=product_id,
-                basePlanId=base_plan_id,
-            ).execute()
+            self._execute(
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .delete(
+                    packageName=package_name,
+                    productId=product_id,
+                    basePlanId=base_plan_id,
+                )
+            )
 
             return SubscriptionCatalogResult(
                 success=True,
@@ -3094,7 +3206,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result: dict[str, Any] = (
+            result: dict[str, Any] = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3104,7 +3216,6 @@ class PlayStoreClient:
                     basePlanId=base_plan_id,
                     body=request,
                 )
-                .execute()
             )
             return result
 
@@ -3137,7 +3248,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result: dict[str, Any] = (
+            result: dict[str, Any] = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3146,7 +3257,6 @@ class PlayStoreClient:
                     productId=product_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return result
 
@@ -3182,7 +3292,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3191,7 +3301,6 @@ class PlayStoreClient:
                     productId=product_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_subscription(package_name, sub)
@@ -3248,7 +3357,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3259,7 +3368,6 @@ class PlayStoreClient:
                     basePlanId=base_plan_id,
                     offerId=offer_id,
                 )
-                .execute()
             )
             return self._parse_subscription_offer(data)
 
@@ -3289,22 +3397,28 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.monetization()
-                .subscriptions()
-                .basePlans()
-                .offers()
-                .list(
-                    packageName=package_name,
-                    productId=product_id,
-                    basePlanId=base_plan_id,
+            offers: list[SubscriptionOffer] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {
+                    "packageName": package_name,
+                    "productId": product_id,
+                    "basePlanId": base_plan_id,
+                }
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(
+                    service.monetization().subscriptions().basePlans().offers().list(**kwargs)
                 )
-                .execute()
-            )
-            return [
-                self._parse_subscription_offer(offer)
-                for offer in result.get("subscriptionOffers", [])
-            ]
+                offers.extend(
+                    self._parse_subscription_offer(offer)
+                    for offer in result.get("subscriptionOffers", [])
+                )
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
+
+            return offers
 
         except HttpError as e:
             self._logger.exception("Failed to list subscription offers", error=str(e))
@@ -3342,7 +3456,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3355,7 +3469,6 @@ class PlayStoreClient:
                     regionsVersion_version=regions_version,
                     body=offer,
                 )
-                .execute()
             )
             return self._parse_subscription_offer(result)
 
@@ -3397,7 +3510,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3411,7 +3524,6 @@ class PlayStoreClient:
                     regionsVersion_version=regions_version,
                     body=offer,
                 )
-                .execute()
             )
             return self._parse_subscription_offer(result)
 
@@ -3443,7 +3555,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3460,7 +3572,6 @@ class PlayStoreClient:
                         "offerId": offer_id,
                     },
                 )
-                .execute()
             )
             return self._parse_subscription_offer(result)
 
@@ -3492,7 +3603,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3509,7 +3620,6 @@ class PlayStoreClient:
                         "offerId": offer_id,
                     },
                 )
-                .execute()
             )
             return self._parse_subscription_offer(result)
 
@@ -3543,12 +3653,18 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.monetization().subscriptions().basePlans().offers().delete(
-                packageName=package_name,
-                productId=product_id,
-                basePlanId=base_plan_id,
-                offerId=offer_id,
-            ).execute()
+            self._execute(
+                service.monetization()
+                .subscriptions()
+                .basePlans()
+                .offers()
+                .delete(
+                    packageName=package_name,
+                    productId=product_id,
+                    basePlanId=base_plan_id,
+                    offerId=offer_id,
+                )
+            )
 
             return SubscriptionCatalogResult(
                 success=True,
@@ -3589,7 +3705,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3600,7 +3716,6 @@ class PlayStoreClient:
                     basePlanId=base_plan_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_subscription_offer(offer)
@@ -3641,7 +3756,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3652,7 +3767,6 @@ class PlayStoreClient:
                     basePlanId=base_plan_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_subscription_offer(offer)
@@ -3695,7 +3809,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.monetization()
                 .subscriptions()
                 .basePlans()
@@ -3706,7 +3820,6 @@ class PlayStoreClient:
                     basePlanId=base_plan_id,
                     body={"requests": requests},
                 )
-                .execute()
             )
             return [
                 self._parse_subscription_offer(offer)
@@ -3738,11 +3851,10 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            listing_data = (
+            listing_data = self._execute(
                 service.edits()
                 .listings()
                 .get(packageName=package_name, editId=edit_id, language=language)
-                .execute()
             )
 
             return Listing(
@@ -3752,6 +3864,9 @@ class PlayStoreClient:
                 short_description=listing_data.get("shortDescription"),
                 video=listing_data.get("video"),
             )
+        except HttpError as e:
+            self._logger.exception("Failed to get store listing", error=str(e))
+            raise PlayStoreClientError(f"Failed to get store listing: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -3784,11 +3899,10 @@ class PlayStoreClient:
         try:
             # Get current listing
             try:
-                current_listing = (
+                current_listing = self._execute(
                     service.edits()
                     .listings()
                     .get(packageName=package_name, editId=edit_id, language=language)
-                    .execute()
                 )
             except HttpError:
                 current_listing = {}
@@ -3814,12 +3928,16 @@ class PlayStoreClient:
                 update_body["video"] = video
 
             # Update listing
-            service.edits().listings().update(
-                packageName=package_name,
-                editId=edit_id,
-                language=language,
-                body=update_body,
-            ).execute()
+            self._execute(
+                service.edits()
+                .listings()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    language=language,
+                    body=update_body,
+                )
+            )
 
             self._commit_edit(package_name, edit_id)
 
@@ -3865,8 +3983,8 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = (
-                service.edits().listings().list(packageName=package_name, editId=edit_id).execute()
+            result = self._execute(
+                service.edits().listings().list(packageName=package_name, editId=edit_id)
             )
 
             listings: list[Listing] = [
@@ -3881,6 +3999,9 @@ class PlayStoreClient:
             ]
 
             return listings
+        except HttpError as e:
+            self._logger.exception("Failed to list store listings", error=str(e))
+            raise PlayStoreClientError(f"Failed to list store listings: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -3903,11 +4024,8 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            testers_data = (
-                service.edits()
-                .testers()
-                .get(packageName=package_name, editId=edit_id, track=track)
-                .execute()
+            testers_data = self._execute(
+                service.edits().testers().get(packageName=package_name, editId=edit_id, track=track)
             )
 
             return TesterInfo(
@@ -3949,18 +4067,26 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            service.edits().testers().update(
-                packageName=package_name,
-                editId=edit_id,
-                track=track,
-                body={"googleGroups": google_groups},
-            ).execute()
+            self._execute(
+                service.edits()
+                .testers()
+                .update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    track=track,
+                    body={"googleGroups": google_groups},
+                )
+            )
 
             self._commit_edit(package_name, edit_id)
 
             return {"success": True, "track": track, "google_groups": google_groups}
 
         except HttpError as e:
+            self._logger.exception("Failed to update testers", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return {"success": False, "track": track, "error": str(e)}
+        except Exception as e:
             self._logger.exception("Failed to update testers", error=str(e))
             self._delete_edit(package_name, edit_id)
             return {"success": False, "track": track, "error": str(e)}
@@ -3983,7 +4109,9 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            order_data = service.orders().get(packageName=package_name, orderId=order_id).execute()
+            order_data = self._execute(
+                service.orders().get(packageName=package_name, orderId=order_id)
+            )
 
             return Order(
                 order_id=order_id,
@@ -4012,8 +4140,8 @@ class PlayStoreClient:
 
         try:
             # NOTE: googleapiclient method is lowercase "batchget" (per the discovery doc).
-            result = (
-                service.orders().batchget(packageName=package_name, orderIds=order_ids).execute()
+            result = self._execute(
+                service.orders().batchget(packageName=package_name, orderIds=order_ids)
             )
 
             return [
@@ -4061,7 +4189,7 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            expansion_data = (
+            expansion_data = self._execute(
                 service.edits()
                 .expansionfiles()
                 .get(
@@ -4070,7 +4198,6 @@ class PlayStoreClient:
                     apkVersionCode=version_code,
                     expansionFileType=expansion_file_type,
                 )
-                .execute()
             )
 
             return ExpansionFile(
@@ -4110,7 +4237,9 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = service.edits().apks().list(packageName=package_name, editId=edit_id).execute()
+            result = self._execute(
+                service.edits().apks().list(packageName=package_name, editId=edit_id)
+            )
             apks: list[Apk] = []
             for apk_data in result.get("apks", []):
                 binary = apk_data.get("binary") or {}
@@ -4123,6 +4252,9 @@ class PlayStoreClient:
                     )
                 )
             return apks
+        except HttpError as e:
+            self._logger.exception("Failed to list APKs", error=str(e))
+            raise PlayStoreClientError(f"Failed to list APKs: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -4140,8 +4272,8 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = (
-                service.edits().bundles().list(packageName=package_name, editId=edit_id).execute()
+            result = self._execute(
+                service.edits().bundles().list(packageName=package_name, editId=edit_id)
             )
             return [
                 Bundle(
@@ -4152,6 +4284,9 @@ class PlayStoreClient:
                 )
                 for bundle_data in result.get("bundles", [])
             ]
+        except HttpError as e:
+            self._logger.exception("Failed to list bundles", error=str(e))
+            raise PlayStoreClientError(f"Failed to list bundles: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -4175,11 +4310,10 @@ class PlayStoreClient:
                 mimetype="application/vnd.android.package-archive",
                 resumable=True,
             )
-            data = (
+            data = self._execute(
                 service.edits()
                 .apks()
                 .upload(packageName=package_name, editId=edit_id, media_body=media)
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             binary = data.get("binary") or {}
@@ -4193,6 +4327,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to upload APK", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to upload APK: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to upload APK", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to upload APK: {e}") from e
 
     def upload_bundle(self, package_name: str, bundle_path: str) -> Bundle:
         """Upload an app bundle (.aab) to a new edit and commit it.
@@ -4214,11 +4352,10 @@ class PlayStoreClient:
                 mimetype="application/octet-stream",
                 resumable=True,
             )
-            data = (
+            data = self._execute(
                 service.edits()
                 .bundles()
                 .upload(packageName=package_name, editId=edit_id, media_body=media)
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             return Bundle(
@@ -4231,6 +4368,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to upload bundle", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to upload bundle: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to upload bundle", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to upload bundle: {e}") from e
 
     def upload_deobfuscation_file(
         self,
@@ -4261,7 +4402,7 @@ class PlayStoreClient:
 
         try:
             media = MediaFileUpload(file_path, mimetype="application/octet-stream", resumable=True)
-            data = (
+            data = self._execute(
                 service.edits()
                 .deobfuscationfiles()
                 .upload(
@@ -4271,7 +4412,6 @@ class PlayStoreClient:
                     deobfuscationFileType=deobfuscation_file_type,
                     media_body=media,
                 )
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             deobfuscation_file = data.get("deobfuscationFile") or {}
@@ -4284,6 +4424,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to upload deobfuscation file", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to upload deobfuscation file: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to upload deobfuscation file", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to upload deobfuscation file: {e}") from e
 
     def upload_expansion_file(
         self,
@@ -4314,7 +4458,7 @@ class PlayStoreClient:
 
         try:
             media = MediaFileUpload(file_path, mimetype="application/octet-stream", resumable=True)
-            data = (
+            data = self._execute(
                 service.edits()
                 .expansionfiles()
                 .upload(
@@ -4324,7 +4468,6 @@ class PlayStoreClient:
                     expansionFileType=expansion_file_type,
                     media_body=media,
                 )
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             expansion_file = data.get("expansionFile") or {}
@@ -4338,6 +4481,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to upload expansion file", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to upload expansion file: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to upload expansion file", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to upload expansion file: {e}") from e
 
     # =========================================================================
     # Store Listing Images API (edits.images)
@@ -4387,7 +4534,7 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = (
+            result = self._execute(
                 service.edits()
                 .images()
                 .list(
@@ -4396,12 +4543,14 @@ class PlayStoreClient:
                     language=language,
                     imageType=image_type,
                 )
-                .execute()
             )
             return [
                 self._parse_app_image(package_name, language, image_type, image_data)
                 for image_data in result.get("images", [])
             ]
+        except HttpError as e:
+            self._logger.exception("Failed to list images", error=str(e))
+            raise PlayStoreClientError(f"Failed to list images: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 
@@ -4436,7 +4585,7 @@ class PlayStoreClient:
         try:
             mimetype = "image/png" if image_path.lower().endswith(".png") else "image/jpeg"
             media = MediaFileUpload(image_path, mimetype=mimetype, resumable=True)
-            data = (
+            data = self._execute(
                 service.edits()
                 .images()
                 .upload(
@@ -4446,7 +4595,6 @@ class PlayStoreClient:
                     imageType=image_type,
                     media_body=media,
                 )
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             image = data.get("image") or {}
@@ -4455,6 +4603,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to upload image", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to upload image: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to upload image", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to upload image: {e}") from e
 
     def delete_image(
         self,
@@ -4485,13 +4637,17 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            service.edits().images().delete(
-                packageName=package_name,
-                editId=edit_id,
-                language=language,
-                imageType=image_type,
-                imageId=image_id,
-            ).execute()
+            self._execute(
+                service.edits()
+                .images()
+                .delete(
+                    packageName=package_name,
+                    editId=edit_id,
+                    language=language,
+                    imageType=image_type,
+                    imageId=image_id,
+                )
+            )
             self._commit_edit(package_name, edit_id)
             return ImageDeleteResult(
                 success=True,
@@ -4505,6 +4661,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to delete image", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to delete image: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to delete image", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to delete image: {e}") from e
 
     def delete_all_images(
         self,
@@ -4532,7 +4692,7 @@ class PlayStoreClient:
         edit_id = self._create_edit(package_name)
 
         try:
-            result = (
+            result = self._execute(
                 service.edits()
                 .images()
                 .deleteall(
@@ -4541,7 +4701,6 @@ class PlayStoreClient:
                     language=language,
                     imageType=image_type,
                 )
-                .execute()
             )
             self._commit_edit(package_name, edit_id)
             deleted_count = len(result.get("deleted", []))
@@ -4557,6 +4716,10 @@ class PlayStoreClient:
             self._logger.exception("Failed to delete all images", error=str(e))
             self._delete_edit(package_name, edit_id)
             raise PlayStoreClientError(f"Failed to delete all images: {e.reason}") from e
+        except Exception as e:
+            self._logger.exception("Failed to delete all images", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            raise PlayStoreClientError(f"Failed to delete all images: {e}") from e
 
     # =========================================================================
     # External Transactions API (alternative billing)
@@ -4606,7 +4769,7 @@ class PlayStoreClient:
         name = f"applications/{package_name}/externalTransactions/{external_transaction_id}"
 
         try:
-            data = service.externaltransactions().getexternaltransaction(name=name).execute()
+            data = self._execute(service.externaltransactions().getexternaltransaction(name=name))
             return self._parse_external_transaction(package_name, external_transaction_id, data)
 
         except HttpError as e:
@@ -4638,14 +4801,12 @@ class PlayStoreClient:
         parent = f"applications/{package_name}"
 
         try:
-            data = (
-                service.externaltransactions()
-                .createexternaltransaction(
+            data = self._execute(
+                service.externaltransactions().createexternaltransaction(
                     parent=parent,
                     externalTransactionId=external_transaction_id,
                     body=transaction,
                 )
-                .execute()
             )
             return self._parse_external_transaction(package_name, external_transaction_id, data)
 
@@ -4679,10 +4840,8 @@ class PlayStoreClient:
         name = f"applications/{package_name}/externalTransactions/{external_transaction_id}"
 
         try:
-            data = (
-                service.externaltransactions()
-                .refundexternaltransaction(name=name, body=refund)
-                .execute()
+            data = self._execute(
+                service.externaltransactions().refundexternaltransaction(name=name, body=refund)
             )
             return self._parse_external_transaction(package_name, external_transaction_id, data)
 
@@ -4727,11 +4886,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.applications()
                 .deviceTierConfigs()
                 .get(packageName=package_name, deviceTierConfigId=device_tier_config_id)
-                .execute()
             )
             return self._parse_device_tier_config(package_name, data)
 
@@ -4752,14 +4910,22 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.applications().deviceTierConfigs().list(packageName=package_name).execute()
-            )
+            configs: list[DeviceTierConfig] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {"packageName": package_name}
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(service.applications().deviceTierConfigs().list(**kwargs))
+                configs.extend(
+                    self._parse_device_tier_config(package_name, config_data)
+                    for config_data in result.get("deviceTierConfigs", [])
+                )
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
 
-            return [
-                self._parse_device_tier_config(package_name, config_data)
-                for config_data in result.get("deviceTierConfigs", [])
-            ]
+            return configs
 
         except HttpError as e:
             self._logger.exception("Failed to list device tier configs", error=str(e))
@@ -4787,7 +4953,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.applications()
                 .deviceTierConfigs()
                 .create(
@@ -4795,7 +4961,6 @@ class PlayStoreClient:
                     allowUnknownDevices=allow_unknown_devices,
                     body=config,
                 )
-                .execute()
             )
             return self._parse_device_tier_config(package_name, data)
 
@@ -4857,11 +5022,22 @@ class PlayStoreClient:
         parent = f"developers/{developer_id}"
 
         try:
-            result = service.users().list(parent=parent).execute()
+            users: list[User] = []
+            page_token: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {"parent": parent}
+                if page_token:
+                    kwargs["pageToken"] = page_token
+                result = self._execute(service.users().list(**kwargs))
+                users.extend(
+                    self._parse_user(developer_id, user_data)
+                    for user_data in result.get("users", [])
+                )
+                page_token = result.get("nextPageToken")
+                if not page_token:
+                    break
 
-            return [
-                self._parse_user(developer_id, user_data) for user_data in result.get("users", [])
-            ]
+            return users
 
         except HttpError as e:
             self._logger.exception("Failed to list users", error=str(e))
@@ -4883,7 +5059,7 @@ class PlayStoreClient:
         parent = f"developers/{developer_id}"
 
         try:
-            data = service.users().create(parent=parent, body=user).execute()
+            data = self._execute(service.users().create(parent=parent, body=user))
             return self._parse_user(developer_id, data)
 
         except HttpError as e:
@@ -4914,7 +5090,9 @@ class PlayStoreClient:
         name = f"developers/{developer_id}/users/{email}"
 
         try:
-            data = service.users().patch(name=name, updateMask=update_mask, body=user).execute()
+            data = self._execute(
+                service.users().patch(name=name, updateMask=update_mask, body=user)
+            )
             return self._parse_user(developer_id, data)
 
         except HttpError as e:
@@ -4936,7 +5114,7 @@ class PlayStoreClient:
         name = f"developers/{developer_id}/users/{email}"
 
         try:
-            service.users().delete(name=name).execute()
+            self._execute(service.users().delete(name=name))
 
             return AccessResult(
                 success=True,
@@ -4963,7 +5141,7 @@ class PlayStoreClient:
         parent = f"developers/{developer_id}/users/{email}"
 
         try:
-            data = service.grants().create(parent=parent, body=grant).execute()
+            data = self._execute(service.grants().create(parent=parent, body=grant))
             return self._parse_grant(developer_id, email, data)
 
         except HttpError as e:
@@ -5001,7 +5179,9 @@ class PlayStoreClient:
         name = f"developers/{developer_id}/users/{email}/grants/{package_name}"
 
         try:
-            data = service.grants().patch(name=name, updateMask=update_mask, body=grant).execute()
+            data = self._execute(
+                service.grants().patch(name=name, updateMask=update_mask, body=grant)
+            )
             return self._parse_grant(developer_id, email, data)
 
         except HttpError as e:
@@ -5029,7 +5209,7 @@ class PlayStoreClient:
         name = f"developers/{developer_id}/users/{email}/grants/{package_name}"
 
         try:
-            service.grants().delete(name=name).execute()
+            self._execute(service.grants().delete(name=name))
 
             return AccessResult(
                 success=True,
@@ -5063,10 +5243,12 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.applications().dataSafety(
-                packageName=package_name,
-                body=safety_labels,
-            ).execute()
+            self._execute(
+                service.applications().dataSafety(
+                    packageName=package_name,
+                    body=safety_labels,
+                )
+            )
             return DataSafetyResult(
                 success=True,
                 package_name=package_name,
@@ -5105,7 +5287,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = service.apprecovery().list(packageName=package_name).execute()
+            result = self._execute(service.apprecovery().list(packageName=package_name))
 
             return [
                 self._parse_app_recovery(package_name, recovery_data)
@@ -5135,7 +5317,9 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = service.apprecovery().create(packageName=package_name, body=recovery).execute()
+            data = self._execute(
+                service.apprecovery().create(packageName=package_name, body=recovery)
+            )
             return self._parse_app_recovery(package_name, data)
 
         except HttpError as e:
@@ -5164,11 +5348,13 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.apprecovery().deploy(
-                packageName=package_name,
-                appRecoveryId=app_recovery_id,
-                body={},
-            ).execute()
+            self._execute(
+                service.apprecovery().deploy(
+                    packageName=package_name,
+                    appRecoveryId=app_recovery_id,
+                    body={},
+                )
+            )
             return AppRecoveryResult(
                 success=True,
                 package_name=package_name,
@@ -5202,11 +5388,13 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.apprecovery().cancel(
-                packageName=package_name,
-                appRecoveryId=app_recovery_id,
-                body={},
-            ).execute()
+            self._execute(
+                service.apprecovery().cancel(
+                    packageName=package_name,
+                    appRecoveryId=app_recovery_id,
+                    body={},
+                )
+            )
             return AppRecoveryResult(
                 success=True,
                 package_name=package_name,
@@ -5243,11 +5431,13 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            service.apprecovery().addTargeting(
-                packageName=package_name,
-                appRecoveryId=app_recovery_id,
-                body=targeting,
-            ).execute()
+            self._execute(
+                service.apprecovery().addTargeting(
+                    packageName=package_name,
+                    appRecoveryId=app_recovery_id,
+                    body=targeting,
+                )
+            )
             return AppRecoveryResult(
                 success=True,
                 package_name=package_name,
@@ -5289,10 +5479,8 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
-                service.generatedapks()
-                .list(packageName=package_name, versionCode=version_code)
-                .execute()
+            result = self._execute(
+                service.generatedapks().list(packageName=package_name, versionCode=version_code)
             )
 
             downloads: list[GeneratedApksDownload] = []
@@ -5390,6 +5578,11 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to download generated APK", error=str(e))
             raise PlayStoreClientError(f"Failed to download generated APK: {e.reason}") from e
+        except OSError as e:
+            self._logger.exception("Failed to write generated APK", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to write generated APK to {destination_path}: {e}"
+            ) from e
 
     # =========================================================================
     # System APK Variants API
@@ -5435,7 +5628,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.systemapks()
                 .variants()
                 .get(
@@ -5443,7 +5636,6 @@ class PlayStoreClient:
                     versionCode=version_code,
                     variantId=variant_id,
                 )
-                .execute()
             )
             return self._parse_system_apk_variant(package_name, version_code, data)
 
@@ -5473,11 +5665,10 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            result = (
+            result = self._execute(
                 service.systemapks()
                 .variants()
                 .list(packageName=package_name, versionCode=version_code)
-                .execute()
             )
 
             return [
@@ -5513,7 +5704,7 @@ class PlayStoreClient:
         service = self._get_service()
 
         try:
-            data = (
+            data = self._execute(
                 service.systemapks()
                 .variants()
                 .create(
@@ -5521,7 +5712,6 @@ class PlayStoreClient:
                     versionCode=version_code,
                     body=variant,
                 )
-                .execute()
             )
             return self._parse_system_apk_variant(package_name, version_code, data)
 
@@ -5584,6 +5774,11 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to download system APK variant", error=str(e))
             raise PlayStoreClientError(f"Failed to download system APK variant: {e.reason}") from e
+        except OSError as e:
+            self._logger.exception("Failed to write system APK variant", error=str(e))
+            raise PlayStoreClientError(
+                f"Failed to write system APK variant to {destination_path}: {e}"
+            ) from e
 
     # =========================================================================
     # Internal App Sharing API
@@ -5629,10 +5824,10 @@ class PlayStoreClient:
                 mimetype="application/vnd.android.package-archive",
                 resumable=True,
             )
-            data = (
-                service.internalappsharingartifacts()
-                .uploadapk(packageName=package_name, media_body=media)
-                .execute()
+            data = self._execute(
+                service.internalappsharingartifacts().uploadapk(
+                    packageName=package_name, media_body=media
+                )
             )
             return self._parse_internal_app_sharing_artifact(package_name, data)
 
@@ -5669,10 +5864,10 @@ class PlayStoreClient:
                 mimetype="application/octet-stream",
                 resumable=True,
             )
-            data = (
-                service.internalappsharingartifacts()
-                .uploadbundle(packageName=package_name, media_body=media)
-                .execute()
+            data = self._execute(
+                service.internalappsharingartifacts().uploadbundle(
+                    packageName=package_name, media_body=media
+                )
             )
             return self._parse_internal_app_sharing_artifact(package_name, data)
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -1253,15 +1253,17 @@ class PlayStoreClient:
                 for item in line_items
             )
 
-            # Expiry is per line item; use the one for this subscription, falling
-            # back to the first line item's expiry if the product id isn't matched.
+            # Expiry is per line item; use the one for this subscription. If no
+            # line item matches, the purchase isn't for this subscription id, so
+            # leave expiry unset rather than reporting another product's expiry
+            # (keeps it consistent with auto_renewing above).
             expiry_raw = next(
                 (
                     item.get("expiryTime")
                     for item in line_items
                     if item.get("productId") == subscription_id
                 ),
-                line_items[0].get("expiryTime") if line_items else None,
+                None,
             )
 
             return SubscriptionPurchase(

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -81,6 +81,12 @@ MAX_RETRIES = 3
 INITIAL_BACKOFF = 1.0  # seconds
 MAX_BACKOFF = 32.0  # seconds
 
+# HTTP methods whose requests are safe to retry on an ambiguous server error
+# (500/503): repeating them cannot create a duplicate side effect. Non-idempotent
+# requests (POST: create, upload, acknowledge, consume, refund, revoke, defer,
+# commit, ...) are only retried on 429 (throttled, so never applied).
+_IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "PUT", "DELETE"})
+
 # Revocation contexts for subscription refunds (Purchases.subscriptionsv2.revoke)
 _REVOCATION_CONTEXTS: dict[str, dict[str, dict]] = {
     "full": {"fullRefund": {}},
@@ -151,48 +157,64 @@ def _parse_review(review_data: dict[str, Any]) -> Review | None:
     )
 
 
-def retry_with_backoff(func):  # type: ignore[no-untyped-def]
-    """Decorator to retry API calls with exponential backoff.
+def _is_retryable_status(status: int, *, retry_server_errors: bool) -> bool:
+    """Whether an HTTP error status should be retried.
 
-    Retries on transient errors (500, 503) and rate limit errors (429).
+    429 (rate limited) is always retryable: the request was throttled, not
+    applied, so repeating it is safe for any HTTP method. 500/503 are retried
+    only when ``retry_server_errors`` is set (idempotent requests), because the
+    server may have already applied a non-idempotent request before erroring.
+    """
+    if status == 429:
+        return True
+    return retry_server_errors and status in (500, 503)
+
+
+def _run_with_backoff(call, *, retry_server_errors=True):  # type: ignore[no-untyped-def]
+    """Run ``call`` with exponential-backoff retries on transient errors."""
+    retries = 0
+    backoff = INITIAL_BACKOFF
+
+    while retries < MAX_RETRIES:
+        try:
+            return call()
+        except HttpError as e:
+            if not _is_retryable_status(e.resp.status, retry_server_errors=retry_server_errors):
+                raise
+            retries += 1
+            if retries >= MAX_RETRIES:
+                raise
+
+            # Add jitter to prevent thundering herd
+            sleep_time = backoff * (0.5 + random.random())  # noqa: S311 # nosec B311 — non-crypto jitter for retry backoff
+            logger.warning(
+                "API error, retrying",
+                status=e.resp.status,
+                retry=retries,
+                sleep=sleep_time,
+            )
+            time.sleep(sleep_time)
+            backoff = min(backoff * 2, MAX_BACKOFF)
+
+    # The loop above always returns or raises while MAX_RETRIES >= 1. This
+    # guards against a misconfigured MAX_RETRIES so a call can never fall
+    # through and implicitly return None.
+    raise PlayStoreClientError(  # pragma: no cover - only reachable if MAX_RETRIES <= 0
+        "Retry attempts exhausted without a result"
+    )
+
+
+def retry_with_backoff(func):  # type: ignore[no-untyped-def]
+    """Decorator to retry a call on transient errors (429/500/503).
+
+    For idempotent operations only (e.g. building the API service). Individual
+    Play API requests go through ``PlayStoreClient._execute``, which decides
+    whether to retry server errors based on the request's HTTP method.
     """
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
-        retries = 0
-        backoff = INITIAL_BACKOFF
-
-        while retries < MAX_RETRIES:
-            try:
-                return func(*args, **kwargs)
-            except HttpError as e:
-                # Retry on server errors and rate limits
-                if e.resp.status in (429, 500, 503):
-                    retries += 1
-                    if retries >= MAX_RETRIES:
-                        raise
-
-                    # Add jitter to prevent thundering herd
-                    sleep_time = backoff * (0.5 + random.random())  # noqa: S311 # nosec B311 — non-crypto jitter for retry backoff
-                    logger.warning(
-                        "API error, retrying",
-                        status=e.resp.status,
-                        retry=retries,
-                        sleep=sleep_time,
-                    )
-                    time.sleep(sleep_time)
-                    backoff = min(backoff * 2, MAX_BACKOFF)
-                else:
-                    raise
-            except Exception:
-                raise
-
-        # The loop above always returns or raises while MAX_RETRIES >= 1.
-        # This guards against a misconfigured MAX_RETRIES so a decorated call
-        # can never fall through and implicitly return None.
-        raise PlayStoreClientError(  # pragma: no cover - only reachable if MAX_RETRIES <= 0
-            "Retry attempts exhausted without a result"
-        )
+        return _run_with_backoff(lambda: func(*args, **kwargs), retry_server_errors=True)
 
     return wrapper
 
@@ -404,16 +426,20 @@ class PlayStoreClient:
             self._logger.exception("Failed to initialize API client", error=str(e))
             raise PlayStoreClientError(f"Failed to initialize API client: {e}") from e
 
-    @retry_with_backoff
     def _execute(self, request: Any) -> Any:
         """Execute a googleapiclient request with retry/backoff.
 
-        All Play API calls go through here so that transient 429/500/503
-        errors are retried with exponential backoff (see ``retry_with_backoff``).
-        Non-transient errors (e.g. 400/403/404) are re-raised immediately for
-        each caller's own ``except HttpError`` handling.
+        All Play API calls go through here. 429 (rate limited) is always
+        retried; 500/503 are retried only for idempotent HTTP methods. A
+        non-idempotent request (POST: create, upload, acknowledge, consume,
+        refund, revoke, defer, commit, ...) is not retried on a 5xx, because
+        the server may have already applied it and a retry could duplicate the
+        side effect. Non-transient errors (e.g. 400/403/404) propagate to each
+        caller's own ``except HttpError`` handling.
         """
-        return request.execute()
+        method = (getattr(request, "method", "") or "").upper()
+        retry_server_errors = method in _IDEMPOTENT_HTTP_METHODS
+        return _run_with_backoff(request.execute, retry_server_errors=retry_server_errors)
 
     def _create_edit(self, package_name: str) -> str:
         """Create a new edit for the package.

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
 import binascii
 import ipaddress
 import json
 import logging
 import os
+import secrets
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -3580,6 +3582,58 @@ async def health_check(request: Request) -> JSONResponse:  # noqa: ARG001
     return JSONResponse({"status": "healthy", "service": "play-store-mcp"})
 
 
+def _authorize_credentials_request(request: Request) -> JSONResponse | None:
+    """Authorize a POST to the /credentials management endpoint.
+
+    If PLAY_STORE_MCP_ADMIN_TOKEN is set, an ``Authorization: Bearer <token>``
+    header matching it (constant-time comparison) is required, and the request
+    is accepted from any host. This is the correct mode behind a reverse proxy,
+    where ``request.client.host`` is the proxy address and cannot be trusted as
+    a "localhost" signal.
+
+    If no admin token is configured, the endpoint accepts loopback (localhost)
+    peers only — the historical behavior.
+
+    Returns an error ``JSONResponse`` if the request is not authorized, else None.
+    """
+    admin_token = os.environ.get("PLAY_STORE_MCP_ADMIN_TOKEN")
+    if admin_token:
+        provided = request.headers.get("authorization", "")
+        expected = f"Bearer {admin_token}"
+        # Compare as bytes: secrets.compare_digest raises TypeError on non-ASCII
+        # str operands, and Starlette decodes header values as latin-1, so a
+        # crafted header could otherwise turn a 401 into an uncaught 500.
+        if not (
+            provided and secrets.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+        ):
+            return JSONResponse(
+                {"success": False, "error": "Missing or invalid admin token"},
+                status_code=401,
+            )
+        return None
+
+    # No admin token configured: only allow loopback peers.
+    client_host = request.client.host if request.client else None
+    try:
+        is_loopback = client_host is not None and ipaddress.ip_address(client_host).is_loopback
+    except ValueError:
+        is_loopback = False
+    if not is_loopback:
+        return JSONResponse(
+            {
+                "success": False,
+                "error": (
+                    "This endpoint is only accessible from localhost. Set "
+                    "PLAY_STORE_MCP_ADMIN_TOKEN and send an 'Authorization: Bearer' header "
+                    "to allow authenticated access (required when running behind a proxy, "
+                    "where the peer address is the proxy and not the real client)."
+                ),
+            },
+            status_code=403,
+        )
+    return None
+
+
 @mcp.custom_route("/credentials", methods=["POST"])
 async def update_credentials(request: Request) -> JSONResponse:
     """Update Google Play Store credentials via HTTP POST.
@@ -3597,18 +3651,12 @@ async def update_credentials(request: Request) -> JSONResponse:
     Returns:
         JSON response with success status
     """
-    # Management endpoint: only allow requests from localhost
-    client_host = request.client.host if request.client else None
-    try:
-        is_loopback = client_host is not None and ipaddress.ip_address(client_host).is_loopback
-    except ValueError:
-        is_loopback = False
-    if not is_loopback:
-        return JSONResponse(
-            {"success": False, "error": "This endpoint is only accessible from localhost"},
-            status_code=403,
-        )
+    # Management endpoint: authorize by admin token (if configured) or localhost.
+    auth_error = _authorize_credentials_request(request)
+    if auth_error is not None:
+        return auth_error
 
+    new_client: PlayStoreClient | None = None
     try:
         body = await request.json()
 
@@ -3660,12 +3708,22 @@ async def update_credentials(request: Request) -> JSONResponse:
                     status_code=400,
                 )
 
-        # Validate credentials by attempting to get service
-        try:
-            _ = new_client._get_service()
-        except PlayStoreClientError as e:
+        if (
+            new_client is None
+        ):  # pragma: no cover - defensive; branches above always assign or return
             return JSONResponse(
-                {"success": False, "error": f"Invalid credentials: {e}"},
+                {"success": False, "error": "No credentials could be parsed from the request"},
+                status_code=400,
+            )
+
+        # Validate credentials by attempting to build the service. This does
+        # blocking network I/O, so run it off the event loop.
+        try:
+            await asyncio.to_thread(new_client._get_service)
+        except PlayStoreClientError:
+            logger.warning("Credential validation failed for /credentials request")
+            return JSONResponse(
+                {"success": False, "error": "Invalid credentials"},
                 status_code=401,
             )
 
@@ -3686,10 +3744,10 @@ async def update_credentials(request: Request) -> JSONResponse:
             {"success": False, "error": "Invalid JSON in request body"},
             status_code=400,
         )
-    except Exception as e:
-        logger.exception("Error updating credentials", error=str(e))
+    except Exception:
+        logger.exception("Error updating credentials")
         return JSONResponse(
-            {"success": False, "error": f"Internal error: {e}"},
+            {"success": False, "error": "Internal server error"},
             status_code=500,
         )
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -2800,18 +2800,19 @@ def set_data_safety(
 
 
 @mcp.tool()
-def list_app_recoveries(package_name: str) -> list[dict[str, Any]]:
-    """List all app recovery actions for an app.
+def list_app_recoveries(package_name: str, version_code: int) -> list[dict[str, Any]]:
+    """List all app recovery actions for an app version.
 
     Args:
         package_name: App package name
+        version_code: App version code the recovery actions target
 
     Returns:
         List of app recovery actions with ID, status, targeting, and create time
     """
     client = get_client_from_context()
 
-    recoveries = client.list_app_recoveries(package_name)
+    recoveries = client.list_app_recoveries(package_name, version_code)
     return [recovery.model_dump() for recovery in recoveries]
 
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -238,17 +238,21 @@ Tests verify that:
 
 ## Retry Logic Testing
 
-The `@retry_with_backoff` decorator is applied to critical methods but is **not directly tested** in unit tests because:
+The `@retry_with_backoff` decorator retries transient errors (HTTP 429/500/503)
+with exponential backoff. It is applied to `_get_service` and to
+`PlayStoreClient._execute`, and **every** Play API call is routed through
+`_execute`, so all real API operations (deploy, upload, list, purchases,
+subscriptions, etc.) inherit the retry behavior.
 
-1. It would make tests slow (waiting for backoff delays)
-2. It would make tests non-deterministic
-3. The decorator is a cross-cutting concern
+It **is** directly unit-tested:
 
-The retry logic is tested through:
-
-- Manual integration testing
-- Production monitoring
-- Code review of the decorator implementation
+- The decorator itself is tested against dummy functions for the 429/500/503
+  retry paths and the exhaustion path (`tests/test_client_extended.py`).
+- Backoff sleeps are neutralized in tests by the autouse `_no_backoff_sleep`
+  fixture in `tests/conftest.py`, which patches `time.sleep`, so retry paths
+  run instantly and deterministically.
+- Method-level tests assert that operations retry transient errors and then
+  succeed or fail as expected.
 
 ## CI/CD Integration
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,13 @@ import pytest
 from play_store_mcp.client import PlayStoreClient
 
 
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep() -> Generator[None, None, None]:
+    """Neutralize retry backoff sleeps so retry paths run instantly in tests."""
+    with patch("play_store_mcp.client.time.sleep"):
+        yield
+
+
 @pytest.fixture
 def _mock_credentials() -> Generator[MagicMock, None, None]:
     """Mock Google credentials."""

--- a/tests/test_app_recovery.py
+++ b/tests/test_app_recovery.py
@@ -84,7 +84,7 @@ def test_list_app_recoveries_success():
     }
     client = _client(service)
 
-    result = client.list_app_recoveries("com.example.app")
+    result = client.list_app_recoveries("com.example.app", 8)
 
     assert [r.app_recovery_id for r in result] == ["123", "456"]
     assert result[0].status == "RECOVERY_STATUS_DRAFT"
@@ -92,7 +92,7 @@ def test_list_app_recoveries_success():
     assert result[0].create_time == "2026-01-01T00:00:00Z"
     assert result[1].status is None
     assert result[1].targeting is None
-    _rec(service).list.assert_called_once_with(packageName="com.example.app")
+    _rec(service).list.assert_called_once_with(packageName="com.example.app", versionCode=8)
 
 
 def test_list_app_recoveries_empty():
@@ -100,7 +100,7 @@ def test_list_app_recoveries_empty():
     _rec(service).list.return_value.execute.return_value = {}
     client = _client(service)
 
-    result = client.list_app_recoveries("com.example.app")
+    result = client.list_app_recoveries("com.example.app", 8)
 
     assert result == []
 
@@ -111,7 +111,7 @@ def test_list_app_recoveries_http_error():
     client = _client(service)
 
     with pytest.raises(PlayStoreClientError, match="Failed to list app recoveries"):
-        client.list_app_recoveries("com.example.app")
+        client.list_app_recoveries("com.example.app", 8)
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +250,7 @@ def test_tool_list_app_recoveries(monkeypatch):
     ]
     monkeypatch.setattr(server, "get_client_from_context", lambda: mc)
 
-    result = server.list_app_recoveries("com.example.app")
+    result = server.list_app_recoveries("com.example.app", 8)
 
     assert result == [
         {
@@ -261,7 +261,7 @@ def test_tool_list_app_recoveries(monkeypatch):
             "create_time": None,
         }
     ]
-    mc.list_app_recoveries.assert_called_once_with("com.example.app")
+    mc.list_app_recoveries.assert_called_once_with("com.example.app", 8)
 
 
 def test_tool_create_app_recovery(monkeypatch):

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -1,0 +1,712 @@
+"""Tests for the batch of audit fixes in client.py and server.py.
+
+Each test class maps to a numbered audit finding (see the module docstrings
+below). These bring branch coverage of the newly hardened code paths back to
+~100% while asserting real behavior, not just execution.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+import play_store_mcp.client as client_module
+from play_store_mcp.client import PlayStoreClient, PlayStoreClientError, _parse_rfc3339
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _make_http_error(status: int, reason: str = "error") -> HttpError:
+    """Create a mock HttpError with the given HTTP status."""
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = reason
+    return HttpError(resp=resp, content=reason.encode())
+
+
+# =========================================================================
+# Finding 1: retry through a real operation (_execute is @retry_with_backoff)
+# =========================================================================
+
+
+class TestExecuteRetryThroughOperation:
+    """The retry decorator wraps _execute, so real API calls retry 429/500/503."""
+
+    def test_operation_retries_transient_then_succeeds(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Two 503s then a success dict: get_order returns parsed result, 3 calls."""
+        execute = _mock_service.orders.return_value.get.return_value.execute
+        execute.side_effect = [
+            _make_http_error(503),
+            _make_http_error(503),
+            {"productId": "prod-1", "purchaseState": 0, "purchaseToken": "tok-1"},
+        ]
+
+        order = client.get_order("com.example.app", "order-1")
+
+        assert order.order_id == "order-1"
+        assert order.product_id == "prod-1"
+        assert order.purchase_state == 0
+        assert order.purchase_token == "tok-1"
+        assert execute.call_count == 3
+
+    def test_operation_raises_after_persistent_transient_errors(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Three consecutive 503s exhaust retries and surface as PlayStoreClientError."""
+        execute = _mock_service.orders.return_value.get.return_value.execute
+        execute.side_effect = [
+            _make_http_error(503),
+            _make_http_error(503),
+            _make_http_error(503),
+        ]
+
+        with pytest.raises(PlayStoreClientError, match="Failed to get order"):
+            client.get_order("com.example.app", "order-1")
+
+        assert execute.call_count == 3
+
+
+# =========================================================================
+# Finding 2: _parse_rfc3339
+# =========================================================================
+
+
+class TestParseRfc3339:
+    """Module-level RFC3339 parser used by subscriptions v2."""
+
+    def test_valid_rfc3339_returns_aware_datetime(self) -> None:
+        result = _parse_rfc3339("2024-10-02T15:01:23Z")
+        assert result == datetime(2024, 10, 2, 15, 1, 23, tzinfo=UTC)
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_none_returns_none(self) -> None:
+        assert _parse_rfc3339(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_rfc3339("") is None
+
+    def test_invalid_string_returns_none(self) -> None:
+        assert _parse_rfc3339("not-a-date") is None
+
+
+# =========================================================================
+# Finding 3: get_subscription_purchase (v2 lineItems + RFC3339 times)
+# =========================================================================
+
+
+class TestGetSubscriptionPurchase:
+    """Subscriptions v2 parsing of start/expiry times and auto-renew state."""
+
+    def _get_mock(self, _mock_service: MagicMock) -> MagicMock:
+        return _mock_service.purchases.return_value.subscriptionsv2.return_value.get
+
+    def test_matching_line_item_populates_times_and_auto_renew(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """The line item whose productId matches supplies expiry + auto-renew."""
+        self._get_mock(_mock_service).return_value.execute.return_value = {
+            "startTime": "2024-10-02T15:01:23Z",
+            "latestOrderId": "order-9",
+            "lineItems": [
+                {
+                    "productId": "sub_premium",
+                    "expiryTime": "2025-01-01T00:00:00Z",
+                    "autoRenewingPlan": {"autoRenewEnabled": True},
+                }
+            ],
+        }
+
+        result = client.get_subscription_purchase("com.example.app", "sub_premium", "token-1")
+
+        assert result.start_time == datetime(2024, 10, 2, 15, 1, 23, tzinfo=UTC)
+        assert result.expiry_time == datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        assert result.auto_renewing is True
+        assert result.order_id == "order-9"
+
+    def test_expiry_falls_back_to_first_line_item(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """When no line item matches, expiry comes from the first line item."""
+        self._get_mock(_mock_service).return_value.execute.return_value = {
+            "startTime": "2024-10-02T15:01:23Z",
+            "lineItems": [
+                {
+                    "productId": "some_other_id",
+                    "expiryTime": "2025-02-02T00:00:00Z",
+                    "autoRenewingPlan": {"autoRenewEnabled": True},
+                }
+            ],
+        }
+
+        result = client.get_subscription_purchase("com.example.app", "sub_premium", "token-1")
+
+        assert result.expiry_time == datetime(2025, 2, 2, 0, 0, 0, tzinfo=UTC)
+        # No line item matched the requested subscription id, so auto_renewing
+        # must be False even though the (non-matching) plan auto-renews.
+        assert result.auto_renewing is False
+
+
+# =========================================================================
+# Finding 4: read methods now wrap HttpError in PlayStoreClientError
+# =========================================================================
+
+
+class TestReadMethodsWrapHttpError:
+    """These read methods previously leaked raw HttpError; now they wrap it."""
+
+    def test_get_releases_wraps_http_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = _mock_service.edits.return_value
+        edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+        edits.tracks.return_value.list.return_value.execute.side_effect = _make_http_error(403)
+
+        with pytest.raises(PlayStoreClientError, match="Failed to fetch releases"):
+            client.get_releases("com.example.app")
+
+    def test_get_app_details_wraps_http_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = _mock_service.edits.return_value
+        edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+        edits.details.return_value.get.return_value.execute.side_effect = _make_http_error(403)
+
+        with pytest.raises(PlayStoreClientError, match="Failed to fetch app details"):
+            client.get_app_details("com.example.app")
+
+    def test_get_listing_wraps_http_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = _mock_service.edits.return_value
+        edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+        edits.listings.return_value.get.return_value.execute.side_effect = _make_http_error(404)
+
+        with pytest.raises(PlayStoreClientError, match="Failed to get store listing"):
+            client.get_listing("com.example.app")
+
+    def test_list_all_listings_wraps_http_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = _mock_service.edits.return_value
+        edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+        edits.listings.return_value.list.return_value.execute.side_effect = _make_http_error(403)
+
+        with pytest.raises(PlayStoreClientError, match="Failed to list store listings"):
+            client.list_all_listings("com.example.app")
+
+
+# =========================================================================
+# Finding 5: edit-orphan cleanup on non-HttpError failures (except Exception)
+# =========================================================================
+
+
+class TestEditOrphanCleanup:
+    """Non-HttpError failures inside edit txns must abandon the edit and wrap."""
+
+    def _prime_edit(self, _mock_service: MagicMock) -> MagicMock:
+        edits = _mock_service.edits.return_value
+        edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+        edits.delete.return_value.execute.return_value = None
+        return edits
+
+    def test_upload_apk_cleanup_on_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        monkeypatch.setattr(
+            client_module, "MediaFileUpload", MagicMock(side_effect=OSError("disk"))
+        )
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"x")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to upload APK"):
+            client.upload_apk("com.example.app", str(apk))
+
+        edits.delete.assert_called()
+
+    def test_upload_bundle_cleanup_on_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        monkeypatch.setattr(
+            client_module, "MediaFileUpload", MagicMock(side_effect=OSError("disk"))
+        )
+        bundle = tmp_path / "app.aab"
+        bundle.write_bytes(b"x")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to upload bundle"):
+            client.upload_bundle("com.example.app", str(bundle))
+
+        edits.delete.assert_called()
+
+    def test_upload_deobfuscation_file_cleanup_on_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        monkeypatch.setattr(
+            client_module, "MediaFileUpload", MagicMock(side_effect=OSError("disk"))
+        )
+        mapping = tmp_path / "mapping.txt"
+        mapping.write_text("x")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to upload deobfuscation file"):
+            client.upload_deobfuscation_file("com.example.app", 100, str(mapping))
+
+        edits.delete.assert_called()
+
+    def test_upload_expansion_file_cleanup_on_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        monkeypatch.setattr(
+            client_module, "MediaFileUpload", MagicMock(side_effect=OSError("disk"))
+        )
+        obb = tmp_path / "main.obb"
+        obb.write_bytes(b"x")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to upload expansion file"):
+            client.upload_expansion_file("com.example.app", 100, str(obb))
+
+        edits.delete.assert_called()
+
+    def test_upload_image_cleanup_on_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        monkeypatch.setattr(
+            client_module, "MediaFileUpload", MagicMock(side_effect=OSError("disk"))
+        )
+        img = tmp_path / "icon.png"
+        img.write_bytes(b"x")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to upload image"):
+            client.upload_image("com.example.app", "en-US", "icon", str(img))
+
+        edits.delete.assert_called()
+
+    def test_delete_image_cleanup_on_runtime_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        # The image delete itself succeeds; the commit step blows up.
+        edits.commit.return_value.execute.side_effect = RuntimeError("commit boom")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to delete image"):
+            client.delete_image("com.example.app", "en-US", "icon", "img-1")
+
+        edits.delete.assert_called()
+
+    def test_delete_all_images_cleanup_on_runtime_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        edits.images.return_value.deleteall.return_value.execute.return_value = {"deleted": []}
+        edits.commit.return_value.execute.side_effect = RuntimeError("commit boom")
+
+        with pytest.raises(PlayStoreClientError, match="Failed to delete all images"):
+            client.delete_all_images("com.example.app", "en-US", "icon")
+
+        edits.delete.assert_called()
+
+    def test_update_testers_cleanup_on_runtime_error(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        edits = self._prime_edit(_mock_service)
+        edits.commit.return_value.execute.side_effect = RuntimeError("commit boom")
+
+        result = client.update_testers("com.example.app", "internal", ["g@example.com"])
+
+        assert result["success"] is False
+        assert result["track"] == "internal"
+        assert "commit boom" in result["error"]
+        edits.delete.assert_called()
+
+
+# =========================================================================
+# Finding 6: revoke_subscription_purchase rejects unknown refund_type
+# =========================================================================
+
+
+class TestRevokeSubscriptionRefundType:
+    def test_invalid_refund_type_raises(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with pytest.raises(PlayStoreClientError, match="Invalid refund_type"):
+            client.revoke_subscription_purchase("com.example.app", "token-1", refund_type="bogus")
+
+
+# =========================================================================
+# Finding 7: pagination across nextPageToken for list_* methods
+# =========================================================================
+
+
+class TestPagination:
+    """Each list_* method must combine pages and pass pageToken on page 2."""
+
+    def test_list_subscriptions_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.monetization.return_value.subscriptions.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"subscriptions": [{"productId": "s1"}], "nextPageToken": "tok"},
+            {"subscriptions": [{"productId": "s2"}]},
+        ]
+
+        result = client.list_subscriptions("com.example.app")
+
+        assert [s.product_id for s in result] == ["s1", "s2"]
+        assert list_mock.call_count == 2
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+    def test_list_one_time_products_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.monetization.return_value.onetimeproducts.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"oneTimeProducts": [{"productId": "p1"}], "nextPageToken": "tok"},
+            {"oneTimeProducts": [{"productId": "p2"}]},
+        ]
+
+        result = client.list_one_time_products("com.example.app")
+
+        assert [p.product_id for p in result] == ["p1", "p2"]
+        assert list_mock.call_count == 2
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+    def test_list_purchase_option_offers_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.monetization.return_value.onetimeproducts.return_value.purchaseOptions.return_value.offers.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"oneTimeProductOffers": [{"offerId": "o1"}], "nextPageToken": "tok"},
+            {"oneTimeProductOffers": [{"offerId": "o2"}]},
+        ]
+
+        result = client.list_purchase_option_offers("com.example.app", "prod", "opt")
+
+        assert [o.offer_id for o in result] == ["o1", "o2"]
+        assert list_mock.call_count == 2
+        first_call = list_mock.call_args_list[0].kwargs
+        assert first_call["productId"] == "prod"
+        assert first_call["purchaseOptionId"] == "opt"
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+    def test_list_subscription_offers_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.monetization.return_value.subscriptions.return_value.basePlans.return_value.offers.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"subscriptionOffers": [{"offerId": "o1"}], "nextPageToken": "tok"},
+            {"subscriptionOffers": [{"offerId": "o2"}]},
+        ]
+
+        result = client.list_subscription_offers("com.example.app", "prod", "base")
+
+        assert [o.offer_id for o in result] == ["o1", "o2"]
+        assert list_mock.call_count == 2
+        first_call = list_mock.call_args_list[0].kwargs
+        assert first_call["productId"] == "prod"
+        assert first_call["basePlanId"] == "base"
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+    def test_list_device_tier_configs_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.applications.return_value.deviceTierConfigs.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"deviceTierConfigs": [{"deviceTierConfigId": "c1"}], "nextPageToken": "tok"},
+            {"deviceTierConfigs": [{"deviceTierConfigId": "c2"}]},
+        ]
+
+        result = client.list_device_tier_configs("com.example.app")
+
+        assert [c.device_tier_config_id for c in result] == ["c1", "c2"]
+        assert list_mock.call_count == 2
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+    def test_list_users_paginates(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        list_mock = _mock_service.users.return_value.list
+        list_mock.return_value.execute.side_effect = [
+            {"users": [{"email": "a@b.com"}], "nextPageToken": "tok"},
+            {"users": [{"email": "c@d.com"}]},
+        ]
+
+        result = client.list_users("dev-123")
+
+        assert [u.email for u in result] == ["a@b.com", "c@d.com"]
+        assert list_mock.call_count == 2
+        assert list_mock.call_args_list[0].kwargs["parent"] == "developers/dev-123"
+        assert list_mock.call_args_list[1].kwargs["pageToken"] == "tok"
+
+
+# =========================================================================
+# Finding 8: download OSError is caught and wrapped
+# =========================================================================
+
+
+class TestDownloadOsError:
+    """Writing to an undwritable path raises OSError, now wrapped."""
+
+    _BAD_PATH = "/nonexistent_dir_xyzzy/out.apk"
+
+    def test_download_generated_apk_wraps_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with pytest.raises(PlayStoreClientError, match="Failed to write generated APK"):
+            client.download_generated_apk("com.example.app", 100, "download-1", self._BAD_PATH)
+
+    def test_download_system_apk_variant_wraps_oserror(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with pytest.raises(PlayStoreClientError, match="Failed to write system APK variant"):
+            client.download_system_apk_variant("com.example.app", 100, 1, self._BAD_PATH)
+
+
+# =========================================================================
+# Finding 9: /credentials endpoint auth hardening
+# =========================================================================
+
+_ADMIN_TOKEN_ENV = "PLAY_STORE_MCP_ADMIN_TOKEN"
+
+
+def _valid_credentials() -> dict[str, str]:
+    return {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "kid",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----",
+        "client_email": "svc@test-project.iam.gserviceaccount.com",
+        "client_id": "1",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+class TestCredentialsAuthorization:
+    """_authorize_credentials_request gating (loopback vs admin token)."""
+
+    def test_no_token_non_loopback_returns_403(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import _authorize_credentials_request
+
+        monkeypatch.delenv(_ADMIN_TOKEN_ENV, raising=False)
+
+        request = MagicMock(spec=Request)
+        request.client.host = "203.0.113.5"
+        request.headers = {}
+
+        result = _authorize_credentials_request(request)
+
+        assert result is not None
+        assert result.status_code == 403
+        assert "localhost" in json.loads(result.body)["error"]
+
+    def test_token_valid_bearer_from_non_loopback_authorizes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import _authorize_credentials_request
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        request = MagicMock(spec=Request)
+        request.client.host = "203.0.113.5"
+        request.headers = {"authorization": "Bearer secret-token"}
+
+        # None means "authorized, proceed".
+        assert _authorize_credentials_request(request) is None
+
+    def test_token_wrong_header_returns_401(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import _authorize_credentials_request
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        request = MagicMock(spec=Request)
+        request.client.host = "127.0.0.1"
+        request.headers = {"authorization": "Bearer wrong-token"}
+
+        result = _authorize_credentials_request(request)
+
+        assert result is not None
+        assert result.status_code == 401
+        assert json.loads(result.body)["error"] == "Missing or invalid admin token"
+
+    def test_token_missing_header_returns_401(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import _authorize_credentials_request
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        request = MagicMock(spec=Request)
+        request.client.host = "127.0.0.1"
+        request.headers = {}
+
+        result = _authorize_credentials_request(request)
+
+        assert result is not None
+        assert result.status_code == 401
+        assert json.loads(result.body)["error"] == "Missing or invalid admin token"
+
+    def test_token_non_ascii_header_returns_401_not_500(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A non-ASCII Authorization header must cleanly return 401, not raise a
+        # TypeError (secrets.compare_digest rejects non-ASCII str operands, and
+        # Starlette decodes header values as latin-1).
+        from starlette.requests import Request
+
+        from play_store_mcp.server import _authorize_credentials_request
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        request = MagicMock(spec=Request)
+        request.client.host = "203.0.113.5"
+        request.headers = {"authorization": "Bearer \x80\xff-not-ascii"}
+
+        result = _authorize_credentials_request(request)
+
+        assert result is not None
+        assert result.status_code == 401
+        assert json.loads(result.body)["error"] == "Missing or invalid admin token"
+
+
+class TestCredentialsEndpointAuth:
+    """update_credentials honors admin-token auth end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_token_allows_non_loopback_and_updates(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import mcp, update_credentials
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        with patch("play_store_mcp.client.PlayStoreClient._get_service") as mock_service:
+            mock_service.return_value = MagicMock()
+
+            request = MagicMock(spec=Request)
+            request.client.host = "203.0.113.5"
+            request.headers = {"authorization": "Bearer secret-token"}
+            request.json = AsyncMock(return_value={"credentials": _valid_credentials()})
+
+            mcp._shared_state = {"client": None, "credentials_updated": False}
+
+            response = await update_credentials(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["success"] is True
+        assert "updated successfully" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_token_wrong_header_blocks_before_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from play_store_mcp.server import update_credentials
+
+        monkeypatch.setenv(_ADMIN_TOKEN_ENV, "secret-token")
+
+        request = MagicMock(spec=Request)
+        request.client.host = "127.0.0.1"
+        request.headers = {"authorization": "Bearer nope"}
+        # If auth were bypassed this would be consulted; it must not be.
+        request.json = AsyncMock(return_value={"credentials": _valid_credentials()})
+
+        response = await update_credentials(request)
+
+        assert response.status_code == 401
+        assert json.loads(response.body)["error"] == "Missing or invalid admin token"
+        request.json.assert_not_called()

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -179,12 +179,12 @@ class TestGetSubscriptionPurchase:
         assert result.auto_renewing is True
         assert result.order_id == "order-9"
 
-    def test_expiry_falls_back_to_first_line_item(
+    def test_no_matching_line_item_yields_no_expiry(
         self,
         client: PlayStoreClient,
         _mock_service: MagicMock,
     ) -> None:
-        """When no line item matches, expiry comes from the first line item."""
+        """When no line item matches the subscription id, expiry is not guessed."""
         self._get_mock(_mock_service).return_value.execute.return_value = {
             "startTime": "2024-10-02T15:01:23Z",
             "lineItems": [
@@ -198,9 +198,9 @@ class TestGetSubscriptionPurchase:
 
         result = client.get_subscription_purchase("com.example.app", "sub_premium", "token-1")
 
-        assert result.expiry_time == datetime(2025, 2, 2, 0, 0, 0, tzinfo=UTC)
-        # No line item matched the requested subscription id, so auto_renewing
-        # must be False even though the (non-matching) plan auto-renews.
+        # No line item matched the requested subscription id, so neither expiry
+        # nor auto-renew is taken from the non-matching product.
+        assert result.expiry_time is None
         assert result.auto_renewing is False
 
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -37,7 +37,7 @@ def _make_http_error(status: int, reason: str = "error") -> HttpError:
 
 
 class TestExecuteRetryThroughOperation:
-    """The retry decorator wraps _execute, so real API calls retry 429/500/503."""
+    """_execute retries via backoff: 429 always; 500/503 only for idempotent methods."""
 
     def test_operation_retries_transient_then_succeeds(
         self,
@@ -45,7 +45,9 @@ class TestExecuteRetryThroughOperation:
         _mock_service: MagicMock,
     ) -> None:
         """Two 503s then a success dict: get_order returns parsed result, 3 calls."""
-        execute = _mock_service.orders.return_value.get.return_value.execute
+        get_req = _mock_service.orders.return_value.get.return_value
+        get_req.method = "GET"  # idempotent → 5xx is retried
+        execute = get_req.execute
         execute.side_effect = [
             _make_http_error(503),
             _make_http_error(503),
@@ -66,7 +68,9 @@ class TestExecuteRetryThroughOperation:
         _mock_service: MagicMock,
     ) -> None:
         """Three consecutive 503s exhaust retries and surface as PlayStoreClientError."""
-        execute = _mock_service.orders.return_value.get.return_value.execute
+        get_req = _mock_service.orders.return_value.get.return_value
+        get_req.method = "GET"  # idempotent → 5xx is retried
+        execute = get_req.execute
         execute.side_effect = [
             _make_http_error(503),
             _make_http_error(503),
@@ -77,6 +81,42 @@ class TestExecuteRetryThroughOperation:
             client.get_order("com.example.app", "order-1")
 
         assert execute.call_count == 3
+
+    def test_non_idempotent_operation_not_retried_on_5xx(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """A POST mutation must NOT retry a 5xx (retrying could duplicate the write)."""
+        ack = _mock_service.purchases.return_value.products.return_value.acknowledge.return_value
+        ack.method = "POST"
+        ack.execute.side_effect = [
+            _make_http_error(503),
+            {},
+        ]
+
+        with pytest.raises(PlayStoreClientError, match="Failed to acknowledge"):
+            client.acknowledge_product_purchase("com.example.app", "sku-1", "tok-1")
+
+        assert ack.execute.call_count == 1
+
+    def test_non_idempotent_operation_retries_on_429(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """A POST mutation still retries 429 (throttled, so never applied)."""
+        ack = _mock_service.purchases.return_value.products.return_value.acknowledge.return_value
+        ack.method = "POST"
+        ack.execute.side_effect = [
+            _make_http_error(429),
+            {},
+        ]
+
+        result = client.acknowledge_product_purchase("com.example.app", "sku-1", "tok-1")
+
+        assert result.success is True
+        assert ack.execute.call_count == 2
 
 
 # =========================================================================

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -1266,11 +1266,11 @@ class TestEditFailures:
         client: PlayStoreClient,
         _mock_service: MagicMock,
     ) -> None:
-        """Test _create_edit failure propagates."""
+        """Test _create_edit failure is wrapped in PlayStoreClientError."""
         mock_edits = _mock_service.edits.return_value
         mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
 
-        with pytest.raises(HttpError):
+        with pytest.raises(PlayStoreClientError, match="Failed to create edit"):
             client._create_edit("com.example.app")
 
     def test_commit_edit_failure(

--- a/tests/test_edit_uploads.py
+++ b/tests/test_edit_uploads.py
@@ -126,7 +126,7 @@ def test_list_apks_http_error_still_abandons_edit():
     _edits(service).apks.return_value.list.return_value.execute.side_effect = _make_http_error()
     client = _client(service)
 
-    with pytest.raises(HttpError):
+    with pytest.raises(PlayStoreClientError, match="Failed to list APKs"):
         client.list_apks("com.example.app")
 
     _edits(service).delete.assert_called_once_with(packageName="com.example.app", editId="edit-123")
@@ -167,7 +167,7 @@ def test_list_bundles_http_error_still_abandons_edit():
     _edits(service).bundles.return_value.list.return_value.execute.side_effect = _make_http_error()
     client = _client(service)
 
-    with pytest.raises(HttpError):
+    with pytest.raises(PlayStoreClientError, match="Failed to list bundles"):
         client.list_bundles("com.example.app")
 
     _edits(service).delete.assert_called_once_with(packageName="com.example.app", editId="edit-123")

--- a/tests/test_listing_images.py
+++ b/tests/test_listing_images.py
@@ -195,7 +195,7 @@ def test_list_images_http_error_still_abandons_edit():
     _images(service).list.return_value.execute.side_effect = _make_http_error()
     client = _client(service)
 
-    with pytest.raises(HttpError):
+    with pytest.raises(PlayStoreClientError, match="Failed to list images"):
         client.list_images("com.example.app", "en-US", "icon")
 
     _edits(service).delete.assert_called_once_with(packageName="com.example.app", editId="edit-123")

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1134,7 +1134,9 @@ class TestCredentialsEndpointExtra:
         assert response.status_code == 500
         data = json.loads(response.body)
         assert data["success"] is False
-        assert "Internal error" in data["error"]
+        # Generic message; the raw exception detail must not leak to the client.
+        assert data["error"] == "Internal server error"
+        assert "boom" not in data["error"]
 
     @pytest.mark.asyncio
     async def test_success_without_shared_state(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,9 +9,6 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
-[manifest]
-constraints = [{ name = "pyjwt", specifier = ">=2.12.0" }]
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -45,11 +42,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -382,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "google-api-python-client"
-version = "2.188.0"
+version = "2.198.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -391,22 +388,22 @@ dependencies = [
     { name = "httplib2" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/d7/14613c7efbab5b428b400961f5dbac46ad9e019c44e1f3fd14d67c33111c/google_api_python_client-2.188.0.tar.gz", hash = "sha256:5c469db6614f071009e3e5bb8b6aeeccae3beb3647fa9c6cd97f0d551edde0b6", size = 14302906, upload-time = "2026-01-13T22:15:13.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/53/0cd38e3a29d72ce45e27feba2ce1cd8049d69af9c48cb14fb164f1be9133/google_api_python_client-2.198.0.tar.gz", hash = "sha256:dfe3e16fb241af6e9c460a33f65085b3450e05cea09364f6b5d8997fb7e43e2a", size = 15060142, upload-time = "2026-06-25T14:32:42.953Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/67/a99a7d79d7a37a67cb8008f1d7dcedc46d29c6df5063aeb446112afd4aa4/google_api_python_client-2.188.0-py3-none-any.whl", hash = "sha256:3cad1b68f9d48b82b93d77927e8370a6f43f33d97848242601f14a93a1c70ef5", size = 14870005, upload-time = "2026-01-13T22:15:11.345Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/92/0fc9e7a09eb240c31b879bd8d2e43f81ed1f86c4798b79ead4a083921ab3/google_api_python_client-2.198.0-py3-none-any.whl", hash = "sha256:fabac935474e817da5e662ff61bf7139439d6f92b32d332a7318a2d45931e03e", size = 15644203, upload-time = "2026-06-25T14:32:39.963Z" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.47.0"
+version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/3c/ec64b9a275ca22fa1cd3b6e77fefcf837b0732c890aa32d2bd21313d9b33/google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da", size = 323719, upload-time = "2026-01-06T21:55:31.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/18/79e9008530b79527e0d5f79e7eef08d3b179b7f851cfd3a2f27822fbdfa9/google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498", size = 234867, upload-time = "2026-01-06T21:55:28.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
 ]
 
 [[package]]
@@ -700,6 +697,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "structlog" },
 ]
 
@@ -719,6 +717,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -921,11 +920,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -1169,18 +1168,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1234,11 +1221,11 @@ wheels = [
 
 [[package]]
 name = "structlog"
-version = "25.5.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Remediates the findings from the full-codebase audit, re-validated against current `main` and extended to the newer subsystems (subscriptions, one-time products, external transactions, device tiers, uploads, users & grants, etc.).

## Fixes

### High
- **Retry actually protects API calls.** All 120 Play API `.execute()` calls now route through a retry-wrapped `_execute()`, so transient 429/500/503 errors retry with exponential backoff. Previously only lazy service init was wrapped, so every real operation (deploy, upload, list, purchases…) failed hard on a transient error.
- **`/credentials` endpoint hardened.** Added optional `PLAY_STORE_MCP_ADMIN_TOKEN` (constant-time `Bearer` check) that works behind a reverse proxy — where the built-in loopback check is meaningless because the peer is the proxy. Loopback-only behavior is preserved when no token is configured; docs updated with the caveat.

### Medium
- **pyjwt CVE-2026-32597 fix now reaches users** — moved `pyjwt[crypto]>=2.12.0` into `[project.dependencies]` (it was a `[tool.uv]` constraint that never shipped in published metadata).
- **Consistent error contract** — 7 read methods (`get_releases`, `get_app_details`, `get_listing`, `list_all_listings`, `list_apks/bundles/images`) plus `_create_edit` no longer leak raw `HttpError`; they raise `PlayStoreClientError`.
- **Orphaned edits fixed** — upload/image/testers write methods abandon the edit on *any* failure (not just `HttpError`), and `promote`/`halt`/`update_rollout` delete the edit before the "version not found" early return.
- **Pagination** — `list_subscriptions`, `list_one_time_products`, `list_purchase_option_offers`, `list_subscription_offers`, `list_device_tier_configs`, and `list_users` now follow `nextPageToken` (fixes silent truncation, including the security-relevant account-access user list).
- **Subscription `start_time`/`expiry_time`** now populated from the v2 response.
- **CI** — release publish gated on a test/lint/type job; `docker.yml` dropped to `contents: read`; blocking credential validation offloaded off the event loop.
- **Version** single-sourced via `importlib.metadata` (was a stale hard-coded `0.2.0`).

### Low
- `uv` pinned to 0.11.26 across workflows + digest-pinned in the Dockerfile; `revoke` `refund_type` guard; `OSError` handling in the download helpers; case-insensitive `.aab`; generic error messages (no exception-text leakage); broken `credentials_path` example fixed; stale `TESTING.md` corrected; dependency refresh (pygments→2.20.0 for CVE-2026-4539, certifi, google-*, structlog).

## Verification
- **695 tests pass, 100% branch coverage** (client/server/models).
- Local scans mimicking the GitHub workflows all clean: `ruff`, `ruff format --check`, `mypy`, `bandit`, `pip-audit` (no known vulnerabilities), `gitleaks` (no leaks), and a full `docker build`.
- Independent diff review passed; its one low-severity finding (`secrets.compare_digest` raising on a non-ASCII `Authorization` header → 500 instead of 401) was fixed and regression-tested.

## Deferred (non-behavioral, noted for follow-up)
- The edit-transaction dedup refactor.
- Trimming the always-null `error` field on raise-style `*Result` models (changing output shape) — left as-is to keep this PR focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now protect the credentials endpoint with a bearer token when running behind a reverse proxy.

* **Bug Fixes**
  * Added stricter access checks for credentials requests.
  * Improved error handling so invalid credentials return a clearer response, while unexpected failures are handled more safely.

* **Documentation**
  * Updated setup and remote-credentials guides with the new token-based access flow and example request headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->