### PR TITLE
feat: opt-in CODE_MODE flag (experimental code-mode transform)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
 
+### Added
+- **Experimental code-mode (opt-in):** set `CODE_MODE=1` to expose tools through
+  FastMCP's code-mode transform (`search`/`get_schema`/`execute` meta-tools with a
+  sandboxed executor) instead of the full tool list, reducing per-request tool-list
+  token overhead. Off by default; requires the `play-store-mcp[code-mode]` extra
+  (Monty sandbox) for the `execute` tool. This is the first step of the tool-surface
+  reduction noted under Planned.
+
 ### Changed
 - Migrated the server framework from the official MCP SDK's `FastMCP`
   (`mcp.server.fastmcp`) to the standalone `fastmcp` package (v3). Behavior is

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ pip install "play-store-mcp[code-mode]"
 export CODE_MODE=1
 ```
 
+Under code mode one `execute` call can invoke up to 50 tool calls (including mutations) behind a single approval. Read-only enforcement still applies inside the sandbox, so pair it with `--read-only` / `PLAY_STORE_MCP_READ_ONLY=1` unless you need writes.
+
 ## 🔧 MCP Client Configuration
 
 ### Claude Desktop

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ play-store-mcp --read-only
 export PLAY_STORE_MCP_READ_ONLY=1
 ```
 
+### Code Mode (Experimental)
+
+Opt in to the experimental code-mode transform to serve the tools as three
+meta-tools (`search`/`get_schema`/`execute`) instead of the full tool list,
+cutting per-request tool-list token overhead. It is off by default. Install the
+sandbox extra and set the environment variable (`CODE_MODE` is env-only — there
+is no CLI flag):
+
+```bash
+pip install "play-store-mcp[code-mode]"
+export CODE_MODE=1
+```
+
 ## 🔧 MCP Client Configuration
 
 ### Claude Desktop
@@ -309,6 +322,7 @@ Add to `.kiro/settings/mcp.json`:
 | `PLAY_STORE_MCP_LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR) | No (default: INFO) |
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
+| `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `play-store-mcp[code-mode]` extra) | No (default: off) |
 
 ## 🧪 Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,14 @@ Code mode replaces the individual tools with three meta-tools — `search`,
 short script that calls them in a sandbox, rather than receiving the full tool
 list on every request. This cuts the per-request tool-list token overhead.
 
+!!! warning "Pair with read-only unless you need writes"
+    Under code mode a single `execute` call can invoke up to 50 tool calls —
+    including mutating operations (`deploy_app`, `refund_order`, `delete_*`,
+    `batch_*`) — behind one approval, rather than the client approving each call.
+    Read-only enforcement still applies inside the sandbox, so if the deployment
+    does not need writes, run code mode with `--read-only` /
+    `PLAY_STORE_MCP_READ_ONLY=1` to block those operations.
+
 Enabling it requires two things:
 
 1. Install the sandbox extra (the `execute` meta-tool runs in the Monty sandbox):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
