### PR TITLE
fix: re-audit follow-ups — shared-client thread safety, test speedup, credential-isolation docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ Configure your MCP client to send the header:
 }
 ```
 
-Per-request credentials are isolated — each request uses only the credentials provided in its headers. No credentials are stored server-side or shared between requests.
+Per-request credentials are isolated — each request uses only the credentials provided in its headers. **This isolation applies only to the per-request header path.** If you also configure a server-side fallback (the `GOOGLE_PLAY_STORE_CREDENTIALS` env var, or a `/credentials` POST), that fallback client is process-global and is shared by every request that does *not* send a credential header — such a request executes under the shared identity rather than failing. For multi-tenant or public deployments, do **not** configure fallback credentials, so a request missing its credential header fails closed instead of using another identity.
 
 ## Read-Only Mode
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -9,6 +9,7 @@ import os
 import random
 import re
 import tempfile
+import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -244,6 +245,10 @@ class PlayStoreClient:
         self._credentials_json = credentials_json or os.environ.get("GOOGLE_PLAY_STORE_CREDENTIALS")
         self._application_name = application_name
         self._service: AndroidPublisherResource | None = None
+        # Serializes API I/O on this client's single (non-thread-safe) httplib2
+        # transport. The shared fallback client is used across concurrent tool
+        # worker threads; per-request header clients each get their own lock.
+        self._http_lock = threading.Lock()
         self._logger = logger.bind(component="PlayStoreClient")
 
     # =========================================================================
@@ -440,7 +445,14 @@ class PlayStoreClient:
         """
         method = (getattr(request, "method", "") or "").upper()
         retry_server_errors = method in _IDEMPOTENT_HTTP_METHODS
-        return _run_with_backoff(request.execute, retry_server_errors=retry_server_errors)
+
+        def _locked_execute() -> Any:
+            # Hold the lock only around the actual transport call, not the
+            # backoff sleep between attempts, so retries don't serialize waits.
+            with self._http_lock:
+                return request.execute()
+
+        return _run_with_backoff(_locked_execute, retry_server_errors=retry_server_errors)
 
     def _create_edit(self, package_name: str) -> str:
         """Create a new edit for the package.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
+
+import structlog
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -11,6 +15,16 @@ if TYPE_CHECKING:
 import pytest
 
 from play_store_mcp.client import PlayStoreClient
+
+# Suppress structlog's Rich-rendered tracebacks (fastmcp pulls in `rich`) on the
+# ~130 client error/warning log sites the error-path tests hit — a ~16x suite
+# slowdown. Two paths configure structlog: filter here at CRITICAL for tests that
+# import only the client (structlog's default config is unfiltered + Rich), and
+# set the env var so the server module — when a test imports it — also configures
+# at CRITICAL rather than INFO. Both drop WARNING/ERROR before any renderer runs.
+# Overridable by exporting PLAY_STORE_MCP_LOG_LEVEL.
+os.environ.setdefault("PLAY_STORE_MCP_LOG_LEVEL", "CRITICAL")
+structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -124,6 +124,31 @@ class TestExecuteRetryThroughOperation:
         assert ack.execute.call_count == 2
 
 
+class TestExecuteThreadSafety:
+    """The client serializes its (non-thread-safe httplib2) transport via a per-client lock."""
+
+    def test_execute_holds_lock_around_request(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """_http_lock is held while request.execute() runs, and released afterwards."""
+        get_req = _mock_service.orders.return_value.get.return_value
+        get_req.method = "GET"
+        observed: dict[str, bool] = {}
+
+        def fake_execute() -> dict[str, Any]:
+            observed["locked_during_call"] = client._http_lock.locked()
+            return {"orderId": "o1", "state": "PROCESSED", "lineItems": []}
+
+        get_req.execute.side_effect = fake_execute
+
+        client.get_order("com.example.app", "o1")
+
+        assert observed["locked_during_call"] is True
+        assert client._http_lock.locked() is False
+
+
 # =========================================================================
 # Finding 2: _parse_rfc3339
 # =========================================================================


### PR DESCRIPTION
## Summary

The three **main-applicable** findings from the full re-audit of the current codebase (the other two findings, M2/M3, are code-mode-specific and are going onto PR #89 where code-mode lives). All pre-existing; independent of code-mode.

## Fixes

- **H1 (HIGH) — shared-client transport thread safety.** The re-audit established (and I verified empirically) that fastmcp v3 dispatches sync `@mcp.tool` functions on an **anyio threadpool**, so concurrent tool calls run on separate threads. The shared fallback `PlayStoreClient` caches one `httplib2` transport, which is **not thread-safe** — concurrent calls could interleave on one connection (`ResponseNotReady`, SSL errors, or a response delivered to the wrong caller). Adds a per-client `threading.Lock` held only around `request.execute()` (released during backoff sleep, so retries don't serialize their waits). Per-request header-auth clients each get their own client+lock, so they stay concurrent. Regression test asserts the lock is held during `execute` and released after.

- **M4 (MEDIUM) — 16× test-suite slowdown.** fastmcp v3 pulls in `rich`; structlog's `ConsoleRenderer` renders a full Rich traceback on every client `logger.exception`/`.warning`, and ~115 error-path tests hit ~130 such sites. `conftest.py` now filters structlog at CRITICAL (and sets the log-level env for the server path) so WARNING/ERROR are dropped before any renderer runs. **Suite ~38s → ~2.4s.** (No test asserts on logs — verified.)

- **M1 (MEDIUM) — credential-isolation docs correction.** `docs/configuration.md` claimed "No credentials are stored server-side or shared between requests" — false for the `GOOGLE_PLAY_STORE_CREDENTIALS` / `/credentials` fallback, which is a process-global client shared by every request that omits a credential header (a header-less request silently runs under the shared identity). Clarifies that the isolation guarantee applies only to the per-request header path, and advises multi-tenant/public deployments not to configure fallback creds so a missing header fails closed.

## Verification

- **708 passed, 17 skipped, 100% branch coverage**; `ruff` / `ruff format` / `mypy` / `bandit` clean; `pip-audit` clean (unchanged deps).
- H1 basis verified live: two concurrent sync tool calls ran on 2 distinct threads over the same time window.
- M4 verified: suite drops to ~2.4s with the conftest change.

## Not in this PR (routed elsewhere)

- **M2** (pair code-mode with `--read-only`; consider lower `max_tool_calls`) and **M3** (a code-mode `execute` read-only-enforcement regression test) are code-mode-specific and are being added to **PR #89** (code-mode), since M3's test requires code-mode to exist. The re-audit's LOW/informational items (typed `_shared_state`, raw-dict result models, naming/batch consistency, CI-perms hardening) are noted for the planned tool-consolidation refactor.