### PR TITLE
docs: add CHANGELOG.md (published on docs site)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Planned
+- Consolidate and reduce the MCP tool surface (currently 119 tools) by grouping
+  related operations, to lower per-request tool-list overhead — with no planned
+  loss of functionality.
+
+## [0.4.0] - 2026-07-02
+
+Major feature expansion: grows from ~24 to **119 MCP tools**, adding broad
+coverage of the Google Play Developer API, plus reliability/security hardening
+and a full dependency refresh.
+
+> **Note — write endpoints are beta.** The new write/mutating tools in this
+> release are covered by unit tests (mocked), but only read-only paths have been
+> exercised against the live Play API. Treat create/update/patch/delete/upload/
+> purchase-action/migrate tools as beta and
+> [open an issue](https://github.com/lusky3/play-store-mcp/issues) for any
+> problems. Run with `--read-only` / `PLAY_STORE_MCP_READ_ONLY=1` to disable all
+> write operations.
+
+> **Note — tool count.** 119 tools is a large surface for a single MCP server:
+> it increases per-request token usage and some clients cap/truncate large tool
+> lists. A follow-up release will reduce this.
+
+### Added
+- **Purchases & orders:** in-app product purchases (`get`/`acknowledge`/`consume`);
+  purchase management (`refund_order`, `cancel`/`defer`/`revoke_subscription_purchase`,
+  `get_product_purchase_v2`); `get_review`, `batch_get_orders`.
+- **Monetization catalog:** in-app products, subscriptions, subscription base
+  plans (incl. price migration), subscription offers, one-time products, and
+  one-time product purchase options & offers.
+- **Artifacts & uploads:** edit upload pipeline (APKs, app bundles, deobfuscation
+  and expansion files); store-listing images; generated APK list + download;
+  system APK variants; internal app sharing uploads.
+- **Account & configuration:** external transactions (alternative billing);
+  device tier configs; app data safety labels; app recovery actions; Play Console
+  account access (users & grants).
+- **Read-only mode:** `--read-only` / `PLAY_STORE_MCP_READ_ONLY` disables all write
+  operations.
+
+### Changed
+- Transient errors (429/500/503) are retried with exponential backoff on real API
+  calls, and the retry is idempotency-aware — non-idempotent (POST) mutations are
+  not retried on an ambiguous 5xx, to avoid duplicate side effects.
+- `/credentials` endpoint hardened: optional `PLAY_STORE_MCP_ADMIN_TOKEN`
+  (constant-time bearer check) for deployments behind a reverse proxy; blocking
+  credential validation moved off the event loop.
+- Consistent error contract: read methods raise `PlayStoreClientError` instead of
+  leaking raw `HttpError`, and edit transactions are always cleaned up on failure.
+- List endpoints now follow `nextPageToken` — fixes silent truncation (including
+  the account-access user list).
+- CI: PyPI publish gated on tests/lint/type-check; least-privilege Docker workflow
+  permissions; pinned `uv`.
+
+### Fixed
+- `list_app_recoveries` now sends the API-required `versionCode` (previously
+  rejected).
+- `__version__` is single-sourced from package metadata (was a stale `0.2.0`).
+- Case-insensitive `.aab` detection.
+- Subscription `start_time` / `expiry_time` populated from the v2 response.
+
+### Security
+- `pyjwt[crypto]>=2.12.0` is now a declared dependency so the CVE-2026-32597 fix
+  reaches installs, not just the lockfile.
+- Credential-update error responses no longer leak exception text.
+
+### Dependencies
+- Refreshed all dependencies to latest, including the majors **mypy 2.x** and
+  **protobuf 7.x**. Validated: 697 tests / 100% branch coverage, ruff/mypy clean,
+  pip-audit clean, and a live read-only API smoke.
+
+## [0.3.0] - 2026-06-19
+
+Security hardening, dependency upgrades, and CI improvements.
+
+### Added
+- Configurable DNS-rebinding protection via the
+  `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` environment variable (for cloud /
+  reverse-proxy deployments).
+
+### Changed
+- Upgraded `mcp` 1.26.0 → 1.28.0 and `cryptography` 46.0.7 → 49.0.0.
+- Hardened CI workflows, suppressed scanner false positives, and addressed
+  code-review findings.
+
+## [0.2.0] and earlier
+
+See the [GitHub Releases](https://github.com/lusky3/play-store-mcp/releases) page.
+
+[Unreleased]: https://github.com/lusky3/play-store-mcp/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/lusky3/play-store-mcp/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/lusky3/play-store-mcp/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-disable-file MD024 -->
+<!-- Keep a Changelog repeats "### Added"/"### Changed"/etc. across versions;
+     MD024 (no-duplicate-headings) is disabled for this file by design. -->
+
 # Changelog
 
 All notable changes to this project are documented in this file.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+---
+title: Changelog
+---
+
+<!-- Single source of truth: the root CHANGELOG.md is included below. -->
+
+--8<-- "CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,9 @@ markdown_extensions:
       alternate_style: true
   - tables
   - attr_list
+  - pymdownx.snippets:
+      base_path: ["."]
+      check_paths: true
 
 nav:
   - Home: index.md
@@ -59,3 +62,4 @@ nav:
       - Validation: tools/validation.md
   - Remote Credentials: remote-credentials.md
   - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md


### PR DESCRIPTION
Adds a maintained changelog (there wasn't one — release history only lived in GitHub Releases).

- **`CHANGELOG.md`** (root, [Keep a Changelog](https://keepachangelog.com) + SemVer) with:
  - **[0.4.0]** — the full entry for this release (Added / Changed / Fixed / Security / Dependencies), including the two release notes: write endpoints are **beta/untested against the live API** (open an issue), and the **119-tool** heads-up with a note that a follow-up release will reduce it.
  - **[0.3.0]** — back-filled (security hardening, `mcp`/`cryptography` upgrades, configurable DNS-rebinding protection).
  - **[Unreleased]** — the planned tool-count reduction.
  - 0.2.0 and earlier link to GitHub Releases.
- **Docs site:** published as a single source — `docs/changelog.md` includes the root `CHANGELOG.md` via `pymdownx.snippets` (no duplicated content), added to the MkDocs nav.

Validated locally with `mkdocs build --strict` (the changelog page renders with the included content).

Independent of the deps refresh (#83, merged) and the pending `v0.4.0` tag.