+| `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No | off |
 
 ## HTTP Transport
 
@@ -145,6 +146,36 @@ Or the environment variable (truthy values: `1`, `true`, `yes`, `on`):
 ```bash
 export PLAY_STORE_MCP_READ_ONLY=1
 ```
+
+## Code Mode (Experimental)
+
+!!! warning "Experimental — off by default"
+    Code mode is opt-in and disabled by default. It wraps the tool surface in
+    FastMCP's experimental code-mode transform.
+
+Code mode replaces the individual tools with three meta-tools — `search`,
+`get_schema`, and `execute` — so the client discovers tools on demand and runs a
+short script that calls them in a sandbox, rather than receiving the full tool
+list on every request. This cuts the per-request tool-list token overhead.
+
+Enabling it requires two things:
+
+1. Install the sandbox extra (the `execute` meta-tool runs in the Monty sandbox):
+
+    ```bash
+    pip install "play-store-mcp[code-mode]"
+    # or: uvx --from "play-store-mcp[code-mode]" play-store-mcp
+    ```
+
+2. Set the environment variable (truthy values: `1`, `true`, `yes`, `on`):
+
+    ```bash
+    export CODE_MODE=1
+    ```
+
+`CODE_MODE` is an environment variable only — there is no CLI flag — because the
+transform is fixed when the server is constructed (before command-line arguments
+are parsed). When it is unset, the classic full tool surface is served unchanged.
 
 ## Logging
 

--- a/docs/superpowers/plans/2026-07-04-code-mode-flag.md
+++ b/docs/superpowers/plans/2026-07-04-code-mode-flag.md
@@ -1,0 +1,268 @@
+# Code-Mode Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `CODE_MODE` flag that wraps the server's tool surface in FastMCP's experimental `CodeMode` transform (discovery meta-tools + sandboxed `execute`), cutting per-request tool-list token overhead — shipping **default-off** while the feature is experimental.
+
+**Architecture:** Plan 2 of 2 (Plan 1 — the fastmcp v3 migration — is merged in #88). `CodeMode` lives in `fastmcp.experimental.transforms.code_mode` and is applied via the `FastMCP(..., transforms=[...])` constructor arg. When `CODE_MODE` is truthy, the server is built with `transforms=[CodeMode()]`, which replaces the 117 individual tools with three meta-tools (`search`, `get_schema`, `execute`); the LLM discovers tools and runs a script that calls them in a sandbox, returning only the final result. When off (default), `transforms=[]` and the classic 117-tool surface is unchanged. Because `transforms` is fixed at construction (module import, before `main()` parses argv), the flag is **environment-only** (`CODE_MODE`), unlike the call-time `--read-only`.
+
+**Tech Stack:** Python ≥3.11, `fastmcp` ≥3.4.2 (already a dep), the `fastmcp[code-mode]` extra (Monty sandbox — only needed at runtime for `execute`), `uv`/`uv.lock`, `pytest`+`pytest-cov` (branch), `ruff`, `mypy`, `bandit`.
+
+## Global Constraints
+
+- **Default OFF.** `CODE_MODE` unset / `0` / `false` / `no` / `off` → classic 117-tool surface, byte-for-byte current behavior. Only `1`/`true`/`yes`/`on` (case-insensitive) enable it. Mirror `_env_read_only()`'s parsing exactly.
+- **Environment-only flag** named `CODE_MODE` (no CLI flag — `transforms` is set at construction/import, before `main()`; document this).
+- **Experimental.** `CodeMode` is marked experimental by FastMCP; the startup log and docs must say so.
+- **Sandbox extra is opt-in.** The `execute` meta-tool's sandbox needs `fastmcp[code-mode]` (Monty). Keep it OUT of the base runtime deps (base install stays lean while default-off); expose it as a `code-mode` optional extra and add it to `dev` so tests/CI can exercise it.
+- **No behavior change when off.** All 117 tools, `/health` + `/credentials`, per-request credentials, admin-token auth, `--read-only`, and DNS-rebinding are untouched in the default path. Read-only gating still applies under code-mode (the guards run inside each tool wrapper, which the sandbox's `call_tool` still invokes).
+- **Coverage:** keep **100% branch coverage**. **Gates before push:** `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/`, `pip-audit` — all clean, mirroring CI.
+- **Commits/PRs carry no Claude attribution.**
+
+## Verified against the installed fastmcp 3.4.2 (do not re-derive)
+
+- `from fastmcp.experimental.transforms.code_mode import CodeMode` imports cleanly (even without the Monty extra).
+- `CodeMode.__init__(*, sandbox_provider=None, discovery_tools=None, execute_tool_name="execute", execute_description=None, max_tool_calls=50)`.
+- `FastMCP.__init__` accepts `transforms: Sequence[Transform] | None`.
+- `FastMCP("x", transforms=[CodeMode()])` then registering tools via `@mcp.tool` → `await mcp.list_tools()` returns exactly `["search", "get_schema", "execute"]` (underlying tools hidden behind the meta-tools). Tools registered *after* construction are picked up. Without the transform, `list_tools()` returns the real tools.
+- `monty` is NOT installed in the current env; `CodeMode()`/`MontySandboxProvider()` still construct (sandbox is created lazily at `execute` time), so enabling + listing works without the extra, but `execute` needs it.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `pyproject.toml` | Add `code-mode` optional extra; add `fastmcp[code-mode]` to `dev` | Modify |
+| `uv.lock` | Locked resolution incl. the sandbox extra for dev | Regenerated |
+| `src/play_store_mcp/server.py` | `_code_mode_enabled()`, `_build_transforms()`, `transforms=` in the `FastMCP(...)` constructor, startup log | Modify (near lines 143-160) |
+| `tests/test_server_extended.py` | Flag parsing + transform-building tests | Modify |
+| `CHANGELOG.md`, `docs/configuration.md`, `README.md` | Document `CODE_MODE` + the extra | Modify |
+
+`client.py` and `models.py` are untouched.
+
+---
+
+## Task 1: Add the `CODE_MODE` flag, the transform wiring, and the optional sandbox extra
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.optional-dependencies]`, ~lines 47-54)
+- Modify: `src/play_store_mcp/server.py` (add helpers above the `mcp = FastMCP(...)` construction ~line 158; add `transforms=` to the constructor)
+- Test: `tests/test_server_extended.py`
+
+**Interfaces:**
+- Produces: `_code_mode_enabled() -> bool`; `_build_transforms() -> list[Any]` (empty when off, `[CodeMode()]` when on); `mcp` constructed with `transforms=_build_transforms()`.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Add the `code-mode` optional extra and put it in `dev`**
+
+In `pyproject.toml`, under `[project.optional-dependencies]`, add a `code-mode` extra and include it in `dev` so tests can exercise the sandbox:
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=0.25.0",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.9.0",
+    "mypy>=1.14.0",
+    "fastmcp[code-mode]>=3.4.2",
+]
+code-mode = [
+    "fastmcp[code-mode]>=3.4.2",
+]
+```
+
+- [ ] **Step 2: Lock and sync**
+
+Run: `uv lock && uv sync --extra dev`
+Expected: resolves the `fastmcp[code-mode]` extra (pulls the Monty sandbox), exit 0.
+
+- [ ] **Step 3: Write the failing tests**
+
+Add to `tests/test_server_extended.py`:
+
+```python
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [("1", True), ("true", True), ("YES", True), ("on", True),
+     ("0", False), ("false", False), ("no", False), ("", False)],
+)
+def test_code_mode_flag_parsing(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
+    """CODE_MODE parses like the read-only flag (case-insensitive truthy set)."""
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", val)
+    assert server._code_mode_enabled() is expected
+
+
+def test_code_mode_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With CODE_MODE unset, no transforms are built (classic tool surface)."""
+    from play_store_mcp import server
+
+    monkeypatch.delenv("CODE_MODE", raising=False)
+    assert server._code_mode_enabled() is False
+    assert server._build_transforms() == []
+
+
+def test_build_transforms_enabled_wraps_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When enabled, _build_transforms() yields a CodeMode that exposes meta-tools."""
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", "1")
+    transforms = server._build_transforms()
+    assert len(transforms) == 1
+
+    probe = FastMCP("probe", transforms=transforms)
+
+    @probe.tool
+    def sample(x: int) -> int:
+        return x
+
+    names = {t.name for t in asyncio.run(probe.list_tools())}
+    assert names == {"search", "get_schema", "execute"}
+```
+
+- [ ] **Step 4: Run to verify they fail**
+
+Run: `uv run pytest tests/test_server_extended.py -k "code_mode or build_transforms" -v`
+Expected: FAIL — `server._code_mode_enabled` / `server._build_transforms` do not exist yet.
+
+- [ ] **Step 5: Add the helpers and wire the constructor**
+
+In `src/play_store_mcp/server.py`, immediately above the `mcp = FastMCP(...)` construction (currently ~line 158), add:
+
+```python
+def _code_mode_enabled() -> bool:
+    """Return True if CODE_MODE enables the experimental code-mode transform."""
+    return os.environ.get("CODE_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_transforms() -> list[Any]:
+    """Return the FastMCP transforms for this process.
+
+    When CODE_MODE is enabled, wrap the tool surface in the experimental CodeMode
+    transform (search/get_schema/execute meta-tools + sandboxed execution), which
+    cuts per-request tool-list overhead. Default: no transforms — the classic
+    117-tool surface, unchanged.
+    """
+    if not _code_mode_enabled():
+        return []
+    # Imported lazily so the base install (without the code-mode extra) never
+    # pays for it when the flag is off.
+    from fastmcp.experimental.transforms.code_mode import CodeMode
+
+    logger.warning(
+        "CODE_MODE enabled: exposing tools via the experimental code-mode transform "
+        "(search/get_schema/execute). The 'execute' sandbox requires the code-mode "
+        "extra — install play-store-mcp[code-mode]."
+    )
+    return [CodeMode()]
+```
+
+Then change the constructor (currently `mcp = FastMCP("Play Store MCP Server", lifespan=lifespan)`) to:
+
+```python
+mcp = FastMCP(
+    "Play Store MCP Server",
+    lifespan=lifespan,
+    transforms=_build_transforms(),
+)
+```
+
+- [ ] **Step 6: Run to verify they pass**
+
+Run: `uv run pytest tests/test_server_extended.py -k "code_mode or build_transforms" -v`
+Expected: PASS. The module-level `mcp` is still built with `CODE_MODE` unset in the test process, so the existing 117-tool tests are unaffected.
+
+- [ ] **Step 7: Full suite + coverage**
+
+Run: `uv run pytest -q --cov=src/play_store_mcp --cov-branch --cov-report=term-missing`
+Expected: all pass, **100%**. Both `_build_transforms()` branches (off → `[]`, on → `[CodeMode()]`) and `_code_mode_enabled()` truthy/falsy are covered by the three tests above.
+
+- [ ] **Step 8: Lint/type/security**
+
+Run: `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/`, `uv run mypy src/`, `uv run --with bandit bandit -r src/ -q`.
+Expected: clean. (`_build_transforms() -> list[Any]` satisfies mypy against `transforms: Sequence[Transform] | None`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/play_store_mcp/server.py tests/test_server_extended.py
+git commit -m "feat: add opt-in CODE_MODE flag wrapping tools in the fastmcp code-mode transform"
+```
+
+---
+
+## Task 2: Integration check, docs, changelog, and PR
+
+**Files:**
+- Modify: `CHANGELOG.md`, `docs/configuration.md`, `README.md`
+
+- [ ] **Step 1: Sandbox integration smoke (best-effort, documented)**
+
+With the `code-mode` extra installed (Task 1 Step 2), verify the meta-tools appear and — if the sandbox can initialize in this environment — that `execute` runs:
+
+Run:
+```bash
+CODE_MODE=1 uv run play-store-mcp --transport streamable-http --host 127.0.0.1 --port 8801 &
+sleep 3
+# The MCP tools/list should now advertise search/get_schema/execute rather than 117 tools.
+curl -s http://127.0.0.1:8801/health -w " (%{http_code})\n"
+kill %1
+```
+Confirm `/health` returns 200 and the server starts with the code-mode startup warning in stderr. A full `execute` round-trip depends on the Monty sandbox being runnable in the host (WASM/subprocess); if it cannot initialize here, record that the transform-level tests (Task 1) plus fastmcp's own upstream sandbox tests are the coverage, and note the limitation in the PR. Do **not** fabricate a passing sandbox run.
+
+- [ ] **Step 2: Document `CODE_MODE` in `docs/configuration.md`**
+
+Add a row to the environment-variable table and a short section:
+
+```markdown
+| `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No (default: off) |
+```
+
+And a subsection explaining: code-mode replaces the individual tools with `search`/`get_schema`/`execute` meta-tools to reduce per-request token overhead; it is experimental and off by default; enabling it requires installing `play-store-mcp[code-mode]` (Monty sandbox) and setting `CODE_MODE=1`; it is env-only (not a CLI flag) because the transform is fixed when the server is constructed.
+
+- [ ] **Step 3: Mention code-mode in `README.md`**
+
+Add a short line under the configuration/usage section noting the opt-in `CODE_MODE` flag and the `play-store-mcp[code-mode]` install extra, flagged experimental.
+
+- [ ] **Step 4: Update the changelog**
+
+In `CHANGELOG.md` under `## [Unreleased]`, add:
+
+```markdown
+### Added
+- **Experimental code-mode (opt-in):** set `CODE_MODE=1` to expose tools through
+  FastMCP's code-mode transform (`search`/`get_schema`/`execute` meta-tools with a
+  sandboxed executor) instead of the full tool list, reducing per-request tool-list
+  token overhead. Off by default; requires the `play-store-mcp[code-mode]` extra
+  (Monty sandbox) for the `execute` tool. This is the first step of the tool-surface
+  reduction noted under Planned.
+```
+
+- [ ] **Step 5: Full gate**
+
+Run the complete CI mirror: `uv run pytest -q --cov=src/play_store_mcp --cov-branch` (100%), `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/`, `pip-audit`. All clean.
+
+- [ ] **Step 6: Commit, push, draft PR**
+
+```bash
+git add CHANGELOG.md docs/configuration.md README.md
+git commit -m "docs: document the opt-in CODE_MODE flag and code-mode extra"
+git push -u origin feat/code-mode
+```
+Open a **draft** PR titled `feat: opt-in CODE_MODE flag (experimental code-mode transform)`, body covering the flag, default-off rationale, the optional sandbox extra, the env-only design, and the integration-check result. Do not mark ready / merge until CI is green.
+
+---
+
+## Self-Review
+
+**Spec coverage:** the `CODE_MODE` flag (env-only, default-off) → T1; the transform wiring + optional extra → T1; experimental/sandbox documentation → T2; changelog → T2. The user's stated requirement ("flag `CODE_MODE=` where true/1 uses code mode and false/0 off", default-off per the later rollout decision) is met by `_code_mode_enabled()` + the default-empty `_build_transforms()`.
+
+**Placeholders:** the only non-deterministic step is Task 2 Step 1 (whether the Monty sandbox can execute in the host), which ships with a concrete command, a pass criterion (`/health` 200 + startup warning + meta-tools advertised), and an explicit documented fallback — not a TBD.
+
+**Type consistency:** `_code_mode_enabled() -> bool` and `_build_transforms() -> list[Any]` are used consistently; the constructor receives `transforms=_build_transforms()`. All fastmcp APIs used (`CodeMode`, `transforms=`, `list_tools`) were verified against the installed 3.4.2 in the section above.
+
+**Note vs Plan 1:** unlike `--read-only` (a call-time mutable global), `CODE_MODE` must be read at construction/import because `transforms` is a constructor arg — hence env-only. A future CLI `--code-mode` would require building `mcp` lazily inside `main()`; out of scope here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.0",
     "mypy>=1.14.0",
+    "fastmcp[code-mode]>=3.4.2",
+]
+code-mode = [
+    "fastmcp[code-mode]>=3.4.2",
 ]
 
 [project.scripts]

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -159,10 +159,40 @@ def _read_only_block(operation: str) -> dict[str, Any] | None:
     return None
 
 
+def _code_mode_enabled() -> bool:
+    """Return True if CODE_MODE enables the experimental code-mode transform."""
+    return os.environ.get("CODE_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_transforms() -> list[Any]:
+    """Return the FastMCP transforms for this process.
+
+    When CODE_MODE is enabled, wrap the tool surface in the experimental CodeMode
+    transform (search/get_schema/execute meta-tools + sandboxed execution), which
+    cuts per-request tool-list overhead. Default: no transforms — the classic
+    117-tool surface, unchanged.
+    """
+    if not _code_mode_enabled():
+        return []
+    # Imported lazily so the base install (without the code-mode extra) never
+    # pays for it when the flag is off.
+    from fastmcp.experimental.transforms.code_mode import (  # noqa: PLC0415 - lazy import: code-mode extra is optional
+        CodeMode,
+    )
+
+    logger.warning(
+        "CODE_MODE enabled: exposing tools via the experimental code-mode transform "
+        "(search/get_schema/execute). The 'execute' sandbox requires the code-mode "
+        "extra — install play-store-mcp[code-mode]."
+    )
+    return [CodeMode()]
+
+
 # Initialize the MCP server
 mcp = FastMCP(
     "Play Store MCP Server",
     lifespan=lifespan,
+    transforms=_build_transforms(),
 )
 
 

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1269,3 +1269,38 @@ def test_build_transforms_enabled_wraps_tools(monkeypatch: pytest.MonkeyPatch) -
 
     names = {t.name for t in asyncio.run(probe.list_tools())}
     assert names == {"search", "get_schema", "execute"}
+
+
+def test_code_mode_preserves_read_only_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A write tool invoked through the code-mode sandbox is still blocked in read-only mode.
+
+    Registers the REAL refund_order wrapper (whose first statement is
+    _read_only_block) on a code-mode server and drives it through the sandbox's
+    call_tool, so this exercises the real guard through the real Monty sandbox
+    (requires the code-mode extra, present in dev).
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", "1")
+    monkeypatch.setattr(server, "READ_ONLY", True)
+
+    probe = FastMCP("probe", transforms=server._build_transforms())
+    probe.tool(server.refund_order)
+
+    result = asyncio.run(
+        probe.call_tool(
+            "execute",
+            {
+                "code": "return await call_tool('refund_order', "
+                "{'package_name': 'com.x', 'order_id': 'GPA.1'})"
+            },
+        )
+    )
+
+    text = result.content[0].text
+    assert "read-only" in text.lower()
+    assert "refund_order" in text

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1212,3 +1212,60 @@ class TestMainEntryPoint:
 
         assert os.environ["GOOGLE_PLAY_STORE_CREDENTIALS"] == "/path/to/creds.json"
         mock_run.assert_called_once()
+
+
+# =========================================================================
+# CODE_MODE flag + transform building
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("YES", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("", False),
+    ],
+)
+def test_code_mode_flag_parsing(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
+    """CODE_MODE parses like the read-only flag (case-insensitive truthy set)."""
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", val)
+    assert server._code_mode_enabled() is expected
+
+
+def test_code_mode_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With CODE_MODE unset, no transforms are built (classic tool surface)."""
+    from play_store_mcp import server
+
+    monkeypatch.delenv("CODE_MODE", raising=False)
+    assert server._code_mode_enabled() is False
+    assert server._build_transforms() == []
+
+
+def test_build_transforms_enabled_wraps_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When enabled, _build_transforms() yields a CodeMode that exposes meta-tools."""
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", "1")
+    transforms = server._build_transforms()
+    assert len(transforms) == 1
+
+    probe = FastMCP("probe", transforms=transforms)
+
+    @probe.tool
+    def sample(x: int) -> int:
+        return x
+
+    names = {t.name for t in asyncio.run(probe.list_tools())}
+    assert names == {"search", "get_schema", "execute"}

--- a/uv.lock
+++ b/uv.lock
@@ -564,6 +564,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
 ]
 
+[package.optional-dependencies]
+code-mode = [
+    { name = "fastmcp-slim", extra = ["code-mode"] },
+]
+
 [[package]]
 name = "fastmcp-slim"
 version = "3.4.2"
@@ -590,6 +595,9 @@ client = [
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "starlette" },
+]
+code-mode = [
+    { name = "pydantic-monty" },
 ]
 server = [
     { name = "authlib" },
@@ -1172,7 +1180,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+code-mode = [
+    { name = "fastmcp", extra = ["code-mode"] },
+]
 dev = [
+    { name = "fastmcp", extra = ["code-mode"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1183,6 +1195,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.2" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = ">=3.4.2" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = ">=3.4.2" },
     { name = "google-api-python-client", specifier = ">=2.180.0" },
     { name = "google-auth", specifier = ">=2.40.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
@@ -1194,7 +1208,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "structlog", specifier = ">=25.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "code-mode"]
 
 [[package]]
 name = "pluggy"
@@ -1407,6 +1421,65 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-monty"
+version = "0.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/f8/431ba0b79d02922811392c4e3d283d6508f7052ceaa1936cc34878703ecc/pydantic_monty-0.0.17.tar.gz", hash = "sha256:9c4904a8fbc63282793f3afd2d180124494c7fc371783f365e5691c9586360af", size = 1007724, upload-time = "2026-04-22T20:13:48.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/42/ca8e42d9f3318f5c454cf8b168d814ec97c6f2afc38756d4b1b806184f6d/pydantic_monty-0.0.17-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:af890d691f6055491a4e643dd5bf09e07bd7a20ad70038531aada6415ab8794a", size = 7344138, upload-time = "2026-04-22T20:13:29.155Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c8/cfaf0a56087301d4e88f72cf54ea45a7eebc09c021c85b8864447f1e3755/pydantic_monty-0.0.17-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2f38a69858dfdd2c9474156616d05e25a288e2080aee24152fa40c19ad425f0e", size = 7334903, upload-time = "2026-04-22T20:14:31.489Z" },
+    { url = "https://files.pythonhosted.org/packages/51/77/a751a6f73f854aa85fed94cfa5ecab21d7bf218c9fa03c96f9edf470cc4e/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bb88264e291cee56770a775f57125538c4713c6d362e89ee63bff506f650a0df", size = 7864258, upload-time = "2026-04-22T20:13:15.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/fe/2eb51eb37e9f712cada64fa8d7df4b63b1f5fc635290147ab158ff0e1ef1/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54c317611454aba8be7ca96aeeea9429f4702a5c4ba89812bea82bed0d8e34fd", size = 7138153, upload-time = "2026-04-22T20:14:22.255Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/15/835b10cdec3b96b089eef9899df6850b7f84a10225c491698b0ecf8e532a/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9563b5b4933f0f08c0e66ec66aaa4f43f2388bcc04b984e58aab2146dacd3829", size = 7443572, upload-time = "2026-04-22T20:13:17.951Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/aca140923fad8a2821a135cfeaa2fbb3321063bbadaa760424a016bb1ac6/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:35f267a501bc1910178a1515fdd3dd927273fbb44e44b8718cb3b33aee79f41b", size = 7967178, upload-time = "2026-04-22T20:14:06.032Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/7c4ff1e3fe2e82a4745decfca67b54a7a61cd306875e32d8e41c5192c69e/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35b000c52755f25f322ea7c4d079f09aa60635ffe24a6463899e423066a41bf3", size = 8198241, upload-time = "2026-04-22T20:15:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/30/0b/702db7b753b96ebc6713e7cbdfaecdb471df3e3cb0f0f6e828620a743b78/pydantic_monty-0.0.17-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61b517776ad13aa4580b1dd89188b18296ceeaf88256423563bbc99e804fd83f", size = 7768859, upload-time = "2026-04-22T20:13:20.044Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/8d16e0cc0c36d1444f25d57da68dd22216bf0961c457a482429cec32141b/pydantic_monty-0.0.17-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5da5362ef25665a23a3b13024497719f65cafa61d696cac76429f84701bee2e2", size = 7316674, upload-time = "2026-04-22T20:14:52.579Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/d47ae703d402e45475333c4bf11b117c8068305f00c1363dbaea13d0fd09/pydantic_monty-0.0.17-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7e655b6ddd552c02b751f1d57fc291fbd5654ff8b166a8bd634857879160d0b7", size = 7767515, upload-time = "2026-04-22T20:15:16.539Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9b/e17fb50d0df5cf9908f8fffa25c5909ed0eb92ca102ded06f7a6d6133e78/pydantic_monty-0.0.17-cp311-cp311-win32.whl", hash = "sha256:ea8b3ae8c42d572cefad841d3bda63cc458d9de2361cb9172914250e6dbe2c75", size = 7230347, upload-time = "2026-04-22T20:14:08.083Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/82/d3119f59652d04bcf69d671ddbd38464d5775fbc738a258d3c8f7800e29d/pydantic_monty-0.0.17-cp311-cp311-win_amd64.whl", hash = "sha256:3293c2f7524bfc7c3d8c794f1c1dc1eb4cf9c65a5e222061e2218ced85f3f6df", size = 8074183, upload-time = "2026-04-22T20:14:50.42Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/31/95827babdb35149f076c5d191b6b1e7a7c58f4bc72432f905e02e4e3231e/pydantic_monty-0.0.17-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27c2254fa7a7b05e969f79578889230d293c62e0b1ee28371ec4f3c54b14426a", size = 7342248, upload-time = "2026-04-22T20:15:18.775Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/67/ca9cfc07cd445d22def53e9db86912f9ae3e11ef772ce41c2ff41a47eac5/pydantic_monty-0.0.17-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:445cc471ce6f5a88ef06741b7ebc7002a2253d182f55a2f47094d4adedaaf497", size = 7311255, upload-time = "2026-04-22T20:15:27.913Z" },
+    { url = "https://files.pythonhosted.org/packages/df/96/abc9c4972d91a9673435b84e12b99d038e42d1f99648fc9e5f242e09d00e/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:39121038405911f59da7bf61164251f59bad3fb1b0cd28f43c42c3949eee2c8a", size = 7868109, upload-time = "2026-04-22T20:15:04.779Z" },
+    { url = "https://files.pythonhosted.org/packages/75/82/9e4d55529bb99d882b9277a721762537a8bc1345ab1d052bb614a88bd15b/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dafc8ffe57c257002f623afdb7d0e41f73de850179ebd90b42611e4f2b6f9884", size = 7139709, upload-time = "2026-04-22T20:15:25.386Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/f1af6acefb7bb38d73934d6853998bbd327de7418b811372519080d9fd84/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ea00838ef8f37dcd8085defcbdfe89fdd05297a6533f1d3f4cad857d13cedc7b", size = 7450444, upload-time = "2026-04-22T20:13:37.974Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/af92ef409e1c065345cf1451bbcf19e00f70a250b8372ec65143ca9a9238/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:683d18089acf14d0de293245b9e37c7f0ec64e6d266f6773144211931aa3ec97", size = 7967525, upload-time = "2026-04-22T20:13:42.674Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1f/23ecd6e268ef24ce6b0fe4a1e76a314990d2e923ac5791e29d657418243d/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1829993dd50cf497cbed66ea9f6c8ff7d157d22592a05c7399f92fb8a549e3c", size = 8199124, upload-time = "2026-04-22T20:15:00.02Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2a/36b694ea0c7e202250a81a57faf00f218738da6c5d070c752f2d81cd34ce/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a7869e3f41a54cc588096c52a8a4de25ecd81e75c867ea4164b14ea1ae1a57f", size = 7739623, upload-time = "2026-04-22T20:14:37.57Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e5/090357d7bc0f0751d1afbb71330695fa26554699c88ba56ecaad91657088/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f9c17663e2c6f07aec5bc54cd7e39a9e20f250a97a9081e1b2b932eb00d0afc5", size = 7317755, upload-time = "2026-04-22T20:14:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/15/63/67200070cf33325ecfda81d4aee3bf312250ce80bd73058103e04e0f3587/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5d2cf98afe2fb124f6ade91d9663d54277478cad417164f83df1854a41ef450c", size = 7769158, upload-time = "2026-04-22T20:14:39.611Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/9ecfbc2f45406cfb247fafdea4f4a8412db3e559a22c4385eb15266ba2c1/pydantic_monty-0.0.17-cp312-cp312-win32.whl", hash = "sha256:b2185cc4effbbd6793eed4e0f0bcb6a3dbfbb3289ea4d47888708813f0a3dd47", size = 7227917, upload-time = "2026-04-22T20:14:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/80/9be3bef8273817ccc17da25c3ce4ff5d5d45e5629c17eacc90cdef073821/pydantic_monty-0.0.17-cp312-cp312-win_amd64.whl", hash = "sha256:7833daed757ec9b09b627cc3577a4a76b114c5148f779531d7cfdb1095bcf0a9", size = 8043469, upload-time = "2026-04-22T20:13:22.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/44/0e106b8b27eb93b66e4f3d279486464e05ba5ee31088848e58b5f506f879/pydantic_monty-0.0.17-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0cdac8c3c16477596bc96ee1cec4f2fbaccd089e2daa1e7b9f227cc89f97cb1", size = 7341507, upload-time = "2026-04-22T20:14:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/88/a0315fa08e62e2d1ef00c03d8202d7bef3f1f71543bebfb916fea265c0a2/pydantic_monty-0.0.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37290d6a1c35aba5cfb8b490bb31c0d822e8ddca8f3ca9ea068e30930d80dd1e", size = 7311916, upload-time = "2026-04-22T20:13:34.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e5/e4da6acb408594cbfbfb8dd3c0491b9b2ee54e9183e7ebc5f584baa07af9/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:49f252b2fb918686d3e8f76cb30245e782d1560a7fa68dbc0f6940d83c12bd41", size = 7867465, upload-time = "2026-04-22T20:13:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/64c2f8eb708a743b0944ea8f71dfd51bc655285b4be28d55577dafbb29fa/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2254d25c34463d67069f5f1567157bde9311654cd5371f8933b8ea9815bfa26a", size = 7139262, upload-time = "2026-04-22T20:14:10.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/67/5d766f9cd304e871a5dfe5f0a85eaa533538ef07e9b2858fdf9f37f83694/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0688a1fa5dc045ac7b7e996d7269b94f74f116d7b1e352c7b5bb5ad53d4fe03", size = 7450119, upload-time = "2026-04-22T20:13:44.515Z" },
+    { url = "https://files.pythonhosted.org/packages/33/98/fa16779021d93edb19807e87cdba56bbec6adfad21f10b41a212572ce513/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b35121ac555ed201405c69d531e4cb916da6984b8cd2e15c8a319117349faf6", size = 7967398, upload-time = "2026-04-22T20:13:55.576Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/287a42720bc9e975ab5b52625aa9fc6bcef8298dd821022cc45c6ee1808d/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c97dc44af25d4392b474902fc40f78f09fe8f44ba791364670334fe12abc077", size = 8198835, upload-time = "2026-04-22T20:15:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/97/37/03edb1fd582b79b2b462afc3fea5e1c8fea73afefc4870dc35fc3c7c492e/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ed2fb365ef9ca921de9a17786ecfa2efe06e65678e6ca57be51658a2a880f31", size = 7739241, upload-time = "2026-04-22T20:13:46.925Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/b765c9ca2ae27def1caa07345aba073ae1239fc2d9cca7a375f3dc2195f7/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5bf9f07b38dd12747e3c95b169a5afb3e2e9107622e01e548246c84d19a69c99", size = 7316719, upload-time = "2026-04-22T20:14:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3b/64fe872cd575ab5262e1ba2959554ead198c939cfaa425f7f8e9b1ad2694/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a5e9bafd4b5acbc0a8e12ee8403a3ce37281c3b0fa5909d3f412bee76c69003c", size = 7769150, upload-time = "2026-04-22T20:13:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/b6a0bb41f39bac2e11e6a2fd42ca0886893fafa6344fb17c3f0a94e22e83/pydantic_monty-0.0.17-cp313-cp313-win32.whl", hash = "sha256:1c239ae3e610d3f39cd1609285209a4e2d046b465ac1bfed0d4374c615eed0fa", size = 7227705, upload-time = "2026-04-22T20:15:12.262Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/d8cd62f537f7ab17714ee19ea221a0e341dab407215376ab1c41d79794c9/pydantic_monty-0.0.17-cp313-cp313-win_amd64.whl", hash = "sha256:1886c3590b02f359ae991f1e76691064f167330eda4fbf22762127ce17d0eb48", size = 8043469, upload-time = "2026-04-22T20:14:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c0/8354baf835e1a04c4b9e11d253f82df7d625a9305e6a23a177fb895b1484/pydantic_monty-0.0.17-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a166bd04d1996f0d144fbb5e1391cd1c0fbdacd4fa3b689dd48931388679fe98", size = 7341303, upload-time = "2026-04-22T20:14:35.653Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ac/d58221b5e17915421ca00bb08b805ac121b6accb194785d5422da4a2f5fc/pydantic_monty-0.0.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d82f319e3fd79707a7b81bbb68596509d14ac73502d2f0daf4ab5d281efdfbdc", size = 7318912, upload-time = "2026-04-22T20:13:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3f/8eeb8f652f6cd6e06a737aa9f00de2949e37a669b31756bc51b6182457b4/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f38b9875f7ff56fe69538b60b2ecbdcbe2b8b7780407ceb05fe0ee1414bf8d19", size = 7867027, upload-time = "2026-04-22T20:13:51.426Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/ec6620c27c8b4cada6ce53378c52c245e238e50a20b968cafdc1b8573c4e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74a778bb5a4dcdbc85b3b9002f9a72a43fb6ffd88635bfdd502e8d3053008337", size = 7137542, upload-time = "2026-04-22T20:13:35.939Z" },
+    { url = "https://files.pythonhosted.org/packages/41/78/5419785630511b54b15cfb094871bcb53ec9025ba8d91bd7ab5b22b6c98f/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e2ab074a65738e9c1b4be9a432e7ca1e9987a6706018dc7a5af6d4ce7cecdf3", size = 7450222, upload-time = "2026-04-22T20:13:53.378Z" },
+    { url = "https://files.pythonhosted.org/packages/61/04/cec11fa96a47034da3c21af53e73f43d2270f5ce96cd710809859fe9c0b2/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00fd1cd28b4200c9ccd02629868486b366af1bfe1f0584d4c9e513b7a941a868", size = 7967405, upload-time = "2026-04-22T20:14:03.826Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e3/f2be0fb975100b6936ca36a8410098f10fab3b26729c0b0d1de2fac59ff3/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ea6684555bfd00cbe9d2df3e73caada3d82200c168c63cc475197b55b88401", size = 8199028, upload-time = "2026-04-22T20:13:26.802Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/43/358bdaa9c50d21fe4a25a71d43ce9af2d6796616fa47aca84f807433564e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f804a03a3bbd0cf0ade1d4ce11b50ca6858e9c4440b27c746faf1d3c0a272954", size = 7749903, upload-time = "2026-04-22T20:15:09.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/8bcd0a78abf13edceca36aaf5c180fad963e4c2e042fd7247b9e96048306/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:b5476e6c08b86b0bea554b97ce9b142aac1177447f2d3c5751864b27991fd1b1", size = 7312704, upload-time = "2026-04-22T20:14:33.668Z" },
+    { url = "https://files.pythonhosted.org/packages/88/49/5de8bb7f8b82c3ebb8f2485e0b7a40055b072193039d95dcb5d35fcba72c/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b5fcdcca45439844bee268686f37226dbf5803ec7a5945f5536c41419f151dac", size = 7768902, upload-time = "2026-04-22T20:14:29.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7c/500a002f1a52f17c8b8a989875da3e1590c18ce95c89856aa967e2348a36/pydantic_monty-0.0.17-cp314-cp314-win32.whl", hash = "sha256:4dd3e6e80a415e7272f7a7583a4f8e045096653f6074e181117eb61fc8fe3b45", size = 7227049, upload-time = "2026-04-22T20:14:01.871Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/b8f552f2a863778f49ebb708f18aaf0bfb275480a48965786e06efacf1c4/pydantic_monty-0.0.17-cp314-cp314-win_amd64.whl", hash = "sha256:36a8090a628e8cf91df8f66c721a71050ac8f48473d4992b9afbd9585941a647", size = 8062999, upload-time = "2026-04-22T20:14:44.006Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an **opt-in, default-off** `CODE_MODE` flag that wraps the tool surface in FastMCP's experimental **code-mode** transform. When enabled, the server exposes three meta-tools — `search` / `get_schema` / `execute` — instead of the full 117-tool list: the LLM discovers tools on demand and runs a script that calls them in a sandbox, returning only the final result. This cuts per-request tool-list token overhead (the first step of the tool-surface reduction noted under CHANGELOG → Planned).

This is **Plan 2 of 2**, following the fastmcp v3 migration (#88) which was done specifically to unblock code-mode (it lives only in `fastmcp`, at `fastmcp.experimental.transforms.code_mode`).

Executed sub-agent-driven from `docs/superpowers/plans/2026-07-04-code-mode-flag.md`, with independent diff/gate review at each task boundary.

## What changed

- **`CODE_MODE` env flag** (parsed like `--read-only`: `1`/`true`/`yes`/`on`). `_code_mode_enabled()` + `_build_transforms()` → `[CodeMode()]` when on, `[]` when off, passed to the `FastMCP(...)` constructor.
- **Env-only, by design:** `transforms` is fixed when `mcp` is constructed (module import, before `main()` parses argv), so unlike `--read-only` there is no CLI flag. Documented.
- **Optional `code-mode` extra:** the `execute` sandbox (Monty) is only needed at runtime when enabled, so it's an opt-in extra (`pip install "play-store-mcp[code-mode]"`) kept out of the lean base install; added to `dev` for CI/tests.
- **Startup warning** when enabled: flags the feature experimental and points at the extra.
- Docs (`configuration.md`, `README.md`) + CHANGELOG.

## Default-off / behavior parity

With `CODE_MODE` unset, `transforms=[]` and the server is byte-for-byte identical to today (all 117 tools, `/health` + `/credentials`, per-request creds, admin-token auth, `--read-only`, DNS-rebinding). Read-only gating still applies under code-mode — the guards run inside each tool wrapper, which the sandbox's `call_tool` still invokes.

## Verification

- **`pytest`:** 717 passed, 17 skipped, **100% branch coverage**. New tests cover flag parsing (both truthy/falsy) and both `_build_transforms()` branches, asserting the enabled path yields exactly `{search, get_schema, execute}`.
- **`ruff` / `ruff format` / `mypy` / `bandit`:** clean. **`pip-audit`:** no known vulns.
- **Live end-to-end:** with `CODE_MODE=1`, the server boots (`/health` 200, experimental warning fires) and a real **sandbox `execute` round-trip ran successfully** in the dev env (`call_tool('add', {a:2,b:3})` → `{result: 5}`) — the meta-tools work, not just the transform wiring.

## Notes

- Every fastmcp API here was verified against the **installed 3.4.2** (constructor `transforms=`, `CodeMode()`, meta-tool swap) rather than docs.
- Version left at `0.4.0` under `[Unreleased]`; this Added feature is a minor-bump candidate at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental, opt-in code mode that can simplify the available tool surface into three meta-tools and reduce tool-list overhead.
  * Code mode is off by default and can be enabled with an environment setting.

* **Documentation**
  * Expanded setup and configuration docs with code mode usage, enabling steps, and safety notes.
  * Added release notes and a planning doc for the new option.

* **Chores**
  * Updated dependency extras to support the new experimental code mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->