### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "play-store-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for Google Play Developer API - deploy apps, manage releases, reviews, and more"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "play-store-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
Bump version **0.3.0 → 0.4.0**.

The `v0.3.0` tag (`a333035`, 2026-06-19) predates ~16 feature PRs (#62–#81) that added entire new subsystems — subscriptions catalog/base-plans/offers, one-time products, external transactions, device tier configs, data safety, app recovery, generated/system APKs, internal app sharing, edit uploads, listing images, users & grants, purchase management — none of which bumped the version. `client.py` grew from 1,720 → ~5,900 lines while still labeled `0.3.0`.

These are additive, backward-compatible features, so per semver this is a **minor** bump.

- `pyproject.toml` + `uv.lock` project version → `0.4.0` (only lines changed).
- `play_store_mcp.__version__` now resolves to `0.4.0` (single-sourced via `importlib.metadata`).
- 697 tests / 100% coverage, ruff clean.

Merge, then push a `v0.4.0` tag to trigger the release workflow. Independent of the deps-refresh PR (#83).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the app version from **0.3.0** to **0.4.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->