### PR TITLE
fix: get_crash_rate requests invalid metric combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Add to your `claude_desktop_config.json`:
 | --- | --- |
 | `list_in_app_products` | List all in-app products for an app |
 | `get_in_app_product` | Get details of a specific in-app product |
+| `consume_product_purchase` | Consume a one-time in-app product purchase so it can be repurchased |
 
 ### Testers Management Tools
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Add to your `claude_desktop_config.json`:
 | --- | --- |
 | `get_listing` | Get store listing for a specific language |
 | `update_listing` | Update store listing (title, descriptions, video) |
+| `batch_update_listings` | Dry-run or commit listing updates across languages |
 | `list_all_listings` | List all store listings for all languages |
 
 ### Review Tools
@@ -324,6 +325,15 @@ update_listing(
 
 # Get all listings
 listings = list_all_listings(package_name="com.example.myapp")
+
+# Dry-run batch listing updates across languages
+batch_result = batch_update_listings(
+    package_name="com.example.myapp",
+    updates=[
+        {"language": "en-US", "title": "My Awesome App"},
+        {"language": "es-ES", "short_description": "Una app de productividad"},
+    ],
+)
 ```
 
 ### Manage Testers

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -44,6 +44,7 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 |---|---|
 | [`list_in_app_products`](tools/subscriptions.md#list_in_app_products) | List all in-app products |
 | [`get_in_app_product`](tools/subscriptions.md#get_in_app_product) | Get details of a specific product |
+| [`consume_product_purchase`](tools/subscriptions.md#consume_product_purchase) | Consume a one-time in-app product purchase |
 
 ## Testers Tools
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -20,6 +20,7 @@ Complete reference for all MCP tools provided by the Play Store MCP server.
 |---|---|
 | [`get_listing`](tools/store-listings.md#get_listing) | Get store listing for a language |
 | [`update_listing`](tools/store-listings.md#update_listing) | Update store listing text and video |
+| [`batch_update_listings`](tools/store-listings.md#batch_update_listings) | Dry-run or commit listing updates across languages |
 | [`list_all_listings`](tools/store-listings.md#list_all_listings) | List all store listings across languages |
 
 ## Review Tools

--- a/docs/tools/store-listings.md
+++ b/docs/tools/store-listings.md
@@ -5,7 +5,7 @@ Tools for managing app store listings across languages.
 !!! info "Text Limits"
     | Field | Max Length |
     |---|---|
-    | Title | 50 characters |
+    | Title | 30 characters |
     | Short description | 80 characters |
     | Full description | 4,000 characters |
 
@@ -38,7 +38,7 @@ Update the store listing for a specific language. Only provided fields are updat
 |---|---|---|---|
 | `package_name` | string | Yes | App package name |
 | `language` | string | Yes | Language code |
-| `title` | string | No | App title (max 50 chars) |
+| `title` | string | No | App title (max 30 chars) |
 | `full_description` | string | No | Full description (max 4,000 chars) |
 | `short_description` | string | No | Short description (max 80 chars) |
 | `video` | string | No | YouTube video URL |
@@ -52,6 +52,35 @@ update_listing(
     full_description="A comprehensive productivity app that helps you..."
 )
 ```
+
+---
+
+## batch_update_listings
+
+Validate or update store listings for multiple languages. This tool is a dry-run by default:
+it validates all requested text locally and does not create a Google Play edit unless
+`commit=True` is explicitly set.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `package_name` | string | Yes | — | App package name |
+| `updates` | list | Yes | — | Listing updates by language |
+| `commit` | boolean | No | `False` | Commit changes to Google Play when true |
+
+Each `updates` item must include `language` and may include any of `title`,
+`short_description`, `full_description`, and `video`.
+
+```python
+batch_update_listings(
+    package_name="com.example.myapp",
+    updates=[
+        {"language": "en-US", "title": "My App", "short_description": "A better app"},
+        {"language": "es-ES", "title": "Mi App"},
+    ],
+)
+```
+
+Set `commit=True` only after reviewing a successful dry-run result.
 
 ---
 

--- a/docs/tools/subscriptions.md
+++ b/docs/tools/subscriptions.md
@@ -87,3 +87,25 @@ Get details of a specific in-app product.
 ```python
 get_in_app_product("com.example.myapp", sku="premium_upgrade")
 ```
+
+---
+
+## consume_product_purchase
+
+Consume a one-time in-app product purchase after granting entitlement, making the consumable product available for repurchase.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `package_name` | string | Yes | App package name |
+| `product_id` | string | Yes | In-app product SKU |
+| `token` | string | Yes | Purchase token from the client app |
+
+Returns: `success`, `package_name`, `product_id`, `purchase_token`, `message`, `error`
+
+```python
+consume_product_purchase(
+    package_name="com.example.myapp",
+    product_id="coins_100",
+    token="token-from-client-app"
+)
+```

--- a/docs/tools/validation.md
+++ b/docs/tools/validation.md
@@ -59,7 +59,7 @@ Validate store listing text lengths before updating.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `title` | string | No | App title (max 50 characters) |
+| `title` | string | No | App title (max 30 characters) |
 | `short_description` | string | No | Short description (max 80 characters) |
 | `full_description` | string | No | Full description (max 4,000 characters) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "play-store-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "MCP server for Google Play Developer API - deploy apps, manage releases, reviews, and more"
 readme = "README.md"
 license = "MIT"

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -1056,7 +1056,7 @@ class PlayStoreClient:
                             comment=user_comment.get("text", ""),
                             language=user_comment.get("reviewerLanguage", "en"),
                             device=user_comment.get("device"),
-                            android_version=user_comment.get("androidOsVersion"),
+                            android_version=str(user_comment["androidOsVersion"]) if user_comment.get("androidOsVersion") is not None else None,
                             app_version_code=user_comment.get("appVersionCode"),
                             app_version_name=user_comment.get("appVersionName"),
                             developer_reply=dev_comment.get("text") if dev_comment else None,

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -2938,6 +2938,17 @@ class PlayStoreClient:
         parts = date_str.split("-")
         return {"year": int(parts[0]), "month": int(parts[1]), "day": int(parts[2])}
 
+    # Maps metric set name → vitals sub-resource method name in the client library
+    _METRIC_SET_RESOURCE: dict[str, str] = {
+        "crashRateMetricSet": "crashrate",
+        "anrRateMetricSet": "anrrate",
+        "slowStartRateMetricSet": "slowstartrate",
+        "slowRenderingRateMetricSet": "slowrenderingrate",
+        "excessiveWakeupRateMetricSet": "excessivewakeuprate",
+        "stuckBackgroundWakelockRateMetricSet": "stuckbackgroundwakelockrate",
+        "lmkRateMetricSet": "lmkrate",
+    }
+
     def _query_metric_set(
         self,
         package_name: str,
@@ -2948,27 +2959,13 @@ class PlayStoreClient:
         end_date: str,
         aggregation_period: str = "DAILY",
     ) -> "VitalsQueryResult":
-        """Generic helper to query any Reporting API metric set.
-
-        Args:
-            package_name: App package name.
-            metric_set_name: e.g. 'crashRateMetricSet', 'anrRateMetricSet'.
-            metrics: List of metric names to retrieve.
-            dimensions: List of dimension names to group by.
-            start_date: Start date as YYYY-MM-DD.
-            end_date: End date as YYYY-MM-DD (exclusive).
-            aggregation_period: 'DAILY' or 'HOURLY'.
-
-        Returns:
-            VitalsQueryResult with timeline data points.
-        """
+        """Generic helper to query any Reporting API metric set."""
         from play_store_mcp.models import VitalsDataPoint, VitalsQueryResult
 
         service = self._get_reporting_service()
-        parent = f"apps/{package_name}"
 
         body: dict[str, Any] = {
-            "timeline": {
+            "timelineSpec": {
                 "aggregationPeriod": aggregation_period,
                 "startTime": self._build_time_unit(start_date),
                 "endTime": self._build_time_unit(end_date),
@@ -2986,9 +2983,15 @@ class PlayStoreClient:
             end=end_date,
         )
 
+        resource_method = self._METRIC_SET_RESOURCE.get(metric_set_name)
+        if not resource_method:
+            raise PlayStoreClientError(f"Unknown metric set: {metric_set_name}")
+
         try:
-            resource = getattr(service, metric_set_name)()
-            result = resource.query(name=f"{parent}/{metric_set_name}", body=body).execute()
+            resource = getattr(service.vitals(), resource_method)()
+            result = resource.query(
+                name=f"apps/{package_name}/{metric_set_name}", body=body
+            ).execute()
 
             data_points: list[VitalsDataPoint] = []
             for row in result.get("rows", []):
@@ -3015,9 +3018,7 @@ class PlayStoreClient:
                     )
                 )
 
-            # Strip trailing 'MetricSet' suffix for display
             display_name = metric_set_name.replace("MetricSet", "")
-
             return VitalsQueryResult(
                 package_name=package_name,
                 metric_set=display_name,
@@ -3083,7 +3084,7 @@ class PlayStoreClient:
         return self._query_metric_set(
             package_name=package_name,
             metric_set_name="anrRateMetricSet",
-            metrics=["anrRate", "distinctUsers", "anrCount"],
+            metrics=["anrRate", "anrRate7dUserWeighted", "anrRate28dUserWeighted", "distinctUsers"],
             dimensions=dimensions or [],
             start_date=start_date,
             end_date=end_date,
@@ -3107,11 +3108,15 @@ class PlayStoreClient:
         Returns:
             VitalsQueryResult with slowStartupRate per day.
         """
+        # startType is a required dimension for slowStartRateMetricSet
+        dims = list(dimensions) if dimensions else []
+        if "startType" not in dims:
+            dims = ["startType"] + dims
         return self._query_metric_set(
             package_name=package_name,
-            metric_set_name="slowStartupRateMetricSet",
-            metrics=["slowStartupRate", "distinctUsers", "slowStartupCount"],
-            dimensions=dimensions or [],
+            metric_set_name="slowStartRateMetricSet",
+            metrics=["slowStartRate", "slowStartRate7dUserWeighted", "slowStartRate28dUserWeighted", "distinctUsers"],
+            dimensions=dims,
             start_date=start_date,
             end_date=end_date,
         )
@@ -3164,7 +3169,7 @@ class PlayStoreClient:
         return self._query_metric_set(
             package_name=package_name,
             metric_set_name="excessiveWakeupRateMetricSet",
-            metrics=["excessiveWakeupRate", "distinctUsers", "excessiveWakeupCount"],
+            metrics=["excessiveWakeupRate", "excessiveWakeupRate7dUserWeighted", "excessiveWakeupRate28dUserWeighted", "distinctUsers"],
             dimensions=dimensions or [],
             start_date=start_date,
             end_date=end_date,
@@ -3191,7 +3196,37 @@ class PlayStoreClient:
         return self._query_metric_set(
             package_name=package_name,
             metric_set_name="stuckBackgroundWakelockRateMetricSet",
-            metrics=["stuckBgWakelockRate", "distinctUsers", "stuckBgWakelockCount"],
+            metrics=["stuckBgWakelockRate", "stuckBgWakelockRate7dUserWeighted", "stuckBgWakelockRate28dUserWeighted", "distinctUsers"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_lmk_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query Low Memory Killer (LMK) rate metrics.
+
+        LMK rate measures how often the system kills the app due to memory pressure.
+        High LMK rate indicates the app uses too much memory.
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions.
+
+        Returns:
+            VitalsQueryResult with lmkRate per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="lmkRateMetricSet",
+            metrics=["userPerceivedLmkRate", "userPerceivedLmkRate7dUserWeighted", "userPerceivedLmkRate28dUserWeighted", "distinctUsers"],
             dimensions=dimensions or [],
             start_date=start_date,
             end_date=end_date,

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -3756,7 +3756,7 @@ class PlayStoreClient:
         return self._query_metric_set(
             package_name=package_name,
             metric_set_name="crashRateMetricSet",
-            metrics=["crashRate", "distinctUsers", "crashCount"],
+            metrics=["crashRate", "crashRate7dUserWeighted", "crashRate28dUserWeighted", "distinctUsers"],
             dimensions=dimensions or [],
             start_date=start_date,
             end_date=end_date,

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -24,11 +24,14 @@ from play_store_mcp.models import (
     AppDetailsInfo,
     AppDetailsUpdateResult,
     AppInfo,
+    BasePlanActionResult,
     BatchDeploymentResult,
     BundleInfo,
     ConsoleInstallStats,
     ConsoleStatsResult,
+    ConvertRegionPricesResult,
     CountryAvailability,
+    CountryAvailabilityUpdateResult,
     DailyStatPoint,
     DeobfuscationFileResult,
     DeploymentResult,
@@ -38,20 +41,26 @@ from play_store_mcp.models import (
     ImageInfo,
     ImageUploadResult,
     InAppProduct,
+    InAppProductUpsertResult,
     Listing,
     ListingBatchUpdateResult,
+    ListingDeleteResult,
     ListingUpdateResult,
     Order,
     ProductPurchase,
     RefundResult,
+    RegionPrice,
     Release,
     Review,
     ReviewReplyResult,
     SearchTermResult,
     SearchTermsStats,
+    SubscriptionDeferResult,
+    SubscriptionDetails,
     SubscriptionProduct,
     SubscriptionPurchase,
     SubscriptionPurchaseV2,
+    SubscriptionUpsertResult,
     TesterInfo,
     TrackInfo,
     UserInfo,
@@ -1149,6 +1158,168 @@ class PlayStoreClient:
             self._logger.exception("Failed to list subscriptions", error=str(e))
             raise PlayStoreClientError(f"Failed to list subscriptions: {e.reason}") from e
 
+    def get_subscription(self, package_name: str, product_id: str) -> SubscriptionDetails:
+        """Get a subscription product from the Monetization API."""
+        self._logger.info("Getting subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+        try:
+            data = service.monetization().subscriptions().get(
+                packageName=package_name, productId=product_id
+            ).execute()
+            return SubscriptionDetails(
+                product_id=data.get("productId", product_id),
+                package_name=package_name,
+                state=data.get("state"),
+                listings=data.get("listings"),
+                base_plans=data.get("basePlans"),
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to get subscription", error=str(e))
+            raise PlayStoreClientError(f"Failed to get subscription: {e.reason}") from e
+
+    def create_subscription(
+        self,
+        package_name: str,
+        product_id: str,
+        default_language: str,
+        title: str,
+        description: str,
+    ) -> SubscriptionUpsertResult:
+        """Create a new subscription product via the Monetization API."""
+        self._logger.info("Creating subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+        body = {
+            "productId": product_id,
+            "listings": {
+                default_language: {
+                    "title": title,
+                    "description": description,
+                    "benefits": [],
+                }
+            },
+        }
+        try:
+            service.monetization().subscriptions().create(
+                packageName=package_name, productId=product_id, body=body
+            ).execute()
+            return SubscriptionUpsertResult(
+                success=True, package_name=package_name, product_id=product_id,
+                message=f"Created subscription '{product_id}' successfully.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to create subscription", error=str(e))
+            return SubscriptionUpsertResult(
+                success=False, package_name=package_name, product_id=product_id,
+                message=f"Failed to create subscription: {e.reason}", error=str(e),
+            )
+
+    def update_subscription(
+        self,
+        package_name: str,
+        product_id: str,
+        title: str | None = None,
+        description: str | None = None,
+        default_language: str = "en-US",
+    ) -> SubscriptionUpsertResult:
+        """Update an existing subscription product."""
+        self._logger.info("Updating subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+        try:
+            existing = service.monetization().subscriptions().get(
+                packageName=package_name, productId=product_id
+            ).execute()
+            listings = existing.get("listings", {})
+            listing = listings.get(default_language, {})
+            if title:
+                listing["title"] = title
+            if description:
+                listing["description"] = description
+            listings[default_language] = listing
+            existing["listings"] = listings
+            service.monetization().subscriptions().patch(
+                packageName=package_name, productId=product_id,
+                body=existing, updateMask="listings",
+            ).execute()
+            return SubscriptionUpsertResult(
+                success=True, package_name=package_name, product_id=product_id,
+                message=f"Updated subscription '{product_id}' successfully.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to update subscription", error=str(e))
+            return SubscriptionUpsertResult(
+                success=False, package_name=package_name, product_id=product_id,
+                message=f"Failed to update subscription: {e.reason}", error=str(e),
+            )
+
+    def delete_subscription(self, package_name: str, product_id: str) -> SubscriptionUpsertResult:
+        """Delete a subscription product."""
+        self._logger.info("Deleting subscription", package_name=package_name, product_id=product_id)
+        service = self._get_service()
+        try:
+            service.monetization().subscriptions().delete(
+                packageName=package_name, productId=product_id
+            ).execute()
+            return SubscriptionUpsertResult(
+                success=True, package_name=package_name, product_id=product_id,
+                message=f"Deleted subscription '{product_id}' successfully.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to delete subscription", error=str(e))
+            return SubscriptionUpsertResult(
+                success=False, package_name=package_name, product_id=product_id,
+                message=f"Failed to delete subscription: {e.reason}", error=str(e),
+            )
+
+    def activate_base_plan(
+        self, package_name: str, product_id: str, base_plan_id: str
+    ) -> BasePlanActionResult:
+        """Activate a base plan for a subscription."""
+        self._logger.info("Activating base plan", package_name=package_name,
+                          product_id=product_id, base_plan_id=base_plan_id)
+        service = self._get_service()
+        try:
+            service.monetization().subscriptions().basePlans().activate(
+                packageName=package_name, productId=product_id,
+                basePlanId=base_plan_id, body={},
+            ).execute()
+            return BasePlanActionResult(
+                success=True, package_name=package_name, product_id=product_id,
+                base_plan_id=base_plan_id, action="activate",
+                message=f"Activated base plan '{base_plan_id}' for '{product_id}'.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to activate base plan", error=str(e))
+            return BasePlanActionResult(
+                success=False, package_name=package_name, product_id=product_id,
+                base_plan_id=base_plan_id, action="activate",
+                message=f"Failed to activate base plan: {e.reason}", error=str(e),
+            )
+
+    def deactivate_base_plan(
+        self, package_name: str, product_id: str, base_plan_id: str
+    ) -> BasePlanActionResult:
+        """Deactivate a base plan for a subscription."""
+        self._logger.info("Deactivating base plan", package_name=package_name,
+                          product_id=product_id, base_plan_id=base_plan_id)
+        service = self._get_service()
+        try:
+            service.monetization().subscriptions().basePlans().deactivate(
+                packageName=package_name, productId=product_id,
+                basePlanId=base_plan_id, body={},
+            ).execute()
+            return BasePlanActionResult(
+                success=True, package_name=package_name, product_id=product_id,
+                base_plan_id=base_plan_id, action="deactivate",
+                message=f"Deactivated base plan '{base_plan_id}' for '{product_id}'.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to deactivate base plan", error=str(e))
+            return BasePlanActionResult(
+                success=False, package_name=package_name, product_id=product_id,
+                base_plan_id=base_plan_id, action="deactivate",
+                message=f"Failed to deactivate base plan: {e.reason}", error=str(e),
+            )
+
     def get_subscription_purchase(
         self,
         package_name: str,
@@ -1424,6 +1595,101 @@ class PlayStoreClient:
             self._logger.exception("Failed to get in-app product", error=str(e))
             raise PlayStoreClientError(f"Failed to get in-app product: {e.reason}") from e
 
+    def create_in_app_product(
+        self,
+        package_name: str,
+        sku: str,
+        product_type: str,
+        default_language: str,
+        title: str,
+        description: str,
+        default_price_amount: str,
+        default_price_currency: str,
+    ) -> InAppProductUpsertResult:
+        """Create a new in-app product (managed product or subscription)."""
+        self._logger.info("Creating in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+        price_micros = str(int(float(default_price_amount) * 1_000_000))
+        body = {
+            "packageName": package_name,
+            "sku": sku,
+            "purchaseType": product_type,
+            "defaultLanguage": default_language,
+            "status": "active",
+            "listings": {default_language: {"title": title, "description": description}},
+            "defaultPrice": {"priceMicros": price_micros, "currency": default_price_currency},
+        }
+        try:
+            service.inappproducts().insert(packageName=package_name, body=body).execute()
+            return InAppProductUpsertResult(
+                success=True, package_name=package_name, sku=sku,
+                message=f"Created in-app product '{sku}' successfully.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to create in-app product", error=str(e))
+            return InAppProductUpsertResult(
+                success=False, package_name=package_name, sku=sku,
+                message=f"Failed to create in-app product: {e.reason}", error=str(e),
+            )
+
+    def update_in_app_product(
+        self,
+        package_name: str,
+        sku: str,
+        title: str | None = None,
+        description: str | None = None,
+        default_price_amount: str | None = None,
+        default_price_currency: str | None = None,
+        status: str | None = None,
+    ) -> InAppProductUpsertResult:
+        """Update an existing in-app product."""
+        self._logger.info("Updating in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+        try:
+            existing = service.inappproducts().get(packageName=package_name, sku=sku).execute()
+            if title or description:
+                lang = existing.get("defaultLanguage", "en-US")
+                listings = existing.get("listings", {})
+                listing = listings.get(lang, {})
+                if title:
+                    listing["title"] = title
+                if description:
+                    listing["description"] = description
+                listings[lang] = listing
+                existing["listings"] = listings
+            if default_price_amount:
+                currency = default_price_currency or existing.get("defaultPrice", {}).get("currency", "USD")
+                existing["defaultPrice"] = {
+                    "priceMicros": str(int(float(default_price_amount) * 1_000_000)),
+                    "currency": currency,
+                }
+            if status:
+                existing["status"] = status
+            service.inappproducts().update(packageName=package_name, sku=sku, body=existing).execute()
+            return InAppProductUpsertResult(
+                success=True, package_name=package_name, sku=sku,
+                message=f"Updated in-app product '{sku}' successfully.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to update in-app product", error=str(e))
+            return InAppProductUpsertResult(
+                success=False, package_name=package_name, sku=sku,
+                message=f"Failed to update in-app product: {e.reason}", error=str(e),
+            )
+
+    def delete_in_app_product(self, package_name: str, sku: str) -> dict:
+        """Delete an in-app product."""
+        self._logger.info("Deleting in-app product", package_name=package_name, sku=sku)
+        service = self._get_service()
+        try:
+            service.inappproducts().delete(packageName=package_name, sku=sku).execute()
+            return {"success": True, "package_name": package_name, "sku": sku,
+                    "message": f"Deleted in-app product '{sku}' successfully."}
+        except HttpError as e:
+            self._logger.exception("Failed to delete in-app product", error=str(e))
+            return {"success": False, "package_name": package_name, "sku": sku,
+                    "message": f"Failed to delete in-app product: {e.reason}", "error": str(e)}
+
     # =========================================================================
     # Store Listings API
     # =========================================================================
@@ -1554,6 +1820,79 @@ class PlayStoreClient:
                 language=language,
                 message=f"Failed to update listing: {e}",
                 error=str(e),
+            )
+
+    def delete_listing(self, package_name: str, language: str) -> ListingDeleteResult:
+        """Delete the store listing for a specific language."""
+        self._logger.info("Deleting listing", package_name=package_name, language=language)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+        try:
+            service.edits().listings().delete(
+                packageName=package_name, editId=edit_id, language=language
+            ).execute()
+            self._commit_edit(package_name, edit_id)
+            return ListingDeleteResult(
+                success=True, package_name=package_name, language=language,
+                message=f"Deleted store listing for language '{language}'.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to delete listing", error=str(e))
+            return ListingDeleteResult(
+                success=False, package_name=package_name, language=language,
+                message=f"Failed to delete listing: {e.reason}", error=str(e),
+            )
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def delete_all_listings(self, package_name: str) -> ListingDeleteResult:
+        """Delete all store listings for an app."""
+        self._logger.info("Deleting all listings", package_name=package_name)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+        try:
+            service.edits().listings().deleteall(
+                packageName=package_name, editId=edit_id
+            ).execute()
+            self._commit_edit(package_name, edit_id)
+            return ListingDeleteResult(
+                success=True, package_name=package_name,
+                message="Deleted all store listings.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to delete all listings", error=str(e))
+            return ListingDeleteResult(
+                success=False, package_name=package_name,
+                message=f"Failed to delete all listings: {e.reason}", error=str(e),
+            )
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def convert_region_prices(
+        self, package_name: str, price_amount: str, currency_code: str
+    ) -> ConvertRegionPricesResult:
+        """Convert a base price to all regional equivalents."""
+        self._logger.info("Converting region prices", package_name=package_name)
+        service = self._get_service()
+        price_micros = str(int(float(price_amount) * 1_000_000))
+        try:
+            result = service.monetization().convertRegionPrices(
+                packageName=package_name,
+                body={"price": {"priceMicros": price_micros, "currencyCode": currency_code}},
+            ).execute()
+            converted: list[RegionPrice] = []
+            for region_code, price_data in result.get("convertedRegionPrices", {}).items():
+                p = price_data.get("price", {})
+                converted.append(RegionPrice(
+                    region_code=region_code,
+                    price_micros=p.get("priceMicros", "0"),
+                    currency_code=p.get("currencyCode", ""),
+                ))
+            return ConvertRegionPricesResult(success=True, converted_prices=converted)
+        except HttpError as e:
+            self._logger.exception("Failed to convert region prices", error=str(e))
+            return ConvertRegionPricesResult(
+                success=False, converted_prices=[], error=str(e),
             )
 
     def batch_update_listings(
@@ -2555,6 +2894,41 @@ class PlayStoreClient:
         finally:
             self._delete_edit(package_name, edit_id)
 
+    def update_country_availability(
+        self,
+        package_name: str,
+        track: str,
+        countries: list[str],
+        rest_of_world: bool = False,
+    ) -> CountryAvailabilityUpdateResult:
+        """Set the list of countries where a track is available."""
+        self._logger.info("Updating country availability", package_name=package_name, track=track)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+        try:
+            body = {
+                "countries": [{"countryCode": c} for c in countries],
+                "restOfWorld": rest_of_world,
+            }
+            service.edits().countryavailability().update(
+                packageName=package_name, editId=edit_id, track=track, body=body
+            ).execute()
+            self._commit_edit(package_name, edit_id)
+            return CountryAvailabilityUpdateResult(
+                success=True, package_name=package_name, track=track,
+                countries_set=countries, rest_of_world=rest_of_world,
+                message=f"Updated country availability for track '{track}': {len(countries)} countries.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to update country availability", error=str(e))
+            return CountryAvailabilityUpdateResult(
+                success=False, package_name=package_name, track=track,
+                countries_set=[], rest_of_world=rest_of_world,
+                message=f"Failed to update country availability: {e.reason}", error=str(e),
+            )
+        finally:
+            self._delete_edit(package_name, edit_id)
+
     # =========================================================================
     # Users API
     # =========================================================================
@@ -2681,6 +3055,32 @@ class PlayStoreClient:
                 error=str(e),
             )
 
+    def update_user(
+        self,
+        developer_id: str,
+        email: str,
+        access_state: str,
+    ) -> UserOperationResult:
+        """Update a user's account-level access state."""
+        self._logger.info("Updating user", developer_id=developer_id, email=email)
+        service = self._get_service()
+        try:
+            service.users().patch(
+                name=f"developers/{developer_id}/users/{email}",
+                body={"accessState": access_state},
+                updateMask="accessState",
+            ).execute()
+            return UserOperationResult(
+                success=True, email=email,
+                message=f"Updated user {email} access state to '{access_state}'.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to update user", error=str(e))
+            return UserOperationResult(
+                success=False, email=email,
+                message=f"Failed to update user: {e.reason}", error=str(e),
+            )
+
     # =========================================================================
     # Grants API
     # =========================================================================
@@ -2779,6 +3179,34 @@ class PlayStoreClient:
                 email=email,
                 message=f"Failed to revoke grant: {e.reason}",
                 error=str(e),
+            )
+
+    def update_grant(
+        self,
+        developer_id: str,
+        email: str,
+        package_name: str,
+        app_level_permissions: list[str],
+    ) -> UserOperationResult:
+        """Update a user's app-level permissions on a specific app."""
+        self._logger.info("Updating grant", developer_id=developer_id,
+                          email=email, package_name=package_name)
+        service = self._get_service()
+        try:
+            service.grants().patch(
+                name=f"developers/{developer_id}/users/{email}/grants/{package_name}",
+                body={"appLevelPermissions": app_level_permissions},
+                updateMask="appLevelPermissions",
+            ).execute()
+            return UserOperationResult(
+                success=True, email=email,
+                message=f"Updated permissions for {email} on {package_name}: {app_level_permissions}",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to update grant", error=str(e))
+            return UserOperationResult(
+                success=False, email=email,
+                message=f"Failed to update grant: {e.reason}", error=str(e),
             )
 
     # =========================================================================
@@ -3094,6 +3522,43 @@ class PlayStoreClient:
                 email="",
                 message=f"Failed to revoke subscription: {e.reason}",
                 error=str(e),
+            )
+
+    def defer_subscription(
+        self,
+        package_name: str,
+        subscription_id: str,
+        token: str,
+        expected_expiry_time_millis: str,
+        desired_expiry_time_millis: str,
+    ) -> SubscriptionDeferResult:
+        """Defer a subscription's renewal to a future time."""
+        self._logger.info("Deferring subscription", package_name=package_name,
+                          subscription_id=subscription_id)
+        service = self._get_service()
+        try:
+            result = service.purchases().subscriptions().defer(
+                packageName=package_name,
+                subscriptionId=subscription_id,
+                token=token,
+                body={
+                    "deferralInfo": {
+                        "expectedExpiryTimeMillis": expected_expiry_time_millis,
+                        "desiredExpiryTimeMillis": desired_expiry_time_millis,
+                    }
+                },
+            ).execute()
+            new_expiry = result.get("newExpiryTimeMillis")
+            return SubscriptionDeferResult(
+                success=True, package_name=package_name, subscription_id=subscription_id,
+                new_expiry_time_millis=new_expiry,
+                message=f"Deferred subscription. New expiry: {new_expiry} ms.",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to defer subscription", error=str(e))
+            return SubscriptionDeferResult(
+                success=False, package_name=package_name, subscription_id=subscription_id,
+                message=f"Failed to defer subscription: {e.reason}", error=str(e),
             )
 
     # =========================================================================

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -48,6 +48,7 @@ from play_store_mcp.models import (
     ListingUpdateResult,
     Order,
     ProductPurchase,
+    ProductPurchaseOperationResult,
     RefundResult,
     RegionPrice,
     Release,
@@ -3373,6 +3374,59 @@ class PlayStoreClient:
                 success=False,
                 email="",
                 message=f"Failed to acknowledge purchase: {e.reason}",
+                error=str(e),
+            )
+
+    def consume_product_purchase(
+        self,
+        package_name: str,
+        product_id: str,
+        token: str,
+    ) -> ProductPurchaseOperationResult:
+        """Consume a one-time in-app product purchase.
+
+        Consuming a purchase makes the product available for repurchase. This
+        should only be used for consumable in-app products after entitlement is
+        granted.
+
+        Args:
+            package_name: App package name.
+            product_id: Product SKU.
+            token: Purchase token from the client.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Consuming product purchase",
+            package_name=package_name,
+            product_id=product_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.purchases().products().consume(
+                packageName=package_name,
+                productId=product_id,
+                token=token,
+            ).execute()
+
+            return ProductPurchaseOperationResult(
+                success=True,
+                package_name=package_name,
+                product_id=product_id,
+                purchase_token=token,
+                message=f"Successfully consumed purchase of {product_id}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to consume purchase", error=str(e))
+            return ProductPurchaseOperationResult(
+                success=False,
+                package_name=package_name,
+                product_id=product_id,
+                purchase_token=token,
+                message=f"Failed to consume purchase: {e.reason}",
                 error=str(e),
             )
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import random
@@ -32,10 +33,13 @@ from play_store_mcp.models import (
     ConvertRegionPricesResult,
     CountryAvailability,
     CountryAvailabilityUpdateResult,
+    CustomStoreListingSummary,
+    CustomStoreListingsResult,
     DailyStatPoint,
     DeobfuscationFileResult,
     DeploymentResult,
     ExpansionFile,
+    ExperimentReportRaw,
     GeneratedApkInfo,
     GrantInfo,
     ImageInfo,
@@ -55,6 +59,8 @@ from play_store_mcp.models import (
     ReviewReplyResult,
     SearchTermResult,
     SearchTermsStats,
+    StoreListingExperimentSummary,
+    StoreListingExperimentsResult,
     SubscriptionDeferResult,
     SubscriptionDetails,
     SubscriptionProduct,
@@ -3943,11 +3949,17 @@ class PlayStoreClient:
     }
 
     _OPENCLI_BIN = os.path.expanduser("~/.npm-global/bin/opencli")
+    # "default" matches the session name already used by the deployed uv-tool
+    # install of this server -- keep this in sync so all browser-driven tools
+    # (get_search_terms, get_acquisition_funnel, this file's newer additions)
+    # share one authenticated, logged-into-Play-Console browser tab instead of
+    # each spinning up its own unauthenticated session.
+    _OPENCLI_SESSION = "default"
 
     def _run_browser_js(self, js: str, timeout: int = 20) -> str:
         """Run JS in the OpenCLI automation browser and return the result string."""
         result = subprocess.run(
-            [self._OPENCLI_BIN, "browser", "eval", js],
+            [self._OPENCLI_BIN, "browser", self._OPENCLI_SESSION, "eval", js],
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
@@ -4293,4 +4305,286 @@ class PlayStoreClient:
             start_date=start_date,
             end_date=end_date,
             stages=stages,
+        )
+
+    # =========================================================================
+    # Custom Store Listings (CSL) and Store Listing Experiments (A/B tests)
+    #
+    # Neither has any Android Publisher API surface (confirmed 2026-07-01 by
+    # cross-checking the full REST resource index at
+    # https://developers.google.com/android-publisher/api-ref/rest -- only
+    # v3.edits.listings exists, nothing for custom listings or experiments).
+    # These are Play Console UI-only features, so everything below reads the
+    # Console via OpenCLI browser automation instead of the REST API.
+    #
+    # The experiments RPC response is an undocumented internal protobuf
+    # (playconsoleapps-pa.clients6.google.com). There is no public .proto
+    # schema for it, so `_decode_protobuf_generic` below is a schema-less
+    # wire-format walker: it recovers field numbers/wire types/values but not
+    # field *names* beyond what we've manually confirmed by reverse
+    # engineering one real response (see StoreListingExperimentSummary
+    # docstring for which fields are trusted vs inferred).
+    # =========================================================================
+
+    def _run_opencli_cli(self, args: list[str], timeout: int = 30) -> str:
+        """Run an arbitrary `opencli browser <session> <args...>` command and return stdout."""
+        result = subprocess.run(
+            [self._OPENCLI_BIN, "browser", self._OPENCLI_SESSION, *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode != 0:
+            raise PlayStoreClientError(f"opencli browser {' '.join(args)} failed: {result.stderr[:300]}")
+        return result.stdout.strip()
+
+    @staticmethod
+    def _decode_varint(buf: bytes, pos: int) -> tuple[int, int]:
+        result = 0
+        shift = 0
+        while True:
+            b = buf[pos]
+            result |= (b & 0x7F) << shift
+            pos += 1
+            if not (b & 0x80):
+                break
+            shift += 7
+        return result, pos
+
+    @classmethod
+    def _decode_protobuf_generic(cls, buf: bytes) -> dict[int, list[Any]]:
+        """Schema-less protobuf wire-format decode.
+
+        Returns {field_number: [value, ...]} (repeated fields collect all
+        occurrences in order). Length-delimited fields are returned as a
+        decoded UTF-8 string if printable, else recursively decoded as a
+        nested message if that succeeds, else raw bytes.
+        """
+        fields: dict[int, list[Any]] = {}
+        pos = 0
+        while pos < len(buf):
+            tag, pos = cls._decode_varint(buf, pos)
+            field_num = tag >> 3
+            wire_type = tag & 0x7
+            if wire_type == 0:
+                val, pos = cls._decode_varint(buf, pos)
+            elif wire_type == 2:
+                length, pos = cls._decode_varint(buf, pos)
+                chunk = buf[pos:pos + length]
+                pos += length
+                val = None
+                try:
+                    s = chunk.decode("utf-8")
+                    if s.isprintable():
+                        val = s
+                except UnicodeDecodeError:
+                    pass
+                if val is None:
+                    try:
+                        val = cls._decode_protobuf_generic(chunk) if chunk else {}
+                    except Exception:
+                        val = chunk
+            elif wire_type == 1:
+                val = buf[pos:pos + 8]
+                pos += 8
+            elif wire_type == 5:
+                val = buf[pos:pos + 4]
+                pos += 4
+            else:
+                break
+            fields.setdefault(field_num, []).append(val)
+        return fields
+
+    def get_custom_store_listings(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+    ) -> CustomStoreListingsResult:
+        """List Custom Store Listings (CSL) for an app via Console UI scrape.
+
+        Requires OpenCLI with an active, logged-in Play Console browser
+        session. Returns name + edit URL only -- per-CSL content (title,
+        short/full description, targeting) requires opening each edit URL
+        individually; that page's fields are Angular Material inputs that
+        weren't reliably extractable via simple CSS selectors as of
+        2026-07-01, so per-CSL content scraping is not yet implemented here.
+
+        Args:
+            package_name: App package name (display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+
+        Returns:
+            CustomStoreListingsResult with each CSL's internal name and edit URL.
+        """
+        url = f"https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/store-listings"
+        self._run_opencli_cli(["open", url], timeout=45)
+        time.sleep(3)
+        state = self._run_opencli_cli(["state"], timeout=30)
+
+        pattern = re.compile(
+            r"Edit listing '([^']+)'[^>]*?custom-store-listings/(\d+)"
+        )
+        seen: dict[str, str] = {}
+        for name, listing_id in pattern.findall(state):
+            seen[listing_id] = name
+
+        listings = [
+            CustomStoreListingSummary(
+                name=name,
+                listing_id=listing_id,
+                edit_url=f"https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/custom-store-listings/{listing_id}",
+            )
+            for listing_id, name in seen.items()
+        ]
+        return CustomStoreListingsResult(package_name=package_name, listings=listings)
+
+    def get_store_listing_experiments(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+    ) -> StoreListingExperimentsResult:
+        """List Store Listing Experiments (A/B tests) for an app via Console RPC capture.
+
+        Requires OpenCLI with an active, logged-in Play Console browser
+        session. Navigates to the experiments overview page, forces a
+        reload to trigger a fresh RPC call, captures that call's response
+        via OpenCLI network capture, and decodes the embedded protobuf
+        with a schema-less wire-format walker (see module docstring above
+        for caveats -- field semantics beyond experiment_id/name/locale are
+        inferred, not from an official schema).
+
+        Args:
+            package_name: App package name (display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+
+        Returns:
+            StoreListingExperimentsResult with one entry per in-progress or
+            past experiment surfaced by the overview page.
+        """
+        url = (
+            f"https://play.google.com/console/u/0/developers/{developer_id}"
+            f"/app/{app_id}/store-listing-experiments/overview"
+        )
+        self._run_opencli_cli(["open", url], timeout=45)
+        time.sleep(3)
+        self._run_opencli_cli(["eval", "location.reload(); 'ok'"], timeout=30)
+        time.sleep(4)
+
+        detail_key = (
+            "POST playconsoleapps-pa.clients6.google.com/v1/developers/apps/"
+            "storelistingexperiments/overview:startupData"
+        )
+        raw = self._run_opencli_cli(["network", "--since", "60s", "--detail", detail_key], timeout=30)
+        try:
+            envelope = json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from experiments overview capture: {raw[:200]}")
+
+        body_b64 = envelope.get("body", {}).get("2")
+        if not body_b64:
+            return StoreListingExperimentsResult(package_name=package_name, experiments=[])
+
+        decoded = self._decode_protobuf_generic(base64.b64decode(body_b64))
+        experiments: list[StoreListingExperimentSummary] = []
+        for exp_msg in decoded.get(1, []):
+            if not isinstance(exp_msg, dict):
+                continue
+            exp_id = ""
+            id_wrapper = exp_msg.get(1)
+            if id_wrapper and isinstance(id_wrapper[0], dict):
+                id_str = id_wrapper[0].get(3)
+                if id_str and isinstance(id_str[0], dict):
+                    exp_id = str(id_str[0].get(1, [""])[0])
+            name = str(exp_msg.get(2, [""])[0])
+            status = exp_msg.get(3, [None])[0]
+            dimension = exp_msg.get(4, [None])[0]
+            locale = ""
+            locale_wrapper = exp_msg.get(5)
+            if locale_wrapper and isinstance(locale_wrapper[0], dict):
+                locale = str(locale_wrapper[0].get(4, [""])[0])
+            start_iso = None
+            ts_wrapper = exp_msg.get(7)
+            if ts_wrapper and isinstance(ts_wrapper[0], dict):
+                seconds = ts_wrapper[0].get(1, [None])[0]
+                if isinstance(seconds, int):
+                    from datetime import datetime, timezone
+                    start_iso = datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat()
+            traffic_split = None
+            split_bytes = exp_msg.get(10, [None])[0]
+            if isinstance(split_bytes, (bytes, bytearray)) and len(split_bytes) == 8:
+                import struct
+                traffic_split = struct.unpack("<d", split_bytes)[0]
+
+            experiments.append(
+                StoreListingExperimentSummary(
+                    experiment_id=exp_id,
+                    name=name,
+                    locale=locale,
+                    dimension_type=dimension if isinstance(dimension, int) else None,
+                    status=status if isinstance(status, int) else None,
+                    start_timestamp=start_iso,
+                    traffic_split=traffic_split,
+                )
+            )
+        return StoreListingExperimentsResult(package_name=package_name, experiments=experiments)
+
+    def get_experiment_report_raw(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        experiment_id: str,
+    ) -> ExperimentReportRaw:
+        """Fetch the raw decodable content of one experiment's report page.
+
+        Does not attempt full field-level parsing of performance metrics
+        (no official schema available for this endpoint). Surfaces creative
+        image URLs and readable text runs found in the payload -- useful
+        for confirming what's actually being tested (e.g. control vs
+        variant screenshot sets) without guessing at metric field numbers.
+
+        Args:
+            package_name: App package name (display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            experiment_id: Numeric experiment id (from get_store_listing_experiments).
+
+        Returns:
+            ExperimentReportRaw with image URLs and readable text strings.
+        """
+        url = (
+            f"https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}"
+            f"/store-listing-experiments/{experiment_id}/report"
+        )
+        self._run_opencli_cli(["open", url], timeout=45)
+        time.sleep(4)
+
+        detail_key = (
+            "POST playconsoleapps-pa.clients6.google.com/v1/developers/apps/"
+            "storelistingexperiments/report:startupData"
+        )
+        raw = self._run_opencli_cli(["network", "--since", "60s", "--detail", detail_key], timeout=30)
+        try:
+            envelope = json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from experiment report capture: {raw[:200]}")
+
+        body_b64 = envelope.get("body", {}).get("2")
+        if not body_b64:
+            return ExperimentReportRaw(experiment_id=experiment_id, image_urls=[], text_strings=[])
+
+        raw_bytes = base64.b64decode(body_b64)
+        urls = list(dict.fromkeys(re.findall(rb"https://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+", raw_bytes)))
+        image_urls = [u.decode("utf-8", errors="ignore") for u in urls]
+
+        text_runs = re.findall(rb"[ -~]{12,}", raw_bytes)
+        unique_texts = list(dict.fromkeys(t.decode("ascii", errors="ignore") for t in text_runs))
+        unique_texts.sort(key=len, reverse=True)
+
+        return ExperimentReportRaw(
+            experiment_id=experiment_id,
+            image_urls=image_urls,
+            text_strings=unique_texts[:50],
         )

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -44,10 +44,14 @@ from play_store_mcp.models import (
     Release,
     Review,
     ReviewReplyResult,
+    SearchTermResult,
+    SearchTermsStats,
     SubscriptionProduct,
     SubscriptionPurchase,
     SubscriptionPurchaseV2,
     TesterInfo,
+    AcquisitionFunnelResult,
+    AcquisitionFunnelStage,
     TrackInfo,
     UserInfo,
     UserOperationResult,
@@ -3468,4 +3472,190 @@ class PlayStoreClient:
             net_installs=net_result,
             active_users=active_result,
             by_country=by_country,
+        )
+
+    # =========================================================================
+    # Acquisition Reporting (browser-based)
+    # =========================================================================
+
+    # Dimension IDs for the acquisition reporting RPC (field "3"."1" of the body):
+    #   2 = STORE_QUERY (search term)
+    #   6 = PLAY_COUNTRY (used for the cross-country aggregate / funnel summary)
+    _ACQ_DIM_STORE_QUERY = 2
+    _ACQ_DIM_COUNTRY = 6
+
+    def _fetch_acquisition_table(
+        self,
+        developer_id: str,
+        app_id: str,
+        dimension_id: int,
+        start_year: int, start_month: int, start_day: int,
+        end_year: int, end_month: int, end_day: int,
+    ) -> dict:
+        """Call stats/acquisition:getAcquisitionDetailsTableData via the browser session."""
+        js = f"""
+(async function() {{
+  const SAPISID = document.cookie.match(/SAPISID=([^;]+)/)?.[1];
+  if (!SAPISID) return JSON.stringify({{error: 'Not logged into Play Console'}});
+  const ts = Date.now();
+  const msgBuffer = new TextEncoder().encode(ts + ' ' + SAPISID + ' https://play.google.com');
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgBuffer);
+  const sha1 = Array.from(new Uint8Array(hashBuffer)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  const auth = 'SAPISIDHASH ' + ts + '_' + sha1;
+  const DEV_ID = '{developer_id}';
+  const APP_ID = '{app_id}';
+  const API_KEY = 'AIzaSyBAha_rcoO_aGsmiR5fWbNfdOjqT0gXwbk';
+  const httpHeaders = 'Content-Type:application/json+protobuf\\r\\nX-Goog-AuthUser:0\\r\\nAuthorization:' + auth + '\\r\\nX-Goog-Api-Key:' + API_KEY + '\\r\\n';
+  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/stats/acquisition:getAcquisitionDetailsTableData?$httpHeaders=' + encodeURIComponent(httpHeaders);
+  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{start_year},'2':{start_month},'3':{start_day}}},'2':{{'1':{end_year},'2':{end_month},'3':{end_day}}}}},'3':{{'1':{dimension_id}}},'5':1}});
+  const resp = await fetch(url, {{method:'POST', body:body, credentials:'include'}});
+  const data = await resp.json();
+  return JSON.stringify(data);
+}})()
+"""
+        raw = self._run_browser_js(js)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from browser acquisition fetch: {raw[:200]}")
+
+    @staticmethod
+    def _to_int(obj: dict | None) -> int:
+        """Pull an int out of a wrapped {"1": "<n>"} value (often a string)."""
+        if not obj:
+            return 0
+        v = obj.get("1")
+        if v is None:
+            return 0
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _to_float(obj: dict | None) -> float:
+        if not obj:
+            return 0.0
+        v = obj.get("1")
+        if v is None:
+            return 0.0
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def get_search_terms(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> SearchTermsStats:
+        """Get search-term acquisition stats from Play Console via browser session.
+
+        Calls the internal `stats/acquisition:getAcquisitionDetailsTableData` RPC
+        with the STORE_QUERY dimension. Many individual queries are aggregated
+        by Google as "Other" (REMOVED_BY_THRESHOLDING_STORE_QUERY) once they fall
+        below the privacy threshold.
+
+        Args:
+            package_name: App package name (for display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+        """
+        from datetime import date as date_cls
+
+        d_start = date_cls.fromisoformat(start_date)
+        d_end = date_cls.fromisoformat(end_date)
+
+        self._logger.info("Fetching search terms via browser", package_name=package_name)
+
+        data = self._fetch_acquisition_table(
+            developer_id, app_id, self._ACQ_DIM_STORE_QUERY,
+            d_start.year, d_start.month, d_start.day,
+            d_end.year, d_end.month, d_end.day,
+        )
+
+        rows = data.get("1", {}).get("3", []) or []
+        terms: list[SearchTermResult] = []
+        for row in rows:
+            label = row.get("1", {})
+            display = label.get("2") or label.get("1") or ""
+            visitors = self._to_int(row.get("2"))
+            installs = self._to_int(row.get("3"))
+            terms.append(SearchTermResult(
+                term=display,
+                installs=installs,
+                store_listing_visitors=visitors,
+            ))
+
+        terms.sort(key=lambda t: t.installs, reverse=True)
+
+        return SearchTermsStats(
+            package_name=package_name,
+            start_date=start_date,
+            end_date=end_date,
+            terms=terms,
+        )
+
+    def get_acquisition_funnel(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> AcquisitionFunnelResult:
+        """Get the acquisition funnel summary from Play Console via browser session.
+
+        Calls the internal `stats/acquisition:getAcquisitionDetailsTableData` RPC
+        and reads the per-period totals (field "1"."2") for store listing
+        visitors -> installers conversion.
+
+        Args:
+            package_name: App package name (for display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+        """
+        from datetime import date as date_cls
+
+        d_start = date_cls.fromisoformat(start_date)
+        d_end = date_cls.fromisoformat(end_date)
+
+        self._logger.info("Fetching acquisition funnel via browser", package_name=package_name)
+
+        data = self._fetch_acquisition_table(
+            developer_id, app_id, self._ACQ_DIM_COUNTRY,
+            d_start.year, d_start.month, d_start.day,
+            d_end.year, d_end.month, d_end.day,
+        )
+
+        totals = data.get("1", {}).get("2", {}) or {}
+        visitors = self._to_int(totals.get("2"))
+        installers = self._to_int(totals.get("3"))
+        conv_rate = self._to_float(totals.get("4"))
+
+        stages = [
+            AcquisitionFunnelStage(
+                stage="store_listing_visitors",
+                value=visitors,
+                conversion_rate=0.0,
+            ),
+            AcquisitionFunnelStage(
+                stage="installers",
+                value=installers,
+                conversion_rate=conv_rate,
+            ),
+        ]
+
+        return AcquisitionFunnelResult(
+            package_name=package_name,
+            start_date=start_date,
+            end_date=end_date,
+            stages=stages,
         )

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -6,6 +6,7 @@ import json
 import os
 import random
 import re
+import subprocess
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -23,7 +24,10 @@ from play_store_mcp.models import (
     AppInfo,
     BatchDeploymentResult,
     BundleInfo,
+    ConsoleInstallStats,
+    ConsoleStatsResult,
     CountryAvailability,
+    DailyStatPoint,
     DeobfuscationFileResult,
     DeploymentResult,
     ExpansionFile,
@@ -3290,3 +3294,178 @@ class PlayStoreClient:
         except HttpError as e:
             self._logger.exception("Failed to list anomalies", error=str(e))
             raise PlayStoreClientError(f"Failed to list vitals anomalies: {e.reason}") from e
+
+    # =========================================================================
+    # Play Console Browser-Based Stats (requires OpenCLI + logged-in browser)
+    # =========================================================================
+
+    # Metric type mapping (reverse-engineered from Play Console internal API)
+    # These map the URL metric names to the numeric type used in the PA RPC body.
+    _CONSOLE_METRIC_TYPES: dict[str, tuple[int, int]] = {
+        "install_events": (1, 1),   # INSTALL_EVENTS, COUNT
+        "net_installs": (2, 1),     # NET_INSTALLS, COUNT
+        "active_users": (3, 2),     # ACTIVE_USERS, UNIQUE
+    }
+
+    _OPENCLI_BIN = os.path.expanduser("~/.npm-global/bin/opencli")
+
+    def _run_browser_js(self, js: str, timeout: int = 20) -> str:
+        """Run JS in the OpenCLI automation browser and return the result string."""
+        result = subprocess.run(
+            [self._OPENCLI_BIN, "browser", "eval", js],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode != 0:
+            raise PlayStoreClientError(f"opencli browser eval failed: {result.stderr[:200]}")
+        return result.stdout.strip()
+
+    def _fetch_console_time_series(
+        self,
+        developer_id: str,
+        app_id: str,
+        metric_type: int,
+        count_type: int,
+        start_year: int, start_month: int, start_day: int,
+        end_year: int, end_month: int, end_day: int,
+        country_codes: list[str] | None = None,
+    ) -> dict:
+        """Make a statspage/time_series request via the browser (bypasses service-account auth)."""
+        dimensions_js = "[{'1':1}"  # always include overall
+        if country_codes:
+            for cc in country_codes:
+                dimensions_js += f",{{'1':2,'2':'{cc}'}}"
+        dimensions_js += "]"
+
+        js = f"""
+(async function() {{
+  const SAPISID = document.cookie.match(/SAPISID=([^;]+)/)?.[1];
+  if (!SAPISID) return JSON.stringify({{error: 'Not logged into Play Console'}});
+  const ts = Date.now();
+  const msgBuffer = new TextEncoder().encode(ts + ' ' + SAPISID + ' https://play.google.com');
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgBuffer);
+  const sha1 = Array.from(new Uint8Array(hashBuffer)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  const auth = 'SAPISIDHASH ' + ts + '_' + sha1;
+  const DEV_ID = '{developer_id}';
+  const APP_ID = '{app_id}';
+  const API_KEY = 'AIzaSyBAha_rcoO_aGsmiR5fWbNfdOjqT0gXwbk';
+  const httpHeaders = 'Content-Type:application/json+protobuf\\r\\nX-Goog-AuthUser:0\\r\\nAuthorization:' + auth + '\\r\\nX-Goog-Api-Key:' + API_KEY + '\\r\\n';
+  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/statspage/time_series?$httpHeaders=' + encodeURIComponent(httpHeaders);
+  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{start_year},'2':{start_month},'3':{start_day}}},'2':{{'1':{end_year},'2':{end_month},'3':{end_day}}}}},'4':[{{'1':{{'1':{metric_type},'2':1,'3':{count_type},'4':1}},'2':2}}],'5':1,'7':{{'1':{dimensions_js}}}}});
+  const resp = await fetch(url, {{method:'POST', body:body, credentials:'include'}});
+  const data = await resp.json();
+  return JSON.stringify(data);
+}})()
+"""
+        raw = self._run_browser_js(js)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from browser stats: {raw[:200]}")
+
+    def _parse_console_series(
+        self,
+        data: dict,
+        metric_name: str,
+        dim_index: int = 0,
+        country_code: str = "overall",
+    ) -> ConsoleStatsResult:
+        """Parse a statspage/time_series response into ConsoleStatsResult."""
+        series_list = data.get("1", [])
+        if dim_index >= len(series_list):
+            return ConsoleStatsResult(metric=metric_name, dimension=country_code, total=0)
+
+        series = series_list[dim_index]
+        points_raw = series.get("4", {}).get("1", [])
+
+        data_points: list[DailyStatPoint] = []
+        total = 0
+        for p in points_raw:
+            val_obj = p.get("2", {})
+            val = int(val_obj.get("2") or val_obj.get("1") or 0)
+            if val == 0:
+                continue
+            date_obj = p.get("4", {})
+            y, m, d = date_obj.get("1", 0), date_obj.get("2", 0), date_obj.get("3", 0)
+            if y and m and d:
+                date_str = f"{y:04d}-{m:02d}-{d:02d}"
+                data_points.append(DailyStatPoint(date=date_str, value=val))
+                total += val
+
+        return ConsoleStatsResult(
+            metric=metric_name,
+            dimension=country_code,
+            total=total,
+            data_points=data_points,
+        )
+
+    def get_install_stats(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        start_date: str,
+        end_date: str,
+        country_codes: list[str] | None = None,
+    ) -> ConsoleInstallStats:
+        """Get install statistics from Play Console via browser session.
+
+        Requires OpenCLI to be installed and the user to be logged into
+        Play Console (play.google.com/console) in the automation browser.
+
+        developer_id and app_id are the numeric IDs visible in the Play Console
+        URL: /console/u/0/developers/{developer_id}/app/{app_id}/statistics
+
+        Args:
+            package_name: App package name (for display only).
+            developer_id: Numeric developer account ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+            country_codes: Optional list of country codes (e.g. ['US','GB']) for breakdown.
+
+        Returns:
+            ConsoleInstallStats with install events, net installs, active users,
+            and optional per-country breakdown.
+        """
+        from datetime import date as date_cls
+
+        def parse_date(s: str) -> tuple[int, int, int]:
+            d = date_cls.fromisoformat(s)
+            return d.year, d.month, d.day
+
+        sy, sm, sd = parse_date(start_date)
+        ey, em, ed = parse_date(end_date)
+
+        self._logger.info("Fetching install stats via browser", package_name=package_name)
+
+        # Fetch all three metrics
+        install_data = self._fetch_console_time_series(
+            developer_id, app_id, 1, 1, sy, sm, sd, ey, em, ed, country_codes
+        )
+        net_data = self._fetch_console_time_series(
+            developer_id, app_id, 2, 1, sy, sm, sd, ey, em, ed
+        )
+        active_data = self._fetch_console_time_series(
+            developer_id, app_id, 3, 2, sy, sm, sd, ey, em, ed
+        )
+
+        install_result = self._parse_console_series(install_data, "install_events", 0, "overall")
+        net_result = self._parse_console_series(net_data, "net_installs", 0, "overall")
+        active_result = self._parse_console_series(active_data, "active_users", 0, "overall")
+
+        # Per-country breakdown for install events
+        by_country: list[ConsoleStatsResult] = []
+        if country_codes:
+            for i, cc in enumerate(country_codes):
+                r = self._parse_console_series(install_data, "install_events", i + 1, cc)
+                by_country.append(r)
+
+        return ConsoleInstallStats(
+            package_name=package_name,
+            start_date=start_date,
+            end_date=end_date,
+            install_events=install_result,
+            net_installs=net_result,
+            active_users=active_result,
+            by_country=by_country,
+        )

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -4447,6 +4447,99 @@ class PlayStoreClient:
             fields.setdefault(field_num, []).append(val)
         return fields
 
+    _EXPERIMENTS_STARTUP_DATA_TYPE = (
+        "type.googleapis.com/play.console.apps.api.storelistingexperiments."
+        "ExperimentOverviewPageStartupDataResponse"
+    )
+
+    @classmethod
+    def _extract_store_listing_experiments_payload(cls, envelope: dict[str, Any]) -> str:
+        """Find the base64 protobuf payload inside an OpenCLI network detail envelope."""
+        body = envelope.get("body")
+        if not isinstance(body, dict):
+            raise PlayStoreClientError("Experiments overview capture has no JSON body object")
+
+        def walk(value: Any) -> str | None:
+            if isinstance(value, dict):
+                if (
+                    value.get("1") == cls._EXPERIMENTS_STARTUP_DATA_TYPE
+                    and isinstance(value.get("2"), str)
+                    and value["2"]
+                ):
+                    return value["2"]
+                for child in value.values():
+                    found = walk(child)
+                    if found:
+                        return found
+            elif isinstance(value, list):
+                for child in value:
+                    found = walk(child)
+                    if found:
+                        return found
+            return None
+
+        payload = walk(body)
+        if payload:
+            return payload
+
+        legacy_payload = body.get("2")
+        if isinstance(legacy_payload, str) and legacy_payload:
+            return legacy_payload
+
+        raise PlayStoreClientError(
+            "Experiments overview capture did not contain a decodable startupData payload"
+        )
+
+    def _capture_store_listing_experiments_envelope(
+        self,
+        detail_key: str,
+        max_wait_seconds: float = 15.0,
+    ) -> dict[str, Any]:
+        """Poll OpenCLI network capture until the experiments startupData response is available."""
+        deadline = time.monotonic() + max_wait_seconds
+        last_detail_error: PlayStoreClientError | None = None
+
+        while True:
+            raw_list = self._run_opencli_cli(["network", "--since", "60s"], timeout=30)
+            try:
+                network_listing = json.loads(raw_list)
+            except json.JSONDecodeError as exc:
+                raise PlayStoreClientError(
+                    f"Invalid JSON from OpenCLI network listing: {raw_list[:200]}"
+                ) from exc
+
+            entries = network_listing.get("entries", [])
+            has_target = any(
+                isinstance(entry, dict) and str(entry.get("key", "")).startswith(detail_key)
+                for entry in entries
+            )
+
+            if has_target:
+                raw_detail = self._run_opencli_cli(
+                    ["network", "--since", "60s", "--detail", detail_key], timeout=30
+                )
+                try:
+                    envelope = json.loads(raw_detail)
+                except json.JSONDecodeError as exc:
+                    raise PlayStoreClientError(
+                        f"Invalid JSON from experiments overview capture: {raw_detail[:200]}"
+                    ) from exc
+
+                try:
+                    self._extract_store_listing_experiments_payload(envelope)
+                    return envelope
+                except PlayStoreClientError as exc:
+                    last_detail_error = exc
+
+            if time.monotonic() >= deadline:
+                if last_detail_error is not None:
+                    raise last_detail_error
+                raise PlayStoreClientError(
+                    "Timed out waiting for experiments overview startupData response"
+                )
+
+            time.sleep(1)
+
     def get_custom_store_listings(
         self,
         package_name: str,
@@ -4522,25 +4615,19 @@ class PlayStoreClient:
             f"/app/{app_id}/store-listing-experiments/overview"
         )
         self._run_opencli_cli(["open", url], timeout=45)
-        time.sleep(3)
         self._run_opencli_cli(["eval", "location.reload(); 'ok'"], timeout=30)
-        time.sleep(4)
 
         detail_key = (
             "POST playconsoleapps-pa.clients6.google.com/v1/developers/apps/"
             "storelistingexperiments/overview:startupData"
         )
-        raw = self._run_opencli_cli(["network", "--since", "60s", "--detail", detail_key], timeout=30)
+        envelope = self._capture_store_listing_experiments_envelope(detail_key)
+        body_b64 = self._extract_store_listing_experiments_payload(envelope)
+
         try:
-            envelope = json.loads(raw)
-        except json.JSONDecodeError:
-            raise PlayStoreClientError(f"Invalid JSON from experiments overview capture: {raw[:200]}")
-
-        body_b64 = envelope.get("body", {}).get("2")
-        if not body_b64:
-            return StoreListingExperimentsResult(package_name=package_name, experiments=[])
-
-        decoded = self._decode_protobuf_generic(base64.b64decode(body_b64))
+            decoded = self._decode_protobuf_generic(base64.b64decode(body_b64))
+        except Exception as exc:
+            raise PlayStoreClientError("Failed to decode experiments overview payload") from exc
         experiments: list[StoreListingExperimentSummary] = []
         for exp_msg in decoded.get(1, []):
             if not isinstance(exp_msg, dict):

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -61,6 +61,9 @@ logger = structlog.get_logger(__name__)
 # API scopes required for Play Developer API
 SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 
+# Scope for Play Developer Reporting API (vitals/crash/ANR data)
+REPORTING_SCOPES = ["https://www.googleapis.com/auth/playdeveloperreporting"]
+
 # Retry configuration
 MAX_RETRIES = 3
 INITIAL_BACKOFF = 1.0  # seconds
@@ -135,6 +138,7 @@ class PlayStoreClient:
         self._credentials_json = credentials_json or os.environ.get("GOOGLE_PLAY_STORE_CREDENTIALS")
         self._application_name = application_name
         self._service: AndroidPublisherResource | None = None
+        self._reporting_service: Any | None = None
         self._logger = logger.bind(component="PlayStoreClient")
 
     # =========================================================================
@@ -315,6 +319,59 @@ class PlayStoreClient:
                 raise
             self._logger.exception("Failed to initialize API client", error=str(e))
             raise PlayStoreClientError(f"Failed to initialize API client: {e}") from e
+
+    def _get_reporting_service(self) -> Any:
+        """Get or create the Play Developer Reporting API service instance."""
+        if self._reporting_service is not None:
+            return self._reporting_service
+
+        self._logger.info("Initializing Play Developer Reporting API client")
+
+        try:
+            credentials = None
+
+            if self._credentials_json:
+                if isinstance(self._credentials_json, str):
+                    if self._credentials_json.strip().startswith("{"):
+                        creds_info = json.loads(self._credentials_json)
+                        credentials = service_account.Credentials.from_service_account_info(
+                            creds_info, scopes=REPORTING_SCOPES
+                        )
+                    elif Path(self._credentials_json).exists():
+                        credentials = service_account.Credentials.from_service_account_file(
+                            self._credentials_json, scopes=REPORTING_SCOPES
+                        )
+                elif isinstance(self._credentials_json, dict):
+                    credentials = service_account.Credentials.from_service_account_info(
+                        self._credentials_json, scopes=REPORTING_SCOPES
+                    )
+
+            if not credentials and self._credentials_path:
+                creds_path = Path(self._credentials_path)
+                if creds_path.exists():
+                    credentials = service_account.Credentials.from_service_account_file(
+                        str(creds_path), scopes=REPORTING_SCOPES
+                    )
+
+            if not credentials:
+                raise PlayStoreClientError(
+                    "No valid credentials found for Reporting API. "
+                    "Set GOOGLE_PLAY_STORE_CREDENTIALS (JSON or path)."
+                )
+
+            self._reporting_service = build(
+                "playdeveloperreporting",
+                "v1beta1",
+                credentials=credentials,
+                cache_discovery=False,
+            )
+            self._logger.info("Reporting API client initialized successfully")
+            return self._reporting_service
+        except Exception as e:
+            if isinstance(e, PlayStoreClientError):
+                raise
+            self._logger.exception("Failed to initialize Reporting API client", error=str(e))
+            raise PlayStoreClientError(f"Failed to initialize Reporting API client: {e}") from e
 
     def _create_edit(self, package_name: str) -> str:
         """Create a new edit for the package.
@@ -2864,3 +2921,337 @@ class PlayStoreClient:
                 message=f"Failed to revoke subscription: {e.reason}",
                 error=str(e),
             )
+
+    # =========================================================================
+    # Play Developer Reporting API
+    # =========================================================================
+
+    def _parse_date(self, time_unit: dict[str, Any]) -> str:
+        """Convert Reporting API TimeUnit dict to YYYY-MM-DD string."""
+        y = time_unit.get("year", 0)
+        m = time_unit.get("month", 0)
+        d = time_unit.get("day", 0)
+        return f"{y:04d}-{m:02d}-{d:02d}"
+
+    def _build_time_unit(self, date_str: str) -> dict[str, Any]:
+        """Convert YYYY-MM-DD string to Reporting API TimeUnit dict."""
+        parts = date_str.split("-")
+        return {"year": int(parts[0]), "month": int(parts[1]), "day": int(parts[2])}
+
+    def _query_metric_set(
+        self,
+        package_name: str,
+        metric_set_name: str,
+        metrics: list[str],
+        dimensions: list[str],
+        start_date: str,
+        end_date: str,
+        aggregation_period: str = "DAILY",
+    ) -> "VitalsQueryResult":
+        """Generic helper to query any Reporting API metric set.
+
+        Args:
+            package_name: App package name.
+            metric_set_name: e.g. 'crashRateMetricSet', 'anrRateMetricSet'.
+            metrics: List of metric names to retrieve.
+            dimensions: List of dimension names to group by.
+            start_date: Start date as YYYY-MM-DD.
+            end_date: End date as YYYY-MM-DD (exclusive).
+            aggregation_period: 'DAILY' or 'HOURLY'.
+
+        Returns:
+            VitalsQueryResult with timeline data points.
+        """
+        from play_store_mcp.models import VitalsDataPoint, VitalsQueryResult
+
+        service = self._get_reporting_service()
+        parent = f"apps/{package_name}"
+
+        body: dict[str, Any] = {
+            "timeline": {
+                "aggregationPeriod": aggregation_period,
+                "startTime": self._build_time_unit(start_date),
+                "endTime": self._build_time_unit(end_date),
+            },
+            "metrics": metrics,
+        }
+        if dimensions:
+            body["dimensions"] = dimensions
+
+        self._logger.info(
+            "Querying metric set",
+            package_name=package_name,
+            metric_set=metric_set_name,
+            start=start_date,
+            end=end_date,
+        )
+
+        try:
+            resource = getattr(service, metric_set_name)()
+            result = resource.query(name=f"{parent}/{metric_set_name}", body=body).execute()
+
+            data_points: list[VitalsDataPoint] = []
+            for row in result.get("rows", []):
+                dims: dict[str, str] = {}
+                for d in row.get("dimensions", []):
+                    key = d.get("dimension", "")
+                    val = d.get("stringValue") or d.get("int64Value") or d.get("decimalValue", {}).get("value", "")
+                    dims[key] = str(val)
+
+                met: dict[str, float | None] = {}
+                for m in row.get("metrics", []):
+                    key = m.get("metric", "")
+                    decimal = m.get("decimalValue", {})
+                    val_str = decimal.get("value") if decimal else None
+                    met[key] = float(val_str) if val_str is not None else None
+
+                date_str = self._parse_date(row.get("startTime", {}))
+                data_points.append(
+                    VitalsDataPoint(
+                        date=date_str,
+                        aggregation_period=aggregation_period,
+                        dimensions=dims,
+                        metrics=met,
+                    )
+                )
+
+            # Strip trailing 'MetricSet' suffix for display
+            display_name = metric_set_name.replace("MetricSet", "")
+
+            return VitalsQueryResult(
+                package_name=package_name,
+                metric_set=display_name,
+                aggregation_period=aggregation_period,
+                data_points=data_points,
+                row_count=len(data_points),
+            )
+
+        except HttpError as e:
+            self._logger.exception("Reporting API query failed", error=str(e))
+            raise PlayStoreClientError(
+                f"Reporting API query failed for {metric_set_name}: {e.reason}"
+            ) from e
+
+    def get_crash_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query crash rate metrics from Play Developer Reporting API.
+
+        Requires the service account to have Performance Analysis permission
+        in Play Console (Account-level > Performance Analysis).
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions e.g. ['versionCode', 'apiLevel'].
+
+        Returns:
+            VitalsQueryResult with crashRate and distinctUsers per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="crashRateMetricSet",
+            metrics=["crashRate", "distinctUsers", "crashCount"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_anr_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query ANR (Application Not Responding) rate metrics.
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions e.g. ['versionCode', 'apiLevel'].
+
+        Returns:
+            VitalsQueryResult with anrRate and distinctUsers per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="anrRateMetricSet",
+            metrics=["anrRate", "distinctUsers", "anrCount"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_slow_startup_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query slow startup rate metrics.
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions.
+
+        Returns:
+            VitalsQueryResult with slowStartupRate per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="slowStartupRateMetricSet",
+            metrics=["slowStartupRate", "distinctUsers", "slowStartupCount"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_slow_rendering_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query slow rendering rate metrics (< 20fps / < 30fps).
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions.
+
+        Returns:
+            VitalsQueryResult with slowRenderingRate20Fps, slowRenderingRate30Fps per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="slowRenderingRateMetricSet",
+            metrics=["slowRenderingRate20Fps", "slowRenderingRate30Fps", "distinctUsers"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_excessive_wakeup_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query excessive wakeup rate metrics.
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions.
+
+        Returns:
+            VitalsQueryResult with excessiveWakeupRate per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="excessiveWakeupRateMetricSet",
+            metrics=["excessiveWakeupRate", "distinctUsers", "excessiveWakeupCount"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def get_stuck_wakelock_rate(
+        self,
+        package_name: str,
+        start_date: str,
+        end_date: str,
+        dimensions: list[str] | None = None,
+    ) -> "VitalsQueryResult":
+        """Query stuck background wakelock rate metrics.
+
+        Args:
+            package_name: App package name.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD (exclusive).
+            dimensions: Optional grouping dimensions.
+
+        Returns:
+            VitalsQueryResult with stuckBgWakelockRate per day.
+        """
+        return self._query_metric_set(
+            package_name=package_name,
+            metric_set_name="stuckBackgroundWakelockRateMetricSet",
+            metrics=["stuckBgWakelockRate", "distinctUsers", "stuckBgWakelockCount"],
+            dimensions=dimensions or [],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def list_vitals_anomalies(
+        self,
+        package_name: str,
+        filter_str: str | None = None,
+    ) -> "list[VitalsAnomaly]":
+        """List detected vitals anomalies for an app.
+
+        Anomalies are automatically detected degradations in any vitals metric.
+
+        Args:
+            package_name: App package name.
+            filter_str: Optional filter string, e.g. 'metric = crashRate'.
+
+        Returns:
+            List of VitalsAnomaly objects.
+        """
+        from play_store_mcp.models import VitalsAnomaly
+
+        service = self._get_reporting_service()
+        parent = f"apps/{package_name}"
+
+        self._logger.info("Listing vitals anomalies", package_name=package_name)
+
+        try:
+            kwargs: dict[str, Any] = {"parent": parent}
+            if filter_str:
+                kwargs["filter"] = filter_str
+
+            result = service.anomalies().list(**kwargs).execute()
+
+            anomalies = []
+            for a in result.get("anomalies", []):
+                dims: dict[str, str] = {}
+                for d in a.get("dimensions", []):
+                    key = d.get("dimension", "")
+                    val = d.get("stringValue") or d.get("int64Value", "")
+                    dims[key] = str(val)
+
+                first_time = a.get("firstDetectionTime")
+                first_str = self._parse_date(first_time) if first_time else None
+
+                last_day = a.get("lastDetectedDay")
+                last_str = self._parse_date(last_day) if last_day else None
+
+                anomalies.append(
+                    VitalsAnomaly(
+                        name=a.get("name", ""),
+                        metric_set=a.get("metricSet", "").replace("MetricSet", ""),
+                        dimensions=dims,
+                        first_detection_time=first_str,
+                        last_detected_day=last_str,
+                    )
+                )
+            return anomalies
+
+        except HttpError as e:
+            self._logger.exception("Failed to list anomalies", error=str(e))
+            raise PlayStoreClientError(f"Failed to list vitals anomalies: {e.reason}") from e

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -18,21 +18,32 @@ from googleapiclient.http import MediaFileUpload
 
 from play_store_mcp.models import (
     AppDetails,
+    AppDetailsInfo,
+    AppDetailsUpdateResult,
     AppInfo,
     BatchDeploymentResult,
+    CountryAvailability,
     DeploymentResult,
     ExpansionFile,
+    GrantInfo,
+    ImageInfo,
+    ImageUploadResult,
     InAppProduct,
     Listing,
     ListingUpdateResult,
     Order,
+    ProductPurchase,
+    RefundResult,
     Release,
     Review,
     ReviewReplyResult,
     SubscriptionProduct,
     SubscriptionPurchase,
+    SubscriptionPurchaseV2,
     TesterInfo,
     TrackInfo,
+    UserInfo,
+    UserOperationResult,
     ValidationError,
     VitalsMetric,
     VitalsOverview,
@@ -1524,10 +1535,10 @@ class PlayStoreClient:
             )
 
             listings: list[Listing] = []
-            for lang, listing_data in result.get("listings", {}).items():
+            for listing_data in result.get("listings", []):
                 listings.append(
                     Listing(
-                        language=lang,
+                        language=listing_data.get("language", ""),
                         title=listing_data.get("title"),
                         full_description=listing_data.get("fullDescription"),
                         short_description=listing_data.get("shortDescription"),
@@ -1565,9 +1576,11 @@ class PlayStoreClient:
                 .execute()
             )
 
+            individual_emails: list[str] = testers_data.get("testers", [])
+            group_emails: list[str] = testers_data.get("googleGroups", [])
             return TesterInfo(
                 track=track,
-                tester_emails=testers_data.get("googleGroups", []),
+                tester_emails=individual_emails + group_emails,
             )
         except HttpError as e:
             if e.resp.status == 404:
@@ -1722,3 +1735,947 @@ class PlayStoreClient:
             raise PlayStoreClientError(f"Failed to get expansion file: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
+
+    # =========================================================================
+    # Images API
+    # =========================================================================
+
+    def list_images(
+        self,
+        package_name: str,
+        language: str,
+        image_type: str,
+    ) -> list[ImageInfo]:
+        """List store listing images of a given type and language.
+
+        Args:
+            package_name: App package name.
+            language: Language code (e.g., en-US).
+            image_type: One of: phoneScreenshots, sevenInchScreenshots,
+                        tenInchScreenshots, tvScreenshots, wearScreenshots,
+                        icon, featureGraphic, tvBanner, promoGraphic.
+
+        Returns:
+            List of image info objects.
+        """
+        self._logger.info(
+            "Listing images",
+            package_name=package_name,
+            language=language,
+            image_type=image_type,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            result = (
+                service.edits()
+                .images()
+                .list(
+                    packageName=package_name,
+                    editId=edit_id,
+                    language=language,
+                    imageType=image_type,
+                )
+                .execute()
+            )
+
+            return [
+                ImageInfo(
+                    image_id=img["id"],
+                    url=img.get("url", ""),
+                    sha1=img.get("sha1"),
+                    sha256=img.get("sha256"),
+                )
+                for img in result.get("images", [])
+            ]
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def upload_image(
+        self,
+        package_name: str,
+        language: str,
+        image_type: str,
+        file_path: str,
+    ) -> ImageUploadResult:
+        """Upload a store listing image.
+
+        Args:
+            package_name: App package name.
+            language: Language code (e.g., en-US).
+            image_type: Image type (e.g., phoneScreenshots, icon, featureGraphic).
+            file_path: Absolute path to the image file (PNG or JPEG).
+
+        Returns:
+            Upload result with image ID.
+        """
+        self._logger.info(
+            "Uploading image",
+            package_name=package_name,
+            language=language,
+            image_type=image_type,
+            file_path=file_path,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            media = MediaFileUpload(file_path, resumable=True)
+            result = (
+                service.edits()
+                .images()
+                .upload(
+                    packageName=package_name,
+                    editId=edit_id,
+                    language=language,
+                    imageType=image_type,
+                    media_body=media,
+                )
+                .execute()
+            )
+
+            self._commit_edit(package_name, edit_id)
+            img = result.get("image", {})
+            return ImageUploadResult(
+                success=True,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                image_id=img.get("id"),
+                message=f"Successfully uploaded {image_type} image for {language}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to upload image", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=False,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                message=f"Failed to upload image: {e.reason}",
+                error=str(e),
+            )
+        except Exception as e:
+            self._logger.exception("Failed to upload image", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=False,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                message=f"Failed to upload image: {e}",
+                error=str(e),
+            )
+
+    def delete_image(
+        self,
+        package_name: str,
+        language: str,
+        image_type: str,
+        image_id: str,
+    ) -> ImageUploadResult:
+        """Delete a specific store listing image.
+
+        Args:
+            package_name: App package name.
+            language: Language code (e.g., en-US).
+            image_type: Image type.
+            image_id: ID of the image to delete.
+
+        Returns:
+            Delete result.
+        """
+        self._logger.info(
+            "Deleting image",
+            package_name=package_name,
+            language=language,
+            image_type=image_type,
+            image_id=image_id,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            service.edits().images().delete(
+                packageName=package_name,
+                editId=edit_id,
+                language=language,
+                imageType=image_type,
+                imageId=image_id,
+            ).execute()
+
+            self._commit_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=True,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                image_id=image_id,
+                message=f"Successfully deleted image {image_id}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete image", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=False,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                message=f"Failed to delete image: {e.reason}",
+                error=str(e),
+            )
+
+    def delete_all_images(
+        self,
+        package_name: str,
+        language: str,
+        image_type: str,
+    ) -> ImageUploadResult:
+        """Delete all store listing images of a given type and language.
+
+        Args:
+            package_name: App package name.
+            language: Language code (e.g., en-US).
+            image_type: Image type to clear.
+
+        Returns:
+            Delete result.
+        """
+        self._logger.info(
+            "Deleting all images",
+            package_name=package_name,
+            language=language,
+            image_type=image_type,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            service.edits().images().deleteall(
+                packageName=package_name,
+                editId=edit_id,
+                language=language,
+                imageType=image_type,
+            ).execute()
+
+            self._commit_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=True,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                message=f"Successfully deleted all {image_type} images for {language}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete all images", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ImageUploadResult(
+                success=False,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                message=f"Failed to delete all images: {e.reason}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # App Details API (edits.details)
+    # =========================================================================
+
+    def get_app_details_info(self, package_name: str) -> AppDetailsInfo:
+        """Get app details including default language and contact info.
+
+        Args:
+            package_name: App package name.
+
+        Returns:
+            App details info.
+        """
+        self._logger.info("Getting app details", package_name=package_name)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            result = (
+                service.edits()
+                .details()
+                .get(packageName=package_name, editId=edit_id)
+                .execute()
+            )
+
+            return AppDetailsInfo(
+                package_name=package_name,
+                default_language=result.get("defaultLanguage"),
+                contact_email=result.get("contactEmail"),
+                contact_phone=result.get("contactPhone"),
+                contact_website=result.get("contactWebsite"),
+            )
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def update_app_details_info(
+        self,
+        package_name: str,
+        default_language: str | None = None,
+        contact_email: str | None = None,
+        contact_phone: str | None = None,
+        contact_website: str | None = None,
+    ) -> AppDetailsUpdateResult:
+        """Update app details such as default language and contact info.
+
+        Args:
+            package_name: App package name.
+            default_language: Default language code (e.g., en-US).
+            contact_email: Developer contact email.
+            contact_phone: Developer contact phone.
+            contact_website: Developer contact website.
+
+        Returns:
+            Update result.
+        """
+        self._logger.info("Updating app details", package_name=package_name)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            current = (
+                service.edits()
+                .details()
+                .get(packageName=package_name, editId=edit_id)
+                .execute()
+            )
+
+            body = {
+                "defaultLanguage": default_language or current.get("defaultLanguage"),
+                "contactEmail": contact_email if contact_email is not None else current.get("contactEmail"),
+                "contactPhone": contact_phone if contact_phone is not None else current.get("contactPhone"),
+                "contactWebsite": contact_website if contact_website is not None else current.get("contactWebsite"),
+            }
+
+            service.edits().details().update(
+                packageName=package_name,
+                editId=edit_id,
+                body=body,
+            ).execute()
+
+            self._commit_edit(package_name, edit_id)
+            return AppDetailsUpdateResult(
+                success=True,
+                package_name=package_name,
+                message="Successfully updated app details",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to update app details", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return AppDetailsUpdateResult(
+                success=False,
+                package_name=package_name,
+                message=f"Failed to update app details: {e.reason}",
+                error=str(e),
+            )
+        except Exception as e:
+            self._logger.exception("Failed to update app details", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return AppDetailsUpdateResult(
+                success=False,
+                package_name=package_name,
+                message=f"Failed to update app details: {e}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # Country Availability API (edits.countryavailability)
+    # =========================================================================
+
+    def get_country_availability(
+        self,
+        package_name: str,
+        track: str,
+    ) -> CountryAvailability:
+        """Get country availability for a release track.
+
+        Args:
+            package_name: App package name.
+            track: Track name (internal, alpha, beta, production).
+
+        Returns:
+            Country availability information.
+        """
+        self._logger.info(
+            "Getting country availability",
+            package_name=package_name,
+            track=track,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            result = (
+                service.edits()
+                .countryavailability()
+                .get(packageName=package_name, editId=edit_id, track=track)
+                .execute()
+            )
+
+            countries = [
+                c.get("countryCode", "")
+                for c in result.get("countries", [])
+            ]
+            return CountryAvailability(
+                package_name=package_name,
+                track=track,
+                countries=countries,
+                rest_of_world=result.get("restOfWorld", False),
+            )
+        except HttpError as e:
+            if e.resp.status == 404:
+                return CountryAvailability(package_name=package_name, track=track)
+            raise PlayStoreClientError(f"Failed to get country availability: {e.reason}") from e
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    # =========================================================================
+    # Users API
+    # =========================================================================
+
+    def list_users(self, developer_id: str) -> list[UserInfo]:
+        """List all users in a developer account.
+
+        Args:
+            developer_id: Developer account ID (numeric, from Play Console URL).
+
+        Returns:
+            List of user info objects.
+        """
+        self._logger.info("Listing users", developer_id=developer_id)
+        service = self._get_service()
+
+        try:
+            result = service.users().list(
+                parent=f"developers/{developer_id}"
+            ).execute()
+
+            users = []
+            for u in result.get("users", []):
+                grants = [
+                    GrantInfo(
+                        package_name=g.get("packageName", ""),
+                        app_level_permissions=g.get("appLevelPermissions", []),
+                    )
+                    for g in u.get("grants", [])
+                ]
+                users.append(
+                    UserInfo(
+                        name=u.get("name"),
+                        email=u.get("email", ""),
+                        access_state=u.get("accessState"),
+                        grants=grants,
+                    )
+                )
+            return users
+
+        except HttpError as e:
+            raise PlayStoreClientError(f"Failed to list users: {e.reason}") from e
+
+    def create_user(
+        self,
+        developer_id: str,
+        email: str,
+        access_state: str = "accessGranted",
+    ) -> UserOperationResult:
+        """Add a user to the developer account.
+
+        Args:
+            developer_id: Developer account ID.
+            email: User email address.
+            access_state: Account-level access state. One of:
+                          accessGranted, accessExpired, accessRevoked.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Creating user",
+            developer_id=developer_id,
+            email=email,
+            access_state=access_state,
+        )
+        service = self._get_service()
+
+        try:
+            service.users().create(
+                parent=f"developers/{developer_id}",
+                body={"email": email, "accessState": access_state},
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email=email,
+                message=f"Successfully added user {email}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to create user", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email=email,
+                message=f"Failed to add user: {e.reason}",
+                error=str(e),
+            )
+
+    def delete_user(
+        self,
+        developer_id: str,
+        email: str,
+    ) -> UserOperationResult:
+        """Remove a user from the developer account.
+
+        Args:
+            developer_id: Developer account ID.
+            email: User email address to remove.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info("Deleting user", developer_id=developer_id, email=email)
+        service = self._get_service()
+
+        try:
+            service.users().delete(
+                name=f"developers/{developer_id}/users/{email}"
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email=email,
+                message=f"Successfully removed user {email}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete user", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email=email,
+                message=f"Failed to remove user: {e.reason}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # Grants API
+    # =========================================================================
+
+    def create_grant(
+        self,
+        developer_id: str,
+        email: str,
+        package_name: str,
+        app_level_permissions: list[str],
+    ) -> UserOperationResult:
+        """Grant a user app-level permissions.
+
+        Args:
+            developer_id: Developer account ID.
+            email: User email address.
+            package_name: App package name to grant access to.
+            app_level_permissions: List of permissions to grant. Valid values include:
+                canAccessStats, canManageProductionRelease, canManageTestTracks,
+                canManageStorePresence, canReplyToReviews.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Creating grant",
+            developer_id=developer_id,
+            email=email,
+            package_name=package_name,
+        )
+        service = self._get_service()
+
+        try:
+            service.grants().create(
+                parent=f"developers/{developer_id}/users/{email}",
+                body={
+                    "packageName": package_name,
+                    "appLevelPermissions": app_level_permissions,
+                },
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email=email,
+                message=f"Successfully granted permissions on {package_name} to {email}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to create grant", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email=email,
+                message=f"Failed to create grant: {e.reason}",
+                error=str(e),
+            )
+
+    def delete_grant(
+        self,
+        developer_id: str,
+        email: str,
+        package_name: str,
+    ) -> UserOperationResult:
+        """Revoke a user's app-level permissions.
+
+        Args:
+            developer_id: Developer account ID.
+            email: User email address.
+            package_name: App package name to revoke access from.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Deleting grant",
+            developer_id=developer_id,
+            email=email,
+            package_name=package_name,
+        )
+        service = self._get_service()
+
+        try:
+            service.grants().delete(
+                name=f"developers/{developer_id}/users/{email}/grants/{package_name}"
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email=email,
+                message=f"Successfully revoked permissions on {package_name} from {email}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to delete grant", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email=email,
+                message=f"Failed to revoke grant: {e.reason}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # Orders Refund API
+    # =========================================================================
+
+    def refund_order(
+        self,
+        package_name: str,
+        order_id: str,
+        revoke: bool = False,
+    ) -> RefundResult:
+        """Refund an order.
+
+        Args:
+            package_name: App package name.
+            order_id: Order ID to refund.
+            revoke: If True, also revokes the user's entitlement to the purchase.
+
+        Returns:
+            Refund result.
+        """
+        self._logger.info(
+            "Refunding order",
+            package_name=package_name,
+            order_id=order_id,
+            revoke=revoke,
+        )
+        service = self._get_service()
+
+        try:
+            service.orders().refund(
+                packageName=package_name,
+                orderId=order_id,
+                revoke=revoke,
+            ).execute()
+
+            return RefundResult(
+                success=True,
+                order_id=order_id,
+                package_name=package_name,
+                revoked=revoke,
+                message=f"Successfully refunded order {order_id}"
+                + (" and revoked entitlement" if revoke else ""),
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to refund order", error=str(e))
+            return RefundResult(
+                success=False,
+                order_id=order_id,
+                package_name=package_name,
+                message=f"Failed to refund order: {e.reason}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # Purchases - Products (one-time in-app purchases)
+    # =========================================================================
+
+    def get_product_purchase(
+        self,
+        package_name: str,
+        product_id: str,
+        token: str,
+    ) -> ProductPurchase:
+        """Get the status of a one-time in-app product purchase.
+
+        Args:
+            package_name: App package name.
+            product_id: Product SKU.
+            token: Purchase token from the client.
+
+        Returns:
+            Product purchase status.
+        """
+        self._logger.info(
+            "Getting product purchase",
+            package_name=package_name,
+            product_id=product_id,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.purchases()
+                .products()
+                .get(
+                    packageName=package_name,
+                    productId=product_id,
+                    token=token,
+                )
+                .execute()
+            )
+
+            purchase_time_ms = result.get("purchaseTimeMillis")
+            from datetime import datetime, timezone
+            purchase_time = (
+                datetime.fromtimestamp(int(purchase_time_ms) / 1000, tz=timezone.utc)
+                if purchase_time_ms
+                else None
+            )
+
+            return ProductPurchase(
+                package_name=package_name,
+                product_id=product_id,
+                purchase_token=token,
+                purchase_time=purchase_time,
+                purchase_state=result.get("purchaseState"),
+                consumption_state=result.get("consumptionState"),
+                developer_payload=result.get("developerPayload"),
+                order_id=result.get("orderId"),
+                acknowledged=bool(result.get("acknowledgementState", 0)),
+                quantity=result.get("quantity"),
+            )
+
+        except HttpError as e:
+            raise PlayStoreClientError(f"Failed to get product purchase: {e.reason}") from e
+
+    def acknowledge_product_purchase(
+        self,
+        package_name: str,
+        product_id: str,
+        token: str,
+        developer_payload: str = "",
+    ) -> UserOperationResult:
+        """Acknowledge a one-time in-app product purchase.
+
+        Must be called within 3 days of purchase, or the purchase will be reversed.
+
+        Args:
+            package_name: App package name.
+            product_id: Product SKU.
+            token: Purchase token from the client.
+            developer_payload: Optional developer payload string.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Acknowledging product purchase",
+            package_name=package_name,
+            product_id=product_id,
+        )
+        service = self._get_service()
+
+        try:
+            service.purchases().products().acknowledge(
+                packageName=package_name,
+                productId=product_id,
+                token=token,
+                body={"developerPayload": developer_payload},
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email="",
+                message=f"Successfully acknowledged purchase of {product_id}",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to acknowledge purchase", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email="",
+                message=f"Failed to acknowledge purchase: {e.reason}",
+                error=str(e),
+            )
+
+    # =========================================================================
+    # Purchases - Subscriptions v2
+    # =========================================================================
+
+    def get_subscription_purchase_v2(
+        self,
+        package_name: str,
+        token: str,
+    ) -> SubscriptionPurchaseV2:
+        """Get subscription purchase details using the v2 API.
+
+        Args:
+            package_name: App package name.
+            token: Purchase token from the client.
+
+        Returns:
+            Subscription purchase v2 status.
+        """
+        self._logger.info(
+            "Getting subscription purchase v2",
+            package_name=package_name,
+        )
+        service = self._get_service()
+
+        try:
+            result = (
+                service.purchases()
+                .subscriptionsv2()
+                .get(packageName=package_name, token=token)
+                .execute()
+            )
+
+            from datetime import datetime, timezone
+
+            def parse_time(ts: str | None) -> datetime | None:
+                if not ts:
+                    return None
+                try:
+                    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                except ValueError:
+                    return None
+
+            line_items = result.get("lineItems", [])
+            first_item = line_items[0] if line_items else {}
+
+            return SubscriptionPurchaseV2(
+                package_name=package_name,
+                purchase_token=token,
+                subscription_state=result.get("subscriptionState"),
+                latest_order_id=result.get("latestOrderId"),
+                start_time=parse_time(result.get("startTime")),
+                expiry_time=parse_time(first_item.get("expiryTime")),
+                auto_renewing=result.get("cancelSurveyResult") is None
+                and result.get("subscriptionState") == "SUBSCRIPTION_STATE_ACTIVE",
+                product_id=first_item.get("productId"),
+                base_plan_id=first_item.get("offerDetails", {}).get("basePlanId"),
+                offer_id=first_item.get("offerDetails", {}).get("offerId"),
+            )
+
+        except HttpError as e:
+            raise PlayStoreClientError(
+                f"Failed to get subscription purchase v2: {e.reason}"
+            ) from e
+
+    def cancel_subscription_v2(
+        self,
+        package_name: str,
+        token: str,
+    ) -> UserOperationResult:
+        """Cancel a subscription using the v2 API.
+
+        Args:
+            package_name: App package name.
+            token: Purchase token from the client.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Canceling subscription v2",
+            package_name=package_name,
+        )
+        service = self._get_service()
+
+        try:
+            service.purchases().subscriptionsv2().cancel(
+                packageName=package_name,
+                token=token,
+                body={},
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email="",
+                message="Successfully canceled subscription",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to cancel subscription", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email="",
+                message=f"Failed to cancel subscription: {e.reason}",
+                error=str(e),
+            )
+
+    def revoke_subscription_v2(
+        self,
+        package_name: str,
+        token: str,
+    ) -> UserOperationResult:
+        """Revoke a subscription using the v2 API (cancels and immediately expires).
+
+        Args:
+            package_name: App package name.
+            token: Purchase token from the client.
+
+        Returns:
+            Operation result.
+        """
+        self._logger.info(
+            "Revoking subscription v2",
+            package_name=package_name,
+        )
+        service = self._get_service()
+
+        try:
+            service.purchases().subscriptionsv2().revoke(
+                packageName=package_name,
+                token=token,
+                body={},
+            ).execute()
+
+            return UserOperationResult(
+                success=True,
+                email="",
+                message="Successfully revoked subscription",
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to revoke subscription", error=str(e))
+            return UserOperationResult(
+                success=False,
+                email="",
+                message=f"Failed to revoke subscription: {e.reason}",
+                error=str(e),
+            )

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -22,9 +22,12 @@ from play_store_mcp.models import (
     AppDetailsUpdateResult,
     AppInfo,
     BatchDeploymentResult,
+    BundleInfo,
     CountryAvailability,
+    DeobfuscationFileResult,
     DeploymentResult,
     ExpansionFile,
+    GeneratedApkInfo,
     GrantInfo,
     ImageInfo,
     ImageUploadResult,
@@ -914,7 +917,7 @@ class PlayStoreClient:
                 short_description=listing.get("shortDescription"),
                 full_description=listing.get("fullDescription"),
                 default_language=details.get("defaultLanguage"),
-                developer_name=details.get("contactWebsite"),
+                developer_name=None,
                 developer_email=details.get("contactEmail"),
                 developer_website=details.get("contactWebsite"),
             )
@@ -1239,24 +1242,14 @@ class PlayStoreClient:
     def get_vitals_overview(self, package_name: str) -> VitalsOverview:
         """Get Android Vitals overview.
 
-        Note: The full Vitals API requires additional setup.
-        This provides a basic overview structure.
-
-        Args:
-            package_name: App package name.
-
-        Returns:
-            Vitals overview (may be partial without full API access).
+        Raises:
+            PlayStoreClientError: Always - requires separate Play Developer Reporting API
+                setup with additional scopes not supported by this MCP.
         """
-        self._logger.info("Getting vitals overview", package_name=package_name)
-
-        # The Vitals API is part of the Play Developer Reporting API
-        # which requires separate authentication/setup
-        # For now, return a placeholder that indicates where data would come from
-
-        return VitalsOverview(
-            package_name=package_name,
-            freshness_info="Vitals data requires Play Developer Reporting API access",
+        raise PlayStoreClientError(
+            "get_vitals_overview requires the Play Developer Reporting API "
+            "(playdeveloperreporting v1beta1), which is not yet implemented in this MCP. "
+            "Use the Google Play Console UI or set up the Reporting API separately."
         )
 
     def get_vitals_metrics(
@@ -1266,34 +1259,15 @@ class PlayStoreClient:
     ) -> list[VitalsMetric]:
         """Get specific Android Vitals metrics.
 
-        Note: Full implementation requires Play Developer Reporting API setup.
-        This is a placeholder implementation.
-
-        Args:
-            package_name: App package name.
-            metric_type: Type of metric (crashRate, anrRate, etc.).
-
-        Returns:
-            List of vitals metrics (placeholder).
+        Raises:
+            PlayStoreClientError: Always - requires separate Play Developer Reporting API
+                setup with additional scopes not supported by this MCP.
         """
-        self._logger.info(
-            "Getting vitals metrics",
-            package_name=package_name,
-            metric_type=metric_type,
+        raise PlayStoreClientError(
+            "get_vitals_metrics requires the Play Developer Reporting API "
+            "(playdeveloperreporting v1beta1), which is not yet implemented in this MCP. "
+            "Use the Google Play Console UI or set up the Reporting API separately."
         )
-
-        # The Play Developer Reporting API is separate and requires additional setup
-        # Return placeholder indicating this limitation
-        return [
-            VitalsMetric(
-                metric_type=metric_type,
-                value=None,
-                benchmark=None,
-                is_below_threshold=None,
-                dimension="api_level",
-                dimension_value="Requires Play Developer Reporting API access",
-            )
-        ]
 
     # =========================================================================
     # In-App Products API
@@ -1535,16 +1509,29 @@ class PlayStoreClient:
             )
 
             listings: list[Listing] = []
-            for listing_data in result.get("listings", []):
-                listings.append(
-                    Listing(
-                        language=listing_data.get("language", ""),
-                        title=listing_data.get("title"),
-                        full_description=listing_data.get("fullDescription"),
-                        short_description=listing_data.get("shortDescription"),
-                        video=listing_data.get("video"),
+            raw_listings = result.get("listings", [])
+            if isinstance(raw_listings, dict):
+                for language, listing_data in raw_listings.items():
+                    listings.append(
+                        Listing(
+                            language=language,
+                            title=listing_data.get("title"),
+                            full_description=listing_data.get("fullDescription"),
+                            short_description=listing_data.get("shortDescription"),
+                            video=listing_data.get("video"),
+                        )
                     )
-                )
+            else:
+                for listing_data in raw_listings:
+                    listings.append(
+                        Listing(
+                            language=listing_data.get("language", ""),
+                            title=listing_data.get("title"),
+                            full_description=listing_data.get("fullDescription"),
+                            short_description=listing_data.get("shortDescription"),
+                            video=listing_data.get("video"),
+                        )
+                    )
 
             return listings
         finally:
@@ -1595,22 +1582,28 @@ class PlayStoreClient:
         package_name: str,
         track: str,
         tester_emails: list[str],
+        google_group_emails: list[str] | None = None,
     ) -> ListingUpdateResult:
-        """Update testers for a specific track.
+        """Update the list of testers for a track.
 
         Args:
             package_name: App package name.
             track: Track name (internal, alpha, beta).
-            tester_emails: List of tester email addresses or Google Group emails.
+            tester_emails: List of individual tester email addresses.
+            google_group_emails: List of Google Group email addresses.
 
         Returns:
             Update result.
         """
+        if google_group_emails is None:
+            google_group_emails = []
+
         self._logger.info(
             "Updating testers",
             package_name=package_name,
             track=track,
-            count=len(tester_emails),
+            individual_count=len(tester_emails),
+            group_count=len(google_group_emails),
         )
         service = self._get_service()
         edit_id = self._create_edit(package_name)
@@ -1620,16 +1613,18 @@ class PlayStoreClient:
                 packageName=package_name,
                 editId=edit_id,
                 track=track,
-                body={"googleGroups": tester_emails},
+                body={"testers": tester_emails, "googleGroups": google_group_emails},
             ).execute()
 
             self._commit_edit(package_name, edit_id)
 
+            total = len(tester_emails) + len(google_group_emails)
+
             return ListingUpdateResult(
                 success=True,
                 package_name=package_name,
-                language=track,  # Reusing field for track
-                message=f"Successfully updated {len(tester_emails)} testers for {track}",
+                language=track,
+                message=f"Successfully updated {total} testers for {track}",
             )
 
         except HttpError as e:
@@ -1733,6 +1728,196 @@ class PlayStoreClient:
                 )
             self._logger.exception("Failed to get expansion file", error=str(e))
             raise PlayStoreClientError(f"Failed to get expansion file: {e.reason}") from e
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def upload_deobfuscation_file(
+        self,
+        package_name: str,
+        version_code: int,
+        file_path: str,
+        deobfuscation_file_type: str = "proguard",
+    ) -> DeobfuscationFileResult:
+        """Upload a deobfuscation (ProGuard/R8) mapping file for an APK version.
+
+        Args:
+            package_name: App package name.
+            version_code: APK version code to associate the mapping with.
+            file_path: Absolute path to the mapping.txt file.
+            deobfuscation_file_type: Type of mapping file - 'proguard' or 'nativeCode'.
+
+        Returns:
+            Upload result.
+        """
+        self._logger.info(
+            "Uploading deobfuscation file",
+            package_name=package_name,
+            version_code=version_code,
+            file_path=file_path,
+            type=deobfuscation_file_type,
+        )
+
+        if not os.path.isfile(file_path):
+            return DeobfuscationFileResult(
+                success=False,
+                package_name=package_name,
+                version_code=version_code,
+                deobfuscation_file_type=deobfuscation_file_type,
+                message=f"File not found: {file_path}",
+            )
+
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            media = MediaFileUpload(
+                file_path,
+                mimetype="application/octet-stream",
+                resumable=False,
+            )
+            service.edits().deobfuscationfiles().upload(
+                packageName=package_name,
+                editId=edit_id,
+                apkVersionCode=version_code,
+                deobfuscationFileType=deobfuscation_file_type,
+                media_body=media,
+            ).execute()
+
+            self._commit_edit(package_name, edit_id)
+
+            return DeobfuscationFileResult(
+                success=True,
+                package_name=package_name,
+                version_code=version_code,
+                deobfuscation_file_type=deobfuscation_file_type,
+                message=(
+                    f"Successfully uploaded {deobfuscation_file_type} mapping "
+                    f"for version {version_code}"
+                ),
+            )
+
+        except HttpError as e:
+            self._logger.exception("Failed to upload deobfuscation file", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return DeobfuscationFileResult(
+                success=False,
+                package_name=package_name,
+                version_code=version_code,
+                deobfuscation_file_type=deobfuscation_file_type,
+                message=f"Failed to upload deobfuscation file: {e.reason}",
+                error=str(e),
+            )
+        except Exception as e:
+            self._logger.exception("Failed to upload deobfuscation file", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return DeobfuscationFileResult(
+                success=False,
+                package_name=package_name,
+                version_code=version_code,
+                deobfuscation_file_type=deobfuscation_file_type,
+                message=f"Failed to upload deobfuscation file: {e}",
+                error=str(e),
+            )
+
+    def list_bundles(self, package_name: str) -> list[BundleInfo]:
+        """List all AAB bundles for the app.
+
+        Args:
+            package_name: App package name.
+
+        Returns:
+            List of bundle information objects.
+        """
+        self._logger.info("Listing bundles", package_name=package_name)
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            result = (
+                service.edits()
+                .bundles()
+                .list(packageName=package_name, editId=edit_id)
+                .execute()
+            )
+
+            bundles = []
+            for b in result.get("bundles", []):
+                bundles.append(
+                    BundleInfo(
+                        package_name=package_name,
+                        version_code=int(b.get("versionCode", 0)),
+                        sha1=b.get("sha1"),
+                        sha256=b.get("sha256"),
+                    )
+                )
+            return bundles
+
+        except HttpError as e:
+            self._logger.exception("Failed to list bundles", error=str(e))
+            raise PlayStoreClientError(f"Failed to list bundles: {e.reason}") from e
+        finally:
+            self._delete_edit(package_name, edit_id)
+
+    def list_generated_apks(
+        self,
+        package_name: str,
+        bundle_version_code: int,
+    ) -> list[GeneratedApkInfo]:
+        """List APKs generated from a specific AAB bundle version.
+
+        Args:
+            package_name: App package name.
+            bundle_version_code: Version code of the bundle to query.
+
+        Returns:
+            List of generated APK info objects.
+        """
+        self._logger.info(
+            "Listing generated APKs",
+            package_name=package_name,
+            bundle_version_code=bundle_version_code,
+        )
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+
+        try:
+            result = (
+                service.edits()
+                .generatedapks()
+                .list(
+                    packageName=package_name,
+                    editId=edit_id,
+                    versionCode=bundle_version_code,
+                )
+                .execute()
+            )
+
+            apks = []
+            for apk in result.get("generatedApks", []):
+                split_types = []
+                if apk.get("generatedSplitApks"):
+                    split_types.append("splits")
+                if apk.get("generatedUniversalApk"):
+                    split_types.append("universal")
+                if apk.get("generatedStandaloneApks"):
+                    split_types.append("standalone")
+
+                apks.append(
+                    GeneratedApkInfo(
+                        package_name=package_name,
+                        bundle_version_code=bundle_version_code,
+                        download_id=apk.get("downloadId"),
+                        variant_id=apk.get("variantId"),
+                        target_sdk_version=apk.get("targetSdkVersion"),
+                        min_sdk_version=apk.get("minSdkVersion"),
+                        split_types=split_types,
+                    )
+                )
+            return apks
+
+        except HttpError as e:
+            self._logger.exception("Failed to list generated APKs", error=str(e))
+            raise PlayStoreClientError(f"Failed to list generated APKs: {e.reason}") from e
         finally:
             self._delete_edit(package_name, edit_id)
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -24,10 +24,14 @@ from play_store_mcp.models import (
     AppInfo,
     BatchDeploymentResult,
     BundleInfo,
+    AcquisitionFunnelResult,
+    AcquisitionFunnelStage,
     ConsoleInstallStats,
     ConsoleStatsResult,
     CountryAvailability,
     DailyStatPoint,
+    SearchTermResult,
+    SearchTermsStats,
     DeobfuscationFileResult,
     DeploymentResult,
     ExpansionFile,
@@ -3468,4 +3472,174 @@ class PlayStoreClient:
             net_installs=net_result,
             active_users=active_result,
             by_country=by_country,
+        )
+
+    def get_search_terms(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> SearchTermsStats:
+        """Get top search terms from Play Console via browser session.
+
+        Calls the top_dimension_values endpoint with dimension=SEARCH_TERM.
+        Requires OpenCLI with an active Play Console browser session.
+
+        Args:
+            package_name: App package name (display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+
+        Returns:
+            SearchTermsStats with terms sorted by installs descending.
+        """
+        from datetime import date as date_cls
+
+        def parse_date(s: str) -> tuple[int, int, int]:
+            d = date_cls.fromisoformat(s)
+            return d.year, d.month, d.day
+
+        sy, sm, sd = parse_date(start_date)
+        ey, em, ed = parse_date(end_date)
+
+        self._logger.info("Fetching search terms via browser", package_name=package_name)
+
+        js = f"""
+(async function() {{
+  const SAPISID = document.cookie.match(/SAPISID=([^;]+)/)?.[1];
+  if (!SAPISID) return JSON.stringify({{error: 'Not logged into Play Console'}});
+  const ts = Date.now();
+  const msgBuffer = new TextEncoder().encode(ts + ' ' + SAPISID + ' https://play.google.com');
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgBuffer);
+  const sha1 = Array.from(new Uint8Array(hashBuffer)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  const auth = 'SAPISIDHASH ' + ts + '_' + sha1;
+  const DEV_ID = '{developer_id}';
+  const APP_ID = '{app_id}';
+  const API_KEY = 'AIzaSyBAha_rcoO_aGsmiR5fWbNfdOjqT0gXwbk';
+  const httpHeaders = 'Content-Type:application/json+protobuf\\r\\nX-Goog-AuthUser:0\\r\\nAuthorization:' + auth + '\\r\\nX-Goog-Api-Key:' + API_KEY + '\\r\\n';
+  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/statspage/top_dimension_values?$httpHeaders=' + encodeURIComponent(httpHeaders);
+  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{sy},'2':{sm},'3':{sd}}},'2':{{'1':{ey},'2':{em},'3':{ed}}}}},'3':{{'1':{{'1':1,'2':1,'3':1,'4':1}},'2':2}},'4':4,'5':50}});
+  const resp = await fetch(url, {{method:'POST', body:body, credentials:'include'}});
+  const data = await resp.json();
+  return JSON.stringify(data);
+}})()
+"""
+        raw = self._run_browser_js(js)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from browser search terms: {raw[:200]}")
+
+        if "error" in data:
+            raise PlayStoreClientError(f"Browser error: {data['error']}")
+
+        # Response field "1" contains list of dimension value rows.
+        # Each row: "1"=search term string, "2"=metrics list (installs at index 0, visitors at index 1).
+        terms: list[SearchTermResult] = []
+        for row in data.get("1", []):
+            term_str = row.get("1", "")
+            metrics = row.get("2", [])
+            installs = int(metrics[0].get("1") or 0) if len(metrics) > 0 else 0
+            visitors = int(metrics[1].get("1") or 0) if len(metrics) > 1 else 0
+            if term_str:
+                terms.append(SearchTermResult(term=term_str, installs=installs, store_listing_visitors=visitors))
+
+        terms.sort(key=lambda t: t.installs, reverse=True)
+
+        return SearchTermsStats(
+            package_name=package_name,
+            start_date=start_date,
+            end_date=end_date,
+            terms=terms,
+        )
+
+    def get_acquisition_funnel(
+        self,
+        package_name: str,
+        developer_id: str,
+        app_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> AcquisitionFunnelResult:
+        """Get user acquisition funnel from Play Console via browser session.
+
+        Calls the stats/acquisition:getAcquisitionSummary endpoint.
+        Requires OpenCLI with an active Play Console browser session.
+
+        Args:
+            package_name: App package name (display only).
+            developer_id: Numeric developer ID from Play Console URL.
+            app_id: Numeric app ID from Play Console URL.
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+
+        Returns:
+            AcquisitionFunnelResult with stages: impressions → store_listing_visitors → installers → buyers.
+        """
+        from datetime import date as date_cls
+
+        def parse_date(s: str) -> tuple[int, int, int]:
+            d = date_cls.fromisoformat(s)
+            return d.year, d.month, d.day
+
+        sy, sm, sd = parse_date(start_date)
+        ey, em, ed = parse_date(end_date)
+
+        self._logger.info("Fetching acquisition funnel via browser", package_name=package_name)
+
+        js = f"""
+(async function() {{
+  const SAPISID = document.cookie.match(/SAPISID=([^;]+)/)?.[1];
+  if (!SAPISID) return JSON.stringify({{error: 'Not logged into Play Console'}});
+  const ts = Date.now();
+  const msgBuffer = new TextEncoder().encode(ts + ' ' + SAPISID + ' https://play.google.com');
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgBuffer);
+  const sha1 = Array.from(new Uint8Array(hashBuffer)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  const auth = 'SAPISIDHASH ' + ts + '_' + sha1;
+  const DEV_ID = '{developer_id}';
+  const APP_ID = '{app_id}';
+  const API_KEY = 'AIzaSyBAha_rcoO_aGsmiR5fWbNfdOjqT0gXwbk';
+  const httpHeaders = 'Content-Type:application/json+protobuf\\r\\nX-Goog-AuthUser:0\\r\\nAuthorization:' + auth + '\\r\\nX-Goog-Api-Key:' + API_KEY + '\\r\\n';
+  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/stats/acquisition:getAcquisitionSummary?$httpHeaders=' + encodeURIComponent(httpHeaders);
+  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{sy},'2':{sm},'3':{sd}}},'2':{{'1':{ey},'2':{em},'3':{ed}}}}}}});
+  const resp = await fetch(url, {{method:'POST', body:body, credentials:'include'}});
+  const data = await resp.json();
+  return JSON.stringify(data);
+}})()
+"""
+        raw = self._run_browser_js(js)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            raise PlayStoreClientError(f"Invalid JSON from browser acquisition funnel: {raw[:200]}")
+
+        if "error" in data:
+            raise PlayStoreClientError(f"Browser error: {data['error']}")
+
+        # Response field "1" contains funnel stages in order.
+        # Each stage: "1"=stage type int (1=impressions,2=visitors,3=installers,4=buyers), "2"=value.
+        stage_names = {1: "impressions", 2: "store_listing_visitors", 3: "installers", 4: "buyers"}
+        raw_stages = data.get("1", [])
+
+        stages: list[AcquisitionFunnelStage] = []
+        prev_value: int | None = None
+        for s in raw_stages:
+            stage_type = int(s.get("1") or 0)
+            value = int(s.get("2") or 0)
+            name = stage_names.get(stage_type, f"stage_{stage_type}")
+            conversion = 0.0
+            if prev_value and prev_value > 0:
+                conversion = value / prev_value
+            stages.append(AcquisitionFunnelStage(stage=name, value=value, conversion_rate=round(conversion, 4)))
+            prev_value = value
+
+        return AcquisitionFunnelResult(
+            package_name=package_name,
+            start_date=start_date,
+            end_date=end_date,
+            stages=stages,
         )

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -18,20 +18,18 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload
 
 from play_store_mcp.models import (
+    AcquisitionFunnelResult,
+    AcquisitionFunnelStage,
     AppDetails,
     AppDetailsInfo,
     AppDetailsUpdateResult,
     AppInfo,
     BatchDeploymentResult,
     BundleInfo,
-    AcquisitionFunnelResult,
-    AcquisitionFunnelStage,
     ConsoleInstallStats,
     ConsoleStatsResult,
     CountryAvailability,
     DailyStatPoint,
-    SearchTermResult,
-    SearchTermsStats,
     DeobfuscationFileResult,
     DeploymentResult,
     ExpansionFile,
@@ -41,6 +39,7 @@ from play_store_mcp.models import (
     ImageUploadResult,
     InAppProduct,
     Listing,
+    ListingBatchUpdateResult,
     ListingUpdateResult,
     Order,
     ProductPurchase,
@@ -48,6 +47,8 @@ from play_store_mcp.models import (
     Release,
     Review,
     ReviewReplyResult,
+    SearchTermResult,
+    SearchTermsStats,
     SubscriptionProduct,
     SubscriptionPurchase,
     SubscriptionPurchaseV2,
@@ -228,7 +229,7 @@ class PlayStoreClient:
         """Validate store listing text lengths.
 
         Args:
-            title: App title (max 50 chars).
+            title: App title (max 30 chars).
             short_description: Short description (max 80 chars).
             full_description: Full description (max 4000 chars).
 
@@ -237,11 +238,11 @@ class PlayStoreClient:
         """
         errors: list[ValidationError] = []
 
-        if title and len(title) > 50:
+        if title and len(title) > 30:
             errors.append(
                 ValidationError(
                     field="title",
-                    message="Title must be 50 characters or less",
+                    message="Title must be 30 characters or less",
                     value=f"{len(title)} characters",
                 )
             )
@@ -1473,7 +1474,7 @@ class PlayStoreClient:
         Args:
             package_name: App package name.
             language: Language code (e.g., en-US, es-ES).
-            title: App title (max 50 characters).
+            title: App title (max 30 characters).
             full_description: Full description (max 4000 characters).
             short_description: Short description (max 80 characters).
             video: YouTube video URL.
@@ -1553,6 +1554,171 @@ class PlayStoreClient:
                 language=language,
                 message=f"Failed to update listing: {e}",
                 error=str(e),
+            )
+
+    def batch_update_listings(
+        self,
+        package_name: str,
+        updates: list[dict[str, Any]],
+        commit: bool = False,
+    ) -> ListingBatchUpdateResult:
+        """Validate or update store listings for multiple languages.
+
+        Dry-run is the default and performs local validation only. A Google Play
+        edit is created only when commit is explicitly true and all inputs pass
+        validation.
+
+        Args:
+            package_name: App package name.
+            updates: Listing updates. Each item must include language and may
+                include title, short_description, full_description, and video.
+            commit: If true, apply and commit all updates in one edit.
+
+        Returns:
+            Batch validation/update result.
+        """
+        errors: list[dict[str, Any]] = []
+        validated_languages: list[str] = []
+        normalized_updates: list[dict[str, Any]] = []
+
+        for index, update in enumerate(updates):
+            language = update.get("language")
+            if not isinstance(language, str) or not language:
+                errors.append(
+                    {
+                        "index": index,
+                        "language": language,
+                        "field": "language",
+                        "message": "language is required",
+                    }
+                )
+                continue
+
+            provided_fields = {
+                field: update[field]
+                for field in ("title", "short_description", "full_description", "video")
+                if field in update
+            }
+            if not provided_fields:
+                errors.append(
+                    {
+                        "index": index,
+                        "language": language,
+                        "field": "updates",
+                        "message": "At least one listing field must be provided",
+                    }
+                )
+                continue
+
+            validation_errors = self.validate_listing_text(
+                title=update.get("title"),
+                short_description=update.get("short_description"),
+                full_description=update.get("full_description"),
+            )
+            if validation_errors:
+                for validation_error in validation_errors:
+                    error_data = validation_error.model_dump()
+                    error_data["index"] = index
+                    error_data["language"] = language
+                    errors.append(error_data)
+                continue
+
+            validated_languages.append(language)
+            normalized_updates.append({"language": language, **provided_fields})
+
+        if errors:
+            return ListingBatchUpdateResult(
+                success=False,
+                package_name=package_name,
+                commit=False,
+                validated_languages=validated_languages,
+                errors=errors,
+                message="Listing batch validation failed; no edit was created.",
+            )
+
+        if not commit:
+            return ListingBatchUpdateResult(
+                success=True,
+                package_name=package_name,
+                commit=False,
+                validated_languages=validated_languages,
+                message="Listing batch dry-run passed; no edit was created.",
+            )
+
+        service = self._get_service()
+        edit_id = self._create_edit(package_name)
+        updated_languages: list[str] = []
+
+        try:
+            for update in normalized_updates:
+                language = update["language"]
+                try:
+                    current_listing = (
+                        service.edits()
+                        .listings()
+                        .get(packageName=package_name, editId=edit_id, language=language)
+                        .execute()
+                    )
+                except HttpError:
+                    current_listing = {}
+
+                update_body = {
+                    "title": update.get("title", current_listing.get("title", "")),
+                    "fullDescription": update.get(
+                        "full_description", current_listing.get("fullDescription", "")
+                    ),
+                    "shortDescription": update.get(
+                        "short_description", current_listing.get("shortDescription", "")
+                    ),
+                }
+                if "video" in update:
+                    update_body["video"] = update["video"]
+                elif current_listing.get("video") is not None:
+                    update_body["video"] = current_listing["video"]
+
+                service.edits().listings().update(
+                    packageName=package_name,
+                    editId=edit_id,
+                    language=language,
+                    body=update_body,
+                ).execute()
+                updated_languages.append(language)
+
+            self._commit_edit(package_name, edit_id)
+            return ListingBatchUpdateResult(
+                success=True,
+                package_name=package_name,
+                commit=True,
+                edit_id=edit_id,
+                validated_languages=validated_languages,
+                updated_languages=updated_languages,
+                message=f"Successfully updated {len(updated_languages)} listing(s).",
+            )
+        except HttpError as e:
+            self._logger.exception("Failed to batch update listings", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ListingBatchUpdateResult(
+                success=False,
+                package_name=package_name,
+                commit=False,
+                edit_id=edit_id,
+                validated_languages=validated_languages,
+                updated_languages=updated_languages,
+                errors=[{"message": f"Failed to batch update listings: {e.reason}"}],
+                message="Failed to batch update listings; edit was deleted.",
+            )
+        except Exception as e:
+            self._logger.exception("Failed to batch update listings", error=str(e))
+            self._delete_edit(package_name, edit_id)
+            return ListingBatchUpdateResult(
+                success=False,
+                package_name=package_name,
+                commit=False,
+                edit_id=edit_id,
+                validated_languages=validated_languages,
+                updated_languages=updated_languages,
+                errors=[{"message": f"Failed to batch update listings: {e}"}],
+                message="Failed to batch update listings; edit was deleted.",
             )
 
     def list_all_listings(self, package_name: str) -> list[Listing]:

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -3508,6 +3508,8 @@ class PlayStoreClient:
 
         self._logger.info("Fetching search terms via browser", package_name=package_name)
 
+        # Uses getAcquisitionDetailsTableData with dimension type 2 (Search term).
+        # Note: low-volume apps may only return "Other" due to Google's privacy threshold.
         js = f"""
 (async function() {{
   const SAPISID = document.cookie.match(/SAPISID=([^;]+)/)?.[1];
@@ -3521,8 +3523,8 @@ class PlayStoreClient:
   const APP_ID = '{app_id}';
   const API_KEY = 'AIzaSyBAha_rcoO_aGsmiR5fWbNfdOjqT0gXwbk';
   const httpHeaders = 'Content-Type:application/json+protobuf\\r\\nX-Goog-AuthUser:0\\r\\nAuthorization:' + auth + '\\r\\nX-Goog-Api-Key:' + API_KEY + '\\r\\n';
-  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/statspage/top_dimension_values?$httpHeaders=' + encodeURIComponent(httpHeaders);
-  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{sy},'2':{sm},'3':{sd}}},'2':{{'1':{ey},'2':{em},'3':{ed}}}}},'3':{{'1':{{'1':1,'2':1,'3':1,'4':1}},'2':2}},'4':4,'5':50}});
+  const url = 'https://playconsolestatsfrontend-pa.clients6.google.com/v1/developers/' + DEV_ID + '/apps/' + APP_ID + '/stats/acquisition:getAcquisitionDetailsTableData?$httpHeaders=' + encodeURIComponent(httpHeaders);
+  const body = JSON.stringify({{'1':{{'1':{{'1':DEV_ID}},'2':{{'1':APP_ID}}}},'2':{{'1':{{'1':{sy},'2':{sm},'3':{sd}}},'2':{{'1':{ey},'2':{em},'3':{ed}}}}},'3':{{'1':2}},'5':1}});
   const resp = await fetch(url, {{method:'POST', body:body, credentials:'include'}});
   const data = await resp.json();
   return JSON.stringify(data);
@@ -3537,14 +3539,21 @@ class PlayStoreClient:
         if "error" in data:
             raise PlayStoreClientError(f"Browser error: {data['error']}")
 
-        # Response field "1" contains list of dimension value rows.
-        # Each row: "1"=search term string, "2"=metrics list (installs at index 0, visitors at index 1).
+        # Response: data["1"]["3"] = list of search term rows.
+        # Each row: "1"={"1": term_id, "2": display_name}, "2"={"1": visitors}, "3"={"1": installs}.
+        # Row "1"."1" == "REMOVED_BY_THRESHOLDING_STORE_QUERY" means data below privacy threshold.
         terms: list[SearchTermResult] = []
-        for row in data.get("1", []):
-            term_str = row.get("1", "")
-            metrics = row.get("2", [])
-            installs = int(metrics[0].get("1") or 0) if len(metrics) > 0 else 0
-            visitors = int(metrics[1].get("1") or 0) if len(metrics) > 1 else 0
+        inner = data.get("1", {})
+        for row in inner.get("3", []):
+            label = row.get("1", {})
+            term_id = label.get("1", "")
+            term_display = label.get("2", term_id)
+            if term_id == "REMOVED_BY_THRESHOLDING_STORE_QUERY":
+                term_str = f"(other: {term_display})"
+            else:
+                term_str = term_display or term_id
+            visitors = int(row.get("2", {}).get("1") or 0)
+            installs = int(row.get("3", {}).get("1") or 0)
             if term_str:
                 terms.append(SearchTermResult(term=term_str, installs=installs, store_listing_visitors=visitors))
 
@@ -3620,22 +3629,33 @@ class PlayStoreClient:
         if "error" in data:
             raise PlayStoreClientError(f"Browser error: {data['error']}")
 
-        # Response field "1" contains funnel stages in order.
-        # Each stage: "1"=stage type int (1=impressions,2=visitors,3=installers,4=buyers), "2"=value.
-        stage_names = {1: "impressions", 2: "store_listing_visitors", 3: "installers", 4: "buyers"}
-        raw_stages = data.get("1", [])
+        # Response structure (from live reverse-engineering):
+        #   "1" = array of traffic sources: [overall, STORE_SEARCH, STORE_BROWSE, DEEPLINK, ...]
+        #         each: "1"."1"=source_id, "2"."1"=install_count
+        #   "2" = conversion summary:
+        #         "2"."1"."1" = store_listing_visitors (total)
+        #         "2"."2"."1" = installers (total)
+        #         "2"."3"."1" = conversion_rate (float)
+        # We build a 2-stage funnel from "2" plus the traffic-source breakdown from "1".
+        summary = data.get("2", {})
+        visitors_val = int(summary.get("1", {}).get("1") or 0)
+        installers_val = int(summary.get("2", {}).get("1") or 0)
+        conversion_val = float(summary.get("3", {}).get("1") or 0.0)
 
-        stages: list[AcquisitionFunnelStage] = []
-        prev_value: int | None = None
-        for s in raw_stages:
-            stage_type = int(s.get("1") or 0)
-            value = int(s.get("2") or 0)
-            name = stage_names.get(stage_type, f"stage_{stage_type}")
-            conversion = 0.0
-            if prev_value and prev_value > 0:
-                conversion = value / prev_value
-            stages.append(AcquisitionFunnelStage(stage=name, value=value, conversion_rate=round(conversion, 4)))
-            prev_value = value
+        stages: list[AcquisitionFunnelStage] = [
+            AcquisitionFunnelStage(stage="store_listing_visitors", value=visitors_val, conversion_rate=0.0),
+            AcquisitionFunnelStage(stage="installers", value=installers_val, conversion_rate=round(conversion_val, 4)),
+        ]
+
+        # Append traffic-source breakdown as additional pseudo-stages (source@installs).
+        source_map = {"STORE_SEARCH": "search", "STORE_BROWSE": "explore", "DEEPLINK": "ads_referral"}
+        for src_item in data.get("1", []):
+            src_id = src_item.get("1", {}).get("1", "")
+            src_count = int(src_item.get("2", {}).get("1") or 0)
+            if src_id and src_id != "@OVERALL@":
+                label = source_map.get(src_id, src_id.lower())
+                conv = round(src_count / installers_val, 4) if installers_val > 0 else 0.0
+                stages.append(AcquisitionFunnelStage(stage=f"src:{label}", value=src_count, conversion_rate=conv))
 
         return AcquisitionFunnelResult(
             package_name=package_name,

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -551,4 +551,100 @@ class AcquisitionFunnelResult(BaseModel):
     package_name: str = Field(..., description="App package name")
     start_date: str = Field(..., description="Start date YYYY-MM-DD")
     end_date: str = Field(..., description="End date YYYY-MM-DD")
+
+
+# ---------------------------------------------------------------------------
+# New models for missing API coverage
+# ---------------------------------------------------------------------------
+
+
+class InAppProductUpsertResult(BaseModel):
+    """Result of creating or updating an in-app product."""
+
+    success: bool
+    package_name: str
+    sku: str
+    message: str
+    error: str | None = None
+
+
+class SubscriptionDetails(BaseModel):
+    """Full subscription product details from the Monetization API."""
+
+    product_id: str
+    package_name: str
+    state: str | None = None
+    listings: dict | None = None
+    base_plans: list[dict] | None = None
+
+
+class SubscriptionUpsertResult(BaseModel):
+    """Result of creating or updating a subscription product."""
+
+    success: bool
+    package_name: str
+    product_id: str
+    message: str
+    error: str | None = None
+
+
+class BasePlanActionResult(BaseModel):
+    """Result of activating or deactivating a base plan."""
+
+    success: bool
+    package_name: str
+    product_id: str
+    base_plan_id: str
+    action: str
+    message: str
+    error: str | None = None
+
+
+class CountryAvailabilityUpdateResult(BaseModel):
+    """Result of updating country availability for a track."""
+
+    success: bool
+    package_name: str
+    track: str
+    countries_set: list[str]
+    rest_of_world: bool
+    message: str
+    error: str | None = None
+
+
+class SubscriptionDeferResult(BaseModel):
+    """Result of deferring a subscription renewal."""
+
+    success: bool
+    package_name: str
+    subscription_id: str
+    new_expiry_time_millis: str | None = None
+    message: str
+    error: str | None = None
+
+
+class ListingDeleteResult(BaseModel):
+    """Result of deleting a store listing."""
+
+    success: bool
+    package_name: str
+    language: str | None = None
+    message: str
+    error: str | None = None
+
+
+class RegionPrice(BaseModel):
+    """Converted price for a specific region."""
+
+    region_code: str
+    price_micros: str
+    currency_code: str
+
+
+class ConvertRegionPricesResult(BaseModel):
+    """Result of converting a price to all regional equivalents."""
+
+    success: bool
+    converted_prices: list[RegionPrice]
+    error: str | None = None
     stages: list[AcquisitionFunnelStage] = Field(default_factory=list, description="Funnel stages in order")

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -428,6 +428,17 @@ class ProductPurchase(BaseModel):
     quantity: int | None = Field(None, description="Purchase quantity")
 
 
+class ProductPurchaseOperationResult(BaseModel):
+    """Result of a one-time in-app product purchase operation."""
+
+    success: bool = Field(..., description="Whether operation succeeded")
+    package_name: str = Field(..., description="App package name")
+    product_id: str = Field(..., description="Product ID")
+    purchase_token: str = Field(..., description="Purchase token")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
 class SubscriptionPurchaseV2(BaseModel):
     """Subscription purchase status (v2 API)."""
 
@@ -551,6 +562,10 @@ class AcquisitionFunnelResult(BaseModel):
     package_name: str = Field(..., description="App package name")
     start_date: str = Field(..., description="Start date YYYY-MM-DD")
     end_date: str = Field(..., description="End date YYYY-MM-DD")
+    stages: list[AcquisitionFunnelStage] = Field(
+        default_factory=list,
+        description="Funnel stages and traffic-source breakdown",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -422,3 +422,47 @@ class SubscriptionPurchaseV2(BaseModel):
     product_id: str | None = Field(None, description="Subscription product ID")
     base_plan_id: str | None = Field(None, description="Base plan ID")
     offer_id: str | None = Field(None, description="Offer ID if applicable")
+
+
+# =============================================================================
+# Play Developer Reporting API Models
+# =============================================================================
+
+
+class VitalsDataPoint(BaseModel):
+    """A single data point from a vitals metric set query."""
+
+    date: str = Field(..., description="Date string YYYY-MM-DD")
+    aggregation_period: str = Field(..., description="DAILY or HOURLY")
+    dimensions: dict[str, str] = Field(
+        default_factory=dict, description="Dimension key-value pairs (e.g. apiLevel: '33')"
+    )
+    metrics: dict[str, float | None] = Field(
+        default_factory=dict, description="Metric key-value pairs (e.g. crashRate: 0.012)"
+    )
+
+
+class VitalsQueryResult(BaseModel):
+    """Result of querying a Play Developer Reporting vitals metric set."""
+
+    package_name: str = Field(..., description="App package name")
+    metric_set: str = Field(
+        ..., description="Metric set name: crashRate, anrRate, slowStartup, etc."
+    )
+    aggregation_period: str = Field(..., description="DAILY or HOURLY")
+    data_points: list[VitalsDataPoint] = Field(
+        default_factory=list, description="Timeline data points"
+    )
+    row_count: int = Field(0, description="Total number of rows returned")
+
+
+class VitalsAnomaly(BaseModel):
+    """A detected anomaly in a vitals metric."""
+
+    name: str = Field(..., description="Anomaly resource name")
+    metric_set: str = Field(..., description="Metric set where anomaly was detected")
+    dimensions: dict[str, str] = Field(
+        default_factory=dict, description="Dimension values for this anomaly"
+    )
+    first_detection_time: str | None = Field(None, description="When the anomaly was first detected")
+    last_detected_day: str | None = Field(None, description="Last day the anomaly was observed")

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -276,6 +276,38 @@ class ImageUploadResult(BaseModel):
     error: str | None = Field(None, description="Error details if failed")
 
 
+class DeobfuscationFileResult(BaseModel):
+    """Result of uploading a deobfuscation (ProGuard/R8) mapping file."""
+
+    success: bool = Field(..., description="Whether upload succeeded")
+    package_name: str = Field(..., description="App package name")
+    version_code: int = Field(..., description="APK version code")
+    deobfuscation_file_type: str = Field(..., description="Type: proguard or nativeCode")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
+class BundleInfo(BaseModel):
+    """Information about an uploaded AAB bundle."""
+
+    package_name: str = Field(..., description="App package name")
+    version_code: int = Field(..., description="Version code of the bundle")
+    sha1: str | None = Field(None, description="SHA1 hash of the bundle")
+    sha256: str | None = Field(None, description="SHA256 hash of the bundle")
+
+
+class GeneratedApkInfo(BaseModel):
+    """Information about a generated APK from an AAB bundle."""
+
+    package_name: str = Field(..., description="App package name")
+    bundle_version_code: int = Field(..., description="Version code of the source bundle")
+    download_id: str | None = Field(None, description="Download ID for the generated APK")
+    variant_id: int | None = Field(None, description="Variant ID")
+    target_sdk_version: int | None = Field(None, description="Target SDK version")
+    min_sdk_version: int | None = Field(None, description="Minimum SDK version")
+    split_types: list[str] = Field(default_factory=list, description="List of split types")
+
+
 # =============================================================================
 # App Details Models
 # =============================================================================

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -200,6 +200,25 @@ class ListingUpdateResult(BaseModel):
     error: str | None = Field(None, description="Error details if failed")
 
 
+class ListingBatchUpdateResult(BaseModel):
+    """Result of validating or updating multiple store listings."""
+
+    success: bool = Field(..., description="Whether validation/update succeeded")
+    package_name: str = Field(..., description="App package name")
+    commit: bool = Field(..., description="Whether changes were committed")
+    edit_id: str | None = Field(None, description="Edit ID used for committed updates")
+    validated_languages: list[str] = Field(
+        default_factory=list, description="Languages that passed validation"
+    )
+    updated_languages: list[str] = Field(
+        default_factory=list, description="Languages updated when commit is true"
+    )
+    errors: list[dict[str, Any]] = Field(
+        default_factory=list, description="Validation or update errors by language"
+    )
+    message: str = Field(..., description="Status message")
+
+
 class TesterInfo(BaseModel):
     """Information about testers for a track."""
 

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -248,3 +248,145 @@ class ValidationError(BaseModel):
     field: str = Field(..., description="Field that failed validation")
     message: str = Field(..., description="Error message")
     value: Any | None = Field(None, description="Invalid value")
+
+
+# =============================================================================
+# Images API Models
+# =============================================================================
+
+
+class ImageInfo(BaseModel):
+    """Store listing image information."""
+
+    image_id: str = Field(..., description="Image ID")
+    url: str = Field(..., description="Image URL")
+    sha1: str | None = Field(None, description="SHA1 hash of image")
+    sha256: str | None = Field(None, description="SHA256 hash of image")
+
+
+class ImageUploadResult(BaseModel):
+    """Result of an image upload or delete operation."""
+
+    success: bool = Field(..., description="Whether operation succeeded")
+    package_name: str = Field(..., description="App package name")
+    language: str = Field(..., description="Language code")
+    image_type: str = Field(..., description="Image type")
+    image_id: str | None = Field(None, description="Image ID (for upload)")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
+# =============================================================================
+# App Details Models
+# =============================================================================
+
+
+class AppDetailsInfo(BaseModel):
+    """App details from edits.details API."""
+
+    package_name: str = Field(..., description="App package name")
+    default_language: str | None = Field(None, description="Default language code")
+    contact_email: str | None = Field(None, description="Developer contact email")
+    contact_phone: str | None = Field(None, description="Developer contact phone")
+    contact_website: str | None = Field(None, description="Developer contact website")
+
+
+class AppDetailsUpdateResult(BaseModel):
+    """Result of updating app details."""
+
+    success: bool = Field(..., description="Whether update succeeded")
+    package_name: str = Field(..., description="App package name")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
+# =============================================================================
+# Country Availability Models
+# =============================================================================
+
+
+class CountryAvailability(BaseModel):
+    """Country availability for a release track."""
+
+    package_name: str = Field(..., description="App package name")
+    track: str = Field(..., description="Release track")
+    countries: list[str] = Field(default_factory=list, description="List of country codes")
+    rest_of_world: bool = Field(False, description="Whether available in rest of world")
+
+
+# =============================================================================
+# Users & Grants Models
+# =============================================================================
+
+
+class GrantInfo(BaseModel):
+    """App-level grant for a user."""
+
+    package_name: str = Field(..., description="App package name")
+    app_level_permissions: list[str] = Field(
+        default_factory=list, description="App-level permissions granted"
+    )
+
+
+class UserInfo(BaseModel):
+    """Developer account user information."""
+
+    name: str | None = Field(None, description="Resource name of user")
+    email: str = Field(..., description="User email address")
+    access_state: str | None = Field(None, description="Account-level access state")
+    grants: list[GrantInfo] = Field(default_factory=list, description="App-level grants")
+
+
+class UserOperationResult(BaseModel):
+    """Result of a user or grant operation."""
+
+    success: bool = Field(..., description="Whether operation succeeded")
+    email: str = Field(..., description="User email address")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
+# =============================================================================
+# Orders & Purchases Models
+# =============================================================================
+
+
+class RefundResult(BaseModel):
+    """Result of an order refund operation."""
+
+    success: bool = Field(..., description="Whether refund succeeded")
+    order_id: str = Field(..., description="Order ID")
+    package_name: str = Field(..., description="App package name")
+    revoked: bool = Field(False, description="Whether entitlement was revoked")
+    message: str = Field(..., description="Status message")
+    error: str | None = Field(None, description="Error details if failed")
+
+
+class ProductPurchase(BaseModel):
+    """One-time in-app product purchase status."""
+
+    package_name: str = Field(..., description="App package name")
+    product_id: str = Field(..., description="Product ID")
+    purchase_token: str = Field(..., description="Purchase token")
+    purchase_time: datetime | None = Field(None, description="Purchase time")
+    purchase_state: int | None = Field(None, description="0=purchased, 1=canceled, 2=pending")
+    consumption_state: int | None = Field(None, description="0=not consumed, 1=consumed")
+    developer_payload: str | None = Field(None, description="Developer payload")
+    order_id: str | None = Field(None, description="Order ID")
+    acknowledged: bool = Field(False, description="Whether purchase was acknowledged")
+    quantity: int | None = Field(None, description="Purchase quantity")
+
+
+class SubscriptionPurchaseV2(BaseModel):
+    """Subscription purchase status (v2 API)."""
+
+    package_name: str = Field(..., description="App package name")
+    purchase_token: str = Field(..., description="Purchase token")
+    subscription_state: str | None = Field(None, description="Subscription state")
+    latest_order_id: str | None = Field(None, description="Latest order ID")
+    start_time: datetime | None = Field(None, description="Subscription start time")
+    expiry_time: datetime | None = Field(None, description="Current period expiry time")
+    auto_renewing: bool = Field(False, description="Whether auto-renewing")
+    product_id: str | None = Field(None, description="Subscription product ID")
+    base_plan_id: str | None = Field(None, description="Base plan ID")
+    offer_id: str | None = Field(None, description="Offer ID if applicable")

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -466,3 +466,36 @@ class VitalsAnomaly(BaseModel):
     )
     first_detection_time: str | None = Field(None, description="When the anomaly was first detected")
     last_detected_day: str | None = Field(None, description="Last day the anomaly was observed")
+
+
+# ---------------------------------------------------------------------------
+# Play Console Browser-Based Stats (via OpenCLI)
+# ---------------------------------------------------------------------------
+
+
+class DailyStatPoint(BaseModel):
+    """A single day's data point from Play Console statistics."""
+
+    date: str = Field(..., description="Date in YYYY-MM-DD format")
+    value: int = Field(..., description="Metric value for this day")
+
+
+class ConsoleStatsResult(BaseModel):
+    """Result from one metric/dimension combination."""
+
+    metric: str = Field(..., description="Metric name: install_events, net_installs, active_users")
+    dimension: str = Field(default="overall", description="Dimension: overall or country code")
+    total: int = Field(0, description="Sum of all daily values in range")
+    data_points: list[DailyStatPoint] = Field(default_factory=list, description="Daily data points (non-zero only)")
+
+
+class ConsoleInstallStats(BaseModel):
+    """Install statistics from Play Console (requires browser login via OpenCLI)."""
+
+    package_name: str = Field(..., description="App package name")
+    start_date: str = Field(..., description="Start date YYYY-MM-DD")
+    end_date: str = Field(..., description="End date YYYY-MM-DD")
+    install_events: ConsoleStatsResult | None = Field(None, description="Total install events including re-installs")
+    net_installs: ConsoleStatsResult | None = Field(None, description="Net installs = installs - uninstalls")
+    active_users: ConsoleStatsResult | None = Field(None, description="Unique active users")
+    by_country: list[ConsoleStatsResult] = Field(default_factory=list, description="Per-country install events breakdown")

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -499,3 +499,37 @@ class ConsoleInstallStats(BaseModel):
     net_installs: ConsoleStatsResult | None = Field(None, description="Net installs = installs - uninstalls")
     active_users: ConsoleStatsResult | None = Field(None, description="Unique active users")
     by_country: list[ConsoleStatsResult] = Field(default_factory=list, description="Per-country install events breakdown")
+
+
+class SearchTermResult(BaseModel):
+    """A single search term row with acquisition stats."""
+
+    term: str = Field(..., description="Search term (or display name; may be 'Other' for thresholded)")
+    installs: int = Field(0, description="Acquisitions (installs) attributable to this term")
+    store_listing_visitors: int = Field(0, description="Store listing visitors who searched this term")
+
+
+class SearchTermsStats(BaseModel):
+    """Search term acquisition stats from Play Console (browser-based)."""
+
+    package_name: str = Field(..., description="App package name")
+    start_date: str = Field(..., description="Start date YYYY-MM-DD")
+    end_date: str = Field(..., description="End date YYYY-MM-DD")
+    terms: list[SearchTermResult] = Field(default_factory=list, description="Terms ordered by installs descending")
+
+
+class AcquisitionFunnelStage(BaseModel):
+    """One stage of the acquisition funnel."""
+
+    stage: str = Field(..., description="Stage name: store_listing_visitors, installers, buyers, etc.")
+    value: int = Field(0, description="Count for this stage")
+    conversion_rate: float = Field(0.0, description="Conversion rate from the previous stage (0.0 for first)")
+
+
+class AcquisitionFunnelResult(BaseModel):
+    """Acquisition funnel summary from Play Console (browser-based)."""
+
+    package_name: str = Field(..., description="App package name")
+    start_date: str = Field(..., description="Start date YYYY-MM-DD")
+    end_date: str = Field(..., description="End date YYYY-MM-DD")
+    stages: list[AcquisitionFunnelStage] = Field(default_factory=list, description="Funnel stages in order")

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -553,6 +553,66 @@ class AcquisitionFunnelResult(BaseModel):
     end_date: str = Field(..., description="End date YYYY-MM-DD")
 
 
+class CustomStoreListingSummary(BaseModel):
+    """A single Custom Store Listing (CSL), read from the Play Console UI.
+
+    CSL configuration (targeting, content, active status) has no Android
+    Publisher API surface -- this is scraped from the Console DOM via
+    OpenCLI, not the official REST API.
+    """
+
+    name: str = Field(..., description="Internal CSL name/slug shown in Console (not shown to end users)")
+    listing_id: str = Field(..., description="Numeric CSL id used in the Console edit URL")
+    edit_url: str = Field(..., description="Full Console URL to edit this CSL")
+
+
+class CustomStoreListingsResult(BaseModel):
+    """List of Custom Store Listings for an app."""
+
+    package_name: str = Field(..., description="App package name")
+    listings: list[CustomStoreListingSummary] = Field(default_factory=list)
+
+
+class StoreListingExperimentSummary(BaseModel):
+    """A single Store Listing Experiment (A/B test), decoded from Console RPC.
+
+    Experiments have no Android Publisher API surface -- this is decoded
+    from an internal protobuf response captured via OpenCLI network
+    capture. Field semantics beyond experiment_id/name/locale are inferred
+    from the response shape, not from an official schema, and may be
+    wrong or incomplete for experiment types this wasn't tested against.
+    """
+
+    experiment_id: str = Field(..., description="Numeric experiment id")
+    name: str = Field(..., description="Experiment display name (often encodes what's being tested)")
+    locale: str = Field("", description="Locale the experiment is scoped to")
+    dimension_type: int | None = Field(None, description="Inferred asset-type enum (e.g. phone screenshots); unverified against an official schema")
+    status: int | None = Field(None, description="Inferred status enum (e.g. running); unverified against an official schema")
+    start_timestamp: str | None = Field(None, description="Inferred experiment start time (ISO), decoded from an embedded protobuf Timestamp")
+    traffic_split: float | None = Field(None, description="Inferred traffic split fraction for the variant arm")
+
+
+class StoreListingExperimentsResult(BaseModel):
+    """List of Store Listing Experiments for an app."""
+
+    package_name: str = Field(..., description="App package name")
+    experiments: list[StoreListingExperimentSummary] = Field(default_factory=list)
+
+
+class ExperimentReportRaw(BaseModel):
+    """Raw decoded content of a single experiment's report page.
+
+    This does not attempt to fully name every protobuf field (no official
+    schema is available). It surfaces what's reliably extractable: any
+    embedded image URLs (control/variant creative) and readable text runs
+    (e.g. the live listing copy embedded in the report for reference).
+    """
+
+    experiment_id: str = Field(..., description="Numeric experiment id")
+    image_urls: list[str] = Field(default_factory=list, description="Creative image URLs found in the report payload, in encounter order")
+    text_strings: list[str] = Field(default_factory=list, description="Readable UTF-8 string runs found in the report payload, deduplicated, longest first")
+
+
 # ---------------------------------------------------------------------------
 # New models for missing API coverage
 # ---------------------------------------------------------------------------

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -499,3 +499,37 @@ class ConsoleInstallStats(BaseModel):
     net_installs: ConsoleStatsResult | None = Field(None, description="Net installs = installs - uninstalls")
     active_users: ConsoleStatsResult | None = Field(None, description="Unique active users")
     by_country: list[ConsoleStatsResult] = Field(default_factory=list, description="Per-country install events breakdown")
+
+
+class SearchTermResult(BaseModel):
+    """A single search term with its install and visitor stats."""
+
+    term: str = Field(..., description="Search term string")
+    installs: int = Field(0, description="Number of installs attributed to this search term")
+    store_listing_visitors: int = Field(0, description="Number of store listing visitors from this term")
+
+
+class SearchTermsStats(BaseModel):
+    """Search terms statistics from Play Console."""
+
+    package_name: str = Field(..., description="App package name")
+    start_date: str = Field(..., description="Start date YYYY-MM-DD")
+    end_date: str = Field(..., description="End date YYYY-MM-DD")
+    terms: list[SearchTermResult] = Field(default_factory=list, description="Search terms sorted by installs descending")
+
+
+class AcquisitionFunnelStage(BaseModel):
+    """A single stage in the user acquisition funnel."""
+
+    stage: str = Field(..., description="Stage name: impressions, store_listing_visitors, installers, buyers")
+    value: int = Field(0, description="Count for this stage")
+    conversion_rate: float = Field(0.0, description="Conversion rate relative to previous stage (0.0-1.0)")
+
+
+class AcquisitionFunnelResult(BaseModel):
+    """User acquisition funnel from Play Console."""
+
+    package_name: str = Field(..., description="App package name")
+    start_date: str = Field(..., description="Start date YYYY-MM-DD")
+    end_date: str = Field(..., description="End date YYYY-MM-DD")
+    stages: list[AcquisitionFunnelStage] = Field(default_factory=list, description="Funnel stages in order")

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1626,7 +1626,10 @@ def get_slow_rendering_rate(
     end_date: str,
     dimensions: list[str] | None = None,
 ) -> dict[str, Any]:
-    f"""Query daily slow rendering (frame drop) rate.
+    f"""Query daily slow rendering (frame drop) rate. GAMES ONLY.
+
+    This metric is only accessible for apps categorized as games in Play Console.
+    Non-game apps will receive a 403 error.
 
     Returns slowRenderingRate20Fps (frames rendered below 20fps) and
     slowRenderingRate30Fps (frames rendered below 30fps), plus distinctUsers.
@@ -1710,6 +1713,39 @@ def get_stuck_wakelock_rate(
     """
     client = get_client_from_context()
     result = client.get_stuck_wakelock_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_lmk_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily Low Memory Killer (LMK) rate.
+
+    LMK rate measures how often the system kills the app due to memory pressure.
+    High values indicate the app consumes too much memory.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with lmkRate, lmkCount, distinctUsers per day
+    """
+    client = get_client_from_context()
+    result = client.get_lmk_rate(
         package_name=package_name,
         start_date=start_date,
         end_date=end_date,

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1466,6 +1466,34 @@ def acknowledge_product_purchase(
     return result.model_dump()
 
 
+@mcp.tool()
+def consume_product_purchase(
+    package_name: str,
+    product_id: str,
+    token: str,
+) -> dict[str, Any]:
+    """Consume a one-time in-app product purchase.
+
+    Use this after granting entitlement for consumable products so the user can
+    buy the same product again.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        product_id: The product SKU (in-app product ID)
+        token: The purchase token returned from the client-side purchase
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.consume_product_purchase(
+        package_name=package_name,
+        product_id=product_id,
+        token=token,
+    )
+    return result.model_dump()
+
+
 # =============================================================================
 # Purchases - Subscriptions v2 Tools
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1937,6 +1937,456 @@ def get_acquisition_funnel(
 
 
 # =============================================================================
+# In-App Products CRUD Tools
+# =============================================================================
+
+
+@mcp.tool()
+def create_in_app_product(
+    package_name: str,
+    sku: str,
+    product_type: str,
+    default_language: str,
+    title: str,
+    description: str,
+    default_price_amount: str,
+    default_price_currency: str,
+) -> dict[str, Any]:
+    """Create a new in-app product (one-time purchase).
+
+    Args:
+        package_name: App package name
+        sku: Unique product SKU identifier (e.g. "coins_100")
+        product_type: "managedProduct" (one-time) or "subscription" (legacy)
+        default_language: Default locale code (e.g. "en-US")
+        title: Product title shown to users
+        description: Product description shown to users
+        default_price_amount: Price as decimal string (e.g. "0.99")
+        default_price_currency: ISO 4217 currency code (e.g. "USD")
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.create_in_app_product(
+        package_name=package_name,
+        sku=sku,
+        product_type=product_type,
+        default_language=default_language,
+        title=title,
+        description=description,
+        default_price_amount=default_price_amount,
+        default_price_currency=default_price_currency,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_in_app_product(
+    package_name: str,
+    sku: str,
+    title: str | None = None,
+    description: str | None = None,
+    default_price_amount: str | None = None,
+    default_price_currency: str | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Update an existing in-app product.
+
+    Args:
+        package_name: App package name
+        sku: Product SKU identifier
+        title: New product title (optional)
+        description: New product description (optional)
+        default_price_amount: New price as decimal string (optional, e.g. "1.99")
+        default_price_currency: Currency code if changing price (optional)
+        status: "active" or "inactive" (optional)
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.update_in_app_product(
+        package_name=package_name,
+        sku=sku,
+        title=title,
+        description=description,
+        default_price_amount=default_price_amount,
+        default_price_currency=default_price_currency,
+        status=status,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_in_app_product(
+    package_name: str,
+    sku: str,
+) -> dict[str, Any]:
+    """Delete an in-app product permanently.
+
+    Args:
+        package_name: App package name
+        sku: Product SKU to delete
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    return client.delete_in_app_product(package_name=package_name, sku=sku)
+
+
+# =============================================================================
+# Subscriptions CRUD Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_subscription(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Get details of a subscription product from the Monetization API.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+
+    Returns:
+        Subscription details including state, listings, and base plans
+    """
+    client = get_client_from_context()
+    result = client.get_subscription(package_name=package_name, product_id=product_id)
+    return result.model_dump()
+
+
+@mcp.tool()
+def create_subscription(
+    package_name: str,
+    product_id: str,
+    default_language: str,
+    title: str,
+    description: str,
+) -> dict[str, Any]:
+    """Create a new subscription product via the Monetization API.
+
+    Args:
+        package_name: App package name
+        product_id: Unique subscription product ID (e.g. "premium_monthly")
+        default_language: Default locale code (e.g. "en-US")
+        title: Subscription title shown to users
+        description: Subscription description shown to users
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.create_subscription(
+        package_name=package_name,
+        product_id=product_id,
+        default_language=default_language,
+        title=title,
+        description=description,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_subscription(
+    package_name: str,
+    product_id: str,
+    title: str | None = None,
+    description: str | None = None,
+    default_language: str = "en-US",
+) -> dict[str, Any]:
+    """Update an existing subscription product's listings.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+        title: New title (optional)
+        description: New description (optional)
+        default_language: Locale to update (default "en-US")
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.update_subscription(
+        package_name=package_name,
+        product_id=product_id,
+        title=title,
+        description=description,
+        default_language=default_language,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_subscription(
+    package_name: str,
+    product_id: str,
+) -> dict[str, Any]:
+    """Delete a subscription product permanently.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID to delete
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_subscription(package_name=package_name, product_id=product_id)
+    return result.model_dump()
+
+
+@mcp.tool()
+def activate_base_plan(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+) -> dict[str, Any]:
+    """Activate a base plan for a subscription product.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+        base_plan_id: Base plan ID to activate
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.activate_base_plan(
+        package_name=package_name, product_id=product_id, base_plan_id=base_plan_id
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def deactivate_base_plan(
+    package_name: str,
+    product_id: str,
+    base_plan_id: str,
+) -> dict[str, Any]:
+    """Deactivate a base plan for a subscription product.
+
+    Args:
+        package_name: App package name
+        product_id: Subscription product ID
+        base_plan_id: Base plan ID to deactivate
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.deactivate_base_plan(
+        package_name=package_name, product_id=product_id, base_plan_id=base_plan_id
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Country Availability Update Tool
+# =============================================================================
+
+
+@mcp.tool()
+def update_country_availability(
+    package_name: str,
+    track: str,
+    countries: list[str],
+    rest_of_world: bool = False,
+) -> dict[str, Any]:
+    """Set the countries where a release track is available.
+
+    Args:
+        package_name: App package name
+        track: Track name (internal, alpha, beta, production)
+        countries: List of ISO 3166-1 alpha-2 country codes (e.g. ["US", "GB", "JP"])
+        rest_of_world: If True, also available in all countries not explicitly listed
+
+    Returns:
+        Update result with the countries set and success status
+    """
+    client = get_client_from_context()
+    result = client.update_country_availability(
+        package_name=package_name,
+        track=track,
+        countries=countries,
+        rest_of_world=rest_of_world,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# User & Grant Update Tools
+# =============================================================================
+
+
+@mcp.tool()
+def update_user(
+    developer_id: str,
+    email: str,
+    access_state: str,
+) -> dict[str, Any]:
+    """Update a user's account-level access state.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address
+        access_state: New access state: accessGranted, accessExpired, or accessRevoked
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.update_user(
+        developer_id=developer_id, email=email, access_state=access_state
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_grant(
+    developer_id: str,
+    email: str,
+    package_name: str,
+    app_level_permissions: list[str],
+) -> dict[str, Any]:
+    """Update a user's app-level permissions on a specific app.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address
+        package_name: App package name
+        app_level_permissions: New permissions list. Valid values:
+                               canAccessStats, canManageProductionRelease,
+                               canManageTestTracks, canManageStorePresence,
+                               canReplyToReviews
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.update_grant(
+        developer_id=developer_id,
+        email=email,
+        package_name=package_name,
+        app_level_permissions=app_level_permissions,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Subscription Defer Tool
+# =============================================================================
+
+
+@mcp.tool()
+def defer_subscription(
+    package_name: str,
+    subscription_id: str,
+    purchase_token: str,
+    expected_expiry_time_millis: str,
+    desired_expiry_time_millis: str,
+) -> dict[str, Any]:
+    """Defer a subscriber's renewal date (customer service use case).
+
+    Args:
+        package_name: App package name
+        subscription_id: Subscription product ID
+        purchase_token: The purchase token from the client app
+        expected_expiry_time_millis: Current expiry time in milliseconds (Unix epoch)
+        desired_expiry_time_millis: New desired expiry time in milliseconds (Unix epoch)
+
+    Returns:
+        Result with the new expiry time in milliseconds
+    """
+    client = get_client_from_context()
+    result = client.defer_subscription(
+        package_name=package_name,
+        subscription_id=subscription_id,
+        token=purchase_token,
+        expected_expiry_time_millis=expected_expiry_time_millis,
+        desired_expiry_time_millis=desired_expiry_time_millis,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Store Listing Delete Tools
+# =============================================================================
+
+
+@mcp.tool()
+def delete_listing(
+    package_name: str,
+    language: str,
+) -> dict[str, Any]:
+    """Delete the store listing for a specific language locale.
+
+    Args:
+        package_name: App package name
+        language: Language code to delete (e.g. "fr-FR", "de-DE")
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_listing(package_name=package_name, language=language)
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_all_listings(
+    package_name: str,
+) -> dict[str, Any]:
+    """Delete all store listings for an app. Use with caution.
+
+    Args:
+        package_name: App package name
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_all_listings(package_name=package_name)
+    return result.model_dump()
+
+
+# =============================================================================
+# Region Price Conversion Tool
+# =============================================================================
+
+
+@mcp.tool()
+def convert_region_prices(
+    package_name: str,
+    price_amount: str,
+    currency_code: str,
+) -> dict[str, Any]:
+    """Convert a base price to all regional equivalents using Google's exchange rates.
+
+    Args:
+        package_name: App package name
+        price_amount: Base price as decimal string (e.g. "9.99")
+        currency_code: ISO 4217 base currency code (e.g. "USD")
+
+    Returns:
+        List of converted prices per region with local currency and amount
+    """
+    client = get_client_from_context()
+    result = client.convert_region_prices(
+        package_name=package_name,
+        price_amount=price_amount,
+        currency_code=currency_code,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
 # Entry Point
 # =============================================================================
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1506,6 +1506,246 @@ def revoke_subscription_v2(
 
 
 # =============================================================================
+# Play Developer Reporting API Tools (Vitals)
+# =============================================================================
+
+_VITALS_DIMENSIONS_HELP = (
+    "Optional list of dimensions to group by. Common values: "
+    "versionCode, apiLevel, deviceModel, deviceBrand, countryCode. "
+    "Default: no grouping (overall totals only)."
+)
+
+_VITALS_PERMISSION_NOTE = (
+    "Requires the service account to have 'Performance Analysis' permission "
+    "in Play Console (Account settings > Users and permissions)."
+)
+
+
+@mcp.tool()
+def get_crash_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily crash rate from Play Developer Reporting API.
+
+    Returns crashRate (ratio of sessions with crash), crashCount, and distinctUsers
+    per day over the requested period.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format (exclusive — use tomorrow's date to include today)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points containing date, metrics, dimensions
+    """
+    client = get_client_from_context()
+    result = client.get_crash_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_anr_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily ANR (Application Not Responding) rate.
+
+    Returns anrRate (ratio of sessions with ANR), anrCount, and distinctUsers per day.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points
+    """
+    client = get_client_from_context()
+    result = client.get_anr_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_slow_startup_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily slow startup rate.
+
+    Returns slowStartupRate (ratio of slow cold starts), slowStartupCount, distinctUsers.
+    A cold start is considered slow if it takes > 5 seconds.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points
+    """
+    client = get_client_from_context()
+    result = client.get_slow_startup_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_slow_rendering_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily slow rendering (frame drop) rate.
+
+    Returns slowRenderingRate20Fps (frames rendered below 20fps) and
+    slowRenderingRate30Fps (frames rendered below 30fps), plus distinctUsers.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points
+    """
+    client = get_client_from_context()
+    result = client.get_slow_rendering_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_excessive_wakeup_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily excessive wakeup rate.
+
+    Returns excessiveWakeupRate (ratio of hours with > 10 wakeups/hour),
+    excessiveWakeupCount, and distinctUsers.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points
+    """
+    client = get_client_from_context()
+    result = client.get_excessive_wakeup_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_stuck_wakelock_rate(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    f"""Query daily stuck background wakelock rate.
+
+    Returns stuckBgWakelockRate (ratio of hours where app holds wakelock > 1 hour),
+    stuckBgWakelockCount, and distinctUsers.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD (exclusive)
+        dimensions: {_VITALS_DIMENSIONS_HELP}
+
+    Returns:
+        VitalsQueryResult with list of data_points
+    """
+    client = get_client_from_context()
+    result = client.get_stuck_wakelock_rate(
+        package_name=package_name,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def list_vitals_anomalies(
+    package_name: str,
+    filter_str: str | None = None,
+) -> list[dict[str, Any]]:
+    f"""List automatically detected vitals anomalies for an app.
+
+    Anomalies are significant degradations in any vitals metric automatically
+    detected by Google Play. Useful for catching regressions.
+
+    {_VITALS_PERMISSION_NOTE}
+
+    Args:
+        package_name: App package name
+        filter_str: Optional filter, e.g. "metric = crashRate" or "metric = anrRate"
+
+    Returns:
+        List of anomalies with metric_set, dimensions, first_detection_time, last_detected_day
+    """
+    client = get_client_from_context()
+    anomalies = client.list_vitals_anomalies(
+        package_name=package_name,
+        filter_str=filter_str,
+    )
+    return [a.model_dump() for a in anomalies]
+
+
+# =============================================================================
 # Entry Point
 # =============================================================================
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1936,6 +1936,126 @@ def get_acquisition_funnel(
     return result.model_dump()
 
 
+@mcp.tool()
+def get_custom_store_listings(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+) -> dict[str, Any]:
+    """List Custom Store Listings (CSL) for an app via Play Console UI scrape (OpenCLI).
+
+    CSL configuration has NO Android Publisher API surface at all -- confirmed by
+    cross-checking the full REST resource index (only v3.edits.listings exists for
+    the Main store listing; nothing for custom listings). This reads the Console UI
+    directly via OpenCLI browser automation instead.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    LIMITATION: returns each CSL's internal name and edit URL only. Per-CSL content
+    (title, short/full description, targeting rules) requires opening each edit URL
+    individually and was not reliably scrapable via simple selectors as of 2026-07-01
+    (Angular Material form fields) -- not yet implemented.
+
+    Find developer_id and app_id in the Play Console URL:
+    https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/store-listings
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+
+    Returns:
+        listings: List of {name, listing_id, edit_url} for each CSL
+    """
+    client = get_client_from_context()
+    result = client.get_custom_store_listings(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_store_listing_experiments(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+) -> dict[str, Any]:
+    """List Store Listing Experiments (A/B tests) for an app via Play Console RPC capture (OpenCLI).
+
+    Store Listing Experiments have NO Android Publisher API surface at all -- same
+    verification as get_custom_store_listings. This decodes an internal, undocumented
+    protobuf response captured via OpenCLI network capture. There is no public schema
+    for this response, so field semantics beyond experiment_id/name/locale are INFERRED
+    from one real reverse-engineered response, not confirmed against an official spec --
+    treat dimension_type/status/traffic_split as best-effort, verify against the Console
+    UI for anything decision-critical.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Find developer_id and app_id in the Play Console URL:
+    https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/store-listing-experiments/overview
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+
+    Returns:
+        experiments: List of experiments with experiment_id, name, locale, and
+                     best-effort dimension_type/status/start_timestamp/traffic_split
+    """
+    client = get_client_from_context()
+    result = client.get_store_listing_experiments(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_experiment_report_raw(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    experiment_id: str,
+) -> dict[str, Any]:
+    """Fetch raw decodable content of one Store Listing Experiment's report (OpenCLI).
+
+    Companion to get_store_listing_experiments. Does not attempt to parse performance
+    metrics (installs/conversion lift per variant) -- no official schema is available
+    for that part of the response. Surfaces creative image URLs and readable text runs
+    found in the payload, which is enough to confirm what's actually being compared
+    (e.g. which screenshot set is the control vs the variant) without guessing at
+    metric field numbers.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        experiment_id: Numeric experiment id (from get_store_listing_experiments)
+
+    Returns:
+        image_urls: Creative image URLs found in the report payload
+        text_strings: Readable text runs found in the report payload (longest first)
+    """
+    client = get_client_from_context()
+    result = client.get_experiment_report_raw(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        experiment_id=experiment_id,
+    )
+    return result.model_dump()
+
+
 # =============================================================================
 # In-App Products CRUD Tools
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1781,6 +1781,52 @@ def list_vitals_anomalies(
     return [a.model_dump() for a in anomalies]
 
 
+@mcp.tool()
+def get_install_stats(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    start_date: str,
+    end_date: str,
+    country_codes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Get install statistics from Play Console via browser session (OpenCLI).
+
+    Returns daily install events, net installs, and active users. Optionally
+    breaks down install events by country.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Find developer_id and app_id in the Play Console URL:
+    https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/statistics
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD
+        country_codes: Optional list of country codes for per-country breakdown (e.g. ["US", "GB"])
+
+    Returns:
+        install_events: Total installs including re-installs with daily breakdown
+        net_installs: Net installs (installs minus uninstalls)
+        active_users: Unique active users
+        by_country: Per-country install events (if country_codes provided)
+    """
+    client = get_client_from_context()
+    result = client.get_install_stats(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        start_date=start_date,
+        end_date=end_date,
+        country_codes=country_codes,
+    )
+    return result.model_dump()
+
+
 # =============================================================================
 # Entry Point
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -595,7 +595,7 @@ def update_listing(
     Args:
         package_name: App package name
         language: Language code (e.g., en-US, es-ES, fr-FR)
-        title: App title (max 50 characters, optional)
+        title: App title (max 30 characters, optional)
         full_description: Full description (max 4000 characters, optional)
         short_description: Short description (max 80 characters, optional)
         video: YouTube video URL (optional)
@@ -612,6 +612,37 @@ def update_listing(
         full_description=full_description,
         short_description=short_description,
         video=video,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def batch_update_listings(
+    package_name: str,
+    updates: list[dict[str, Any]],
+    commit: bool = False,
+) -> dict[str, Any]:
+    """Validate or update store listings for multiple languages.
+
+    This tool is dry-run by default: it validates all requested listing text
+    locally and does not create a Google Play edit unless commit is explicitly
+    set to true.
+
+    Args:
+        package_name: App package name
+        updates: Items with language plus optional title, short_description,
+            full_description, and video fields
+        commit: If true, create one edit, update all locales, and commit it
+
+    Returns:
+        Batch validation/update result
+    """
+    client = get_client_from_context()
+
+    result = client.batch_update_listings(
+        package_name=package_name,
+        updates=updates,
+        commit=commit,
     )
     return result.model_dump()
 
@@ -862,7 +893,7 @@ def validate_listing_text(
     """Validate store listing text lengths before updating.
 
     Args:
-        title: App title (max 50 characters)
+        title: App title (max 30 characters)
         short_description: Short description (max 80 characters)
         full_description: Full description (max 4000 characters)
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1827,6 +1827,82 @@ def get_install_stats(
     return result.model_dump()
 
 
+@mcp.tool()
+def get_search_terms(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    """Get search-term acquisition stats from Play Console via browser session (OpenCLI).
+
+    Returns the list of search terms users typed in Play Store search before
+    acquiring the app, with installs and store-listing visitor counts. Terms
+    falling below the privacy threshold are aggregated as "Other".
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD
+
+    Returns:
+        package_name, start_date, end_date, terms (sorted by installs desc)
+    """
+    client = get_client_from_context()
+    result = client.get_search_terms(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_acquisition_funnel(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    """Get the acquisition funnel summary from Play Console via browser session.
+
+    Returns funnel stages (store listing visitors -> installers) with the
+    conversion rate between them, taken from the Play Console acquisition
+    details RPC.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Args:
+        package_name: App package name
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD
+
+    Returns:
+        package_name, start_date, end_date, stages (ordered list)
+    """
+    client = get_client_from_context()
+    result = client.get_acquisition_funnel(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return result.model_dump()
+
+
 # =============================================================================
 # Entry Point
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -662,20 +662,27 @@ def update_testers(
     package_name: str,
     track: str,
     tester_emails: list[str],
+    google_group_emails: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Update testers for a specific testing track.
+    """Update the list of testers for a track.
 
     Args:
-        package_name: App package name
-        track: Track name (internal, alpha, beta)
-        tester_emails: List of tester email addresses or Google Group emails
+        package_name: App package name (e.g., com.example.myapp)
+        track: Track name - one of: internal, alpha, beta
+        tester_emails: List of individual tester email addresses
+        google_group_emails: Optional list of Google Group email addresses
 
     Returns:
         Update result with success status
     """
     client = get_client_from_context()
 
-    result = client.update_testers(package_name, track, tester_emails)
+    result = client.update_testers(
+        package_name=package_name,
+        track=track,
+        tester_emails=tester_emails,
+        google_group_emails=google_group_emails or [],
+    )
     return result.model_dump()
 
 
@@ -732,6 +739,73 @@ def get_expansion_file(
 
     expansion_file = client.get_expansion_file(package_name, version_code, expansion_file_type)
     return expansion_file.model_dump()
+
+
+@mcp.tool()
+def upload_deobfuscation_file(
+    package_name: str,
+    version_code: int,
+    file_path: str,
+    deobfuscation_file_type: str = "proguard",
+) -> dict[str, Any]:
+    """Upload a ProGuard/R8 deobfuscation mapping file for an APK version.
+
+    This enables human-readable crash stack traces in Play Console.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        version_code: APK version code to associate the mapping with
+        file_path: Absolute path to the mapping.txt file on this machine
+        deobfuscation_file_type: 'proguard' (default) or 'nativeCode'
+
+    Returns:
+        Upload result with success status
+    """
+    client = get_client_from_context()
+    result = client.upload_deobfuscation_file(
+        package_name=package_name,
+        version_code=version_code,
+        file_path=file_path,
+        deobfuscation_file_type=deobfuscation_file_type,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def list_bundles(package_name: str) -> list[dict[str, Any]]:
+    """List all AAB bundles uploaded for an app.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+
+    Returns:
+        List of bundle info with version_code, sha1, sha256
+    """
+    client = get_client_from_context()
+    bundles = client.list_bundles(package_name)
+    return [b.model_dump() for b in bundles]
+
+
+@mcp.tool()
+def list_generated_apks(
+    package_name: str,
+    bundle_version_code: int,
+) -> list[dict[str, Any]]:
+    """List APKs generated from a specific AAB bundle.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        bundle_version_code: Version code of the bundle to query
+
+    Returns:
+        List of generated APK info with download_id, variant_id, sdk versions
+    """
+    client = get_client_from_context()
+    apks = client.list_generated_apks(
+        package_name=package_name,
+        bundle_version_code=bundle_version_code,
+    )
+    return [a.model_dump() for a in apks]
 
 
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -1827,6 +1827,84 @@ def get_install_stats(
     return result.model_dump()
 
 
+@mcp.tool()
+def get_search_terms(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    """Get top search terms driving installs from Play Console via browser session (OpenCLI).
+
+    Returns the search terms that brought users to the store listing, sorted by installs.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Find developer_id and app_id in the Play Console URL:
+    https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/statistics
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD
+
+    Returns:
+        terms: List of search terms with installs and store_listing_visitors, sorted by installs desc
+    """
+    client = get_client_from_context()
+    result = client.get_search_terms(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def get_acquisition_funnel(
+    package_name: str,
+    developer_id: str,
+    app_id: str,
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    """Get user acquisition funnel from Play Console via browser session (OpenCLI).
+
+    Returns the conversion funnel: impressions → store listing visitors → installers → buyers.
+
+    REQUIREMENT: OpenCLI must be installed and the automation browser must be
+    logged into Play Console (play.google.com/console).
+
+    Find developer_id and app_id in the Play Console URL:
+    https://play.google.com/console/u/0/developers/{developer_id}/app/{app_id}/grow-overview
+
+    Args:
+        package_name: App package name (e.g. com.example.app)
+        developer_id: Numeric developer account ID from Play Console URL
+        app_id: Numeric app ID from Play Console URL
+        start_date: Start date YYYY-MM-DD
+        end_date: End date YYYY-MM-DD
+
+    Returns:
+        stages: Funnel stages with value and conversion_rate relative to previous stage
+    """
+    client = get_client_from_context()
+    result = client.get_acquisition_funnel(
+        package_name=package_name,
+        developer_id=developer_id,
+        app_id=app_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return result.model_dump()
+
+
 # =============================================================================
 # Entry Point
 # =============================================================================

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -960,6 +960,478 @@ async def update_credentials(request: Request) -> JSONResponse:
 
 
 # =============================================================================
+# Images Tools
+# =============================================================================
+
+
+@mcp.tool()
+def list_images(
+    package_name: str,
+    language: str,
+    image_type: str,
+) -> list[dict[str, Any]]:
+    """List store listing images for a given language and image type.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        language: Language code (e.g., en-US)
+        image_type: One of: phoneScreenshots, sevenInchScreenshots,
+                    tenInchScreenshots, tvScreenshots, wearScreenshots,
+                    icon, featureGraphic, tvBanner, promoGraphic
+
+    Returns:
+        List of images with id, url, sha1, sha256
+    """
+    client = get_client_from_context()
+    results = client.list_images(package_name=package_name, language=language, image_type=image_type)
+    return [r.model_dump() for r in results]
+
+
+@mcp.tool()
+def upload_image(
+    package_name: str,
+    language: str,
+    image_type: str,
+    file_path: str,
+) -> dict[str, Any]:
+    """Upload a store listing image (screenshot, icon, feature graphic, etc.).
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        language: Language code (e.g., en-US)
+        image_type: One of: phoneScreenshots, sevenInchScreenshots,
+                    tenInchScreenshots, tvScreenshots, wearScreenshots,
+                    icon, featureGraphic, tvBanner, promoGraphic
+        file_path: Absolute path to the image file (PNG or JPEG)
+
+    Returns:
+        Upload result with success status and image ID
+    """
+    client = get_client_from_context()
+    result = client.upload_image(
+        package_name=package_name,
+        language=language,
+        image_type=image_type,
+        file_path=file_path,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_image(
+    package_name: str,
+    language: str,
+    image_type: str,
+    image_id: str,
+) -> dict[str, Any]:
+    """Delete a specific store listing image by ID.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        language: Language code (e.g., en-US)
+        image_type: Image type (e.g., phoneScreenshots, icon)
+        image_id: ID of the image to delete (from list_images)
+
+    Returns:
+        Delete result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_image(
+        package_name=package_name,
+        language=language,
+        image_type=image_type,
+        image_id=image_id,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_all_images(
+    package_name: str,
+    language: str,
+    image_type: str,
+) -> dict[str, Any]:
+    """Delete all store listing images of a given type and language.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        language: Language code (e.g., en-US)
+        image_type: Image type to clear (e.g., phoneScreenshots, featureGraphic)
+
+    Returns:
+        Delete result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_all_images(
+        package_name=package_name,
+        language=language,
+        image_type=image_type,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# App Details Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_app_details_info(package_name: str) -> dict[str, Any]:
+    """Get app details including default language and developer contact info.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+
+    Returns:
+        App details with defaultLanguage, contactEmail, contactPhone, contactWebsite
+    """
+    client = get_client_from_context()
+    result = client.get_app_details_info(package_name=package_name)
+    return result.model_dump()
+
+
+@mcp.tool()
+def update_app_details_info(
+    package_name: str,
+    default_language: str | None = None,
+    contact_email: str | None = None,
+    contact_phone: str | None = None,
+    contact_website: str | None = None,
+) -> dict[str, Any]:
+    """Update app details such as default language and developer contact info.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        default_language: Default language code (e.g., en-US, zh-CN)
+        contact_email: Developer contact email shown on Play Store
+        contact_phone: Developer contact phone shown on Play Store
+        contact_website: Developer contact website shown on Play Store
+
+    Returns:
+        Update result with success status
+    """
+    client = get_client_from_context()
+    result = client.update_app_details_info(
+        package_name=package_name,
+        default_language=default_language,
+        contact_email=contact_email,
+        contact_phone=contact_phone,
+        contact_website=contact_website,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Country Availability Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_country_availability(
+    package_name: str,
+    track: str,
+) -> dict[str, Any]:
+    """Get the list of countries where a release track is available.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        track: Release track - one of: internal, alpha, beta, production
+
+    Returns:
+        Country availability with list of country codes and rest_of_world flag
+    """
+    client = get_client_from_context()
+    result = client.get_country_availability(package_name=package_name, track=track)
+    return result.model_dump()
+
+
+# =============================================================================
+# Users & Grants Tools
+# =============================================================================
+
+
+@mcp.tool()
+def list_users(developer_id: str) -> list[dict[str, Any]]:
+    """List all users in a Google Play developer account.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL,
+                      e.g., the number after 'developers/' in console.play.google.com)
+
+    Returns:
+        List of users with email, access_state, and app-level grants
+    """
+    client = get_client_from_context()
+    results = client.list_users(developer_id=developer_id)
+    return [r.model_dump() for r in results]
+
+
+@mcp.tool()
+def create_user(
+    developer_id: str,
+    email: str,
+    access_state: str = "accessGranted",
+) -> dict[str, Any]:
+    """Add a user to the developer account.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address
+        access_state: Account-level access. One of:
+                      accessGranted (default), accessExpired, accessRevoked
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.create_user(
+        developer_id=developer_id,
+        email=email,
+        access_state=access_state,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_user(
+    developer_id: str,
+    email: str,
+) -> dict[str, Any]:
+    """Remove a user from the developer account.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address to remove
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_user(developer_id=developer_id, email=email)
+    return result.model_dump()
+
+
+@mcp.tool()
+def create_grant(
+    developer_id: str,
+    email: str,
+    package_name: str,
+    app_level_permissions: list[str],
+) -> dict[str, Any]:
+    """Grant a user app-level permissions on a specific app.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address
+        package_name: App package name to grant access to
+        app_level_permissions: List of permissions. Valid values:
+                               canAccessStats, canManageProductionRelease,
+                               canManageTestTracks, canManageStorePresence,
+                               canReplyToReviews
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.create_grant(
+        developer_id=developer_id,
+        email=email,
+        package_name=package_name,
+        app_level_permissions=app_level_permissions,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def delete_grant(
+    developer_id: str,
+    email: str,
+    package_name: str,
+) -> dict[str, Any]:
+    """Revoke a user's app-level permissions on a specific app.
+
+    Args:
+        developer_id: Developer account ID (numeric ID from Play Console URL)
+        email: User's Google account email address
+        package_name: App package name to revoke access from
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.delete_grant(
+        developer_id=developer_id,
+        email=email,
+        package_name=package_name,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Orders Refund Tool
+# =============================================================================
+
+
+@mcp.tool()
+def refund_order(
+    package_name: str,
+    order_id: str,
+    revoke: bool = False,
+) -> dict[str, Any]:
+    """Refund a user's order (purchase or subscription).
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        order_id: The order ID to refund
+        revoke: If True, also revokes the user's entitlement to the item.
+                Use with caution - this removes access immediately.
+
+    Returns:
+        Refund result with success status
+    """
+    client = get_client_from_context()
+    result = client.refund_order(
+        package_name=package_name,
+        order_id=order_id,
+        revoke=revoke,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Purchases - Products Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_product_purchase(
+    package_name: str,
+    product_id: str,
+    token: str,
+) -> dict[str, Any]:
+    """Get the status of a one-time in-app product purchase.
+
+    Use this to verify if a purchase is valid, consumed, or acknowledged.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        product_id: The product SKU (in-app product ID)
+        token: The purchase token returned from the client-side purchase
+
+    Returns:
+        Purchase status including purchase_state (0=purchased, 1=canceled, 2=pending),
+        consumption_state, acknowledged, order_id
+    """
+    client = get_client_from_context()
+    result = client.get_product_purchase(
+        package_name=package_name,
+        product_id=product_id,
+        token=token,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def acknowledge_product_purchase(
+    package_name: str,
+    product_id: str,
+    token: str,
+    developer_payload: str = "",
+) -> dict[str, Any]:
+    """Acknowledge a one-time in-app product purchase.
+
+    Must be called within 3 days of purchase, otherwise the purchase is automatically refunded.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        product_id: The product SKU (in-app product ID)
+        token: The purchase token returned from the client-side purchase
+        developer_payload: Optional string to attach to the purchase (max 100 chars)
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.acknowledge_product_purchase(
+        package_name=package_name,
+        product_id=product_id,
+        token=token,
+        developer_payload=developer_payload,
+    )
+    return result.model_dump()
+
+
+# =============================================================================
+# Purchases - Subscriptions v2 Tools
+# =============================================================================
+
+
+@mcp.tool()
+def get_subscription_purchase_v2(
+    package_name: str,
+    token: str,
+) -> dict[str, Any]:
+    """Get subscription purchase details using the latest v2 API.
+
+    Provides richer subscription state information than the v1 API.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        token: The purchase token returned from the client-side subscription
+
+    Returns:
+        Subscription state including subscription_state, expiry_time,
+        product_id, base_plan_id, offer_id, auto_renewing
+    """
+    client = get_client_from_context()
+    result = client.get_subscription_purchase_v2(
+        package_name=package_name,
+        token=token,
+    )
+    return result.model_dump()
+
+
+@mcp.tool()
+def cancel_subscription_v2(
+    package_name: str,
+    token: str,
+) -> dict[str, Any]:
+    """Cancel a subscription (user keeps access until end of billing period).
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        token: The purchase token of the subscription to cancel
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.cancel_subscription_v2(package_name=package_name, token=token)
+    return result.model_dump()
+
+
+@mcp.tool()
+def revoke_subscription_v2(
+    package_name: str,
+    token: str,
+) -> dict[str, Any]:
+    """Revoke a subscription (cancels AND immediately expires access).
+
+    Use for fraud, abuse, or policy violations. The user loses access immediately.
+
+    Args:
+        package_name: App package name (e.g., com.example.myapp)
+        token: The purchase token of the subscription to revoke
+
+    Returns:
+        Operation result with success status
+    """
+    client = get_client_from_context()
+    result = client.revoke_subscription_v2(package_name=package_name, token=token)
+    return result.model_dump()
+
+
+# =============================================================================
 # Entry Point
 # =============================================================================
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,6 +100,35 @@ class TestGetAppDetails:
         assert details.developer_email == "dev@example.com"
 
 
+class TestProductPurchases:
+    """Test one-time in-app product purchase methods."""
+
+    def test_consume_product_purchase_success(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Consumes a one-time in-app product purchase via the official API."""
+        mock_products = _mock_service.purchases.return_value.products.return_value
+        mock_products.consume.return_value.execute.return_value = {}
+
+        result = client.consume_product_purchase(
+            package_name="com.example.app",
+            product_id="coins_100",
+            token="purchase-token",
+        )
+
+        assert result.success is True
+        assert result.package_name == "com.example.app"
+        assert result.product_id == "coins_100"
+        assert result.purchase_token == "purchase-token"
+        mock_products.consume.assert_called_once_with(
+            packageName="com.example.app",
+            productId="coins_100",
+            token="purchase-token",
+        )
+
+
 class TestDeployApp:
     """Test deploy_app method."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -926,12 +926,18 @@ class TestBrowserStats:
         return PlayStoreClient(credentials_path="/nonexistent/path.json")
 
     def test_get_search_terms_success(self, bare_client: PlayStoreClient) -> None:
+        # Response format from getAcquisitionDetailsTableData with dimension type 2 (search term).
+        # "1" = outer wrapper; "3" = list of rows;
+        # each row: "1"={"1":term_id,"2":display}, "2"={"1":visitors}, "3"={"1":installs}
         response = {
-            "1": [
-                {"1": "puzzle game", "2": [{"1": 42}, {"1": 120}]},
-                {"1": "brain teaser", "2": [{"1": 15}, {"1": 60}]},
-                {"1": "word game", "2": [{"1": 28}, {"1": 95}]},
-            ]
+            "1": {
+                "1": 2,
+                "3": [
+                    {"1": {"1": "puzzle game", "2": "puzzle game"}, "2": {"1": "120"}, "3": {"1": "42"}},
+                    {"1": {"1": "brain teaser", "2": "brain teaser"}, "2": {"1": "60"}, "3": {"1": "15"}},
+                    {"1": {"1": "word game", "2": "word game"}, "2": {"1": "95"}, "3": {"1": "28"}},
+                ],
+            }
         }
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(response), stderr="")
@@ -985,13 +991,20 @@ class TestBrowserStats:
                 )
 
     def test_get_acquisition_funnel_success(self, bare_client: PlayStoreClient) -> None:
+        # Response format from getAcquisitionSummary (live reverse-engineered):
+        # "1" = traffic source array; "2" = conversion summary (visitors, installers, rate)
         response = {
             "1": [
-                {"1": 1, "2": 10000},
-                {"1": 2, "2": 3000},
-                {"1": 3, "2": 500},
-                {"1": 4, "2": 50},
-            ]
+                {"1": {"1": "@OVERALL@"}, "2": {"1": "22"}},
+                {"1": {"1": "STORE_SEARCH", "2": "Google Play search"}, "2": {"1": "9"}},
+                {"1": {"1": "STORE_BROWSE", "2": "Google Play explore"}, "2": {"1": "8"}},
+                {"1": {"1": "DEEPLINK", "2": "Ads and referrals"}, "2": {"1": "5"}},
+            ],
+            "2": {
+                "1": {"1": "177"},
+                "2": {"1": "22"},
+                "3": {"1": 0.12429378531073447},
+            },
         }
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(response), stderr="")
@@ -1004,18 +1017,17 @@ class TestBrowserStats:
             )
 
         assert result.package_name == "com.vast.jujubit"
-        assert len(result.stages) == 4
-        assert result.stages[0].stage == "impressions"
-        assert result.stages[0].value == 10000
+        # 2 funnel stages + 3 traffic source breakdown stages
+        assert len(result.stages) == 5
+        assert result.stages[0].stage == "store_listing_visitors"
+        assert result.stages[0].value == 177
         assert result.stages[0].conversion_rate == 0.0
-        assert result.stages[1].stage == "store_listing_visitors"
-        assert result.stages[1].value == 3000
-        assert result.stages[1].conversion_rate == 0.3
-        assert result.stages[2].stage == "installers"
-        assert result.stages[2].value == 500
-        assert round(result.stages[2].conversion_rate, 4) == round(500 / 3000, 4)
-        assert result.stages[3].stage == "buyers"
-        assert result.stages[3].value == 50
+        assert result.stages[1].stage == "installers"
+        assert result.stages[1].value == 22
+        assert result.stages[1].conversion_rate == round(0.12429378531073447, 4)
+        # Traffic source breakdown
+        assert result.stages[2].stage == "src:search"
+        assert result.stages[2].value == 9
 
     def test_get_acquisition_funnel_empty(self, bare_client: PlayStoreClient) -> None:
         with patch("subprocess.run") as mock_run:
@@ -1027,7 +1039,8 @@ class TestBrowserStats:
                 start_date="2024-01-01",
                 end_date="2024-01-31",
             )
-        assert result.stages == []
+        assert result.stages[0].stage == "store_listing_visitors"
+        assert result.stages[0].value == 0
 
     def test_get_acquisition_funnel_browser_error(self, bare_client: PlayStoreClient) -> None:
         with patch("subprocess.run") as mock_run:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -560,6 +560,92 @@ class TestStoreListings:
         assert any(listing.language == "en-US" for listing in listings)
         assert any(listing.language == "es-ES" for listing in listings)
 
+    def test_batch_update_listings_dry_run_does_not_create_edit(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Test dry-run validates multiple listings without creating an edit."""
+        result = client.batch_update_listings(
+            package_name="com.example.app",
+            updates=[
+                {"language": "en-US", "title": "New Title"},
+                {"language": "es-ES", "short_description": "Nueva descripcion"},
+            ],
+        )
+
+        assert result.success is True
+        assert result.commit is False
+        assert result.validated_languages == ["en-US", "es-ES"]
+        _mock_service.edits.return_value.insert.assert_not_called()
+
+    def test_batch_update_listings_validation_error_blocks_edit(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Test invalid batch input fails before any edit is created."""
+        result = client.batch_update_listings(
+            package_name="com.example.app",
+            updates=[{"language": "en-US", "title": "A" * 31}],
+            commit=True,
+        )
+
+        assert result.success is False
+        assert result.commit is False
+        assert result.errors[0]["field"] == "title"
+        _mock_service.edits.return_value.insert.assert_not_called()
+
+    def test_batch_update_listings_commit_multiple_languages(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Test committing multiple locale listing updates in one edit."""
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.listings.return_value.get.return_value.execute.side_effect = [
+            {
+                "title": "Old Title",
+                "fullDescription": "Old full",
+                "shortDescription": "Old short",
+                "video": "https://youtu.be/old",
+            },
+            {
+                "title": "Titulo viejo",
+                "fullDescription": "Descripcion vieja",
+                "shortDescription": "Corta vieja",
+            },
+        ]
+        mock_edits.listings.return_value.update.return_value.execute.return_value = {}
+        mock_edits.commit.return_value.execute.return_value = {}
+
+        result = client.batch_update_listings(
+            package_name="com.example.app",
+            updates=[
+                {"language": "en-US", "title": "New Title"},
+                {"language": "es-ES", "short_description": "Nueva corta"},
+            ],
+            commit=True,
+        )
+
+        assert result.success is True
+        assert result.commit is True
+        assert result.edit_id == "edit-123"
+        assert result.updated_languages == ["en-US", "es-ES"]
+        assert mock_edits.listings.return_value.update.call_count == 2
+        first_update = mock_edits.listings.return_value.update.call_args_list[0].kwargs
+        assert first_update["language"] == "en-US"
+        assert first_update["body"]["title"] == "New Title"
+        assert first_update["body"]["fullDescription"] == "Old full"
+        assert first_update["body"]["shortDescription"] == "Old short"
+        assert first_update["body"]["video"] == "https://youtu.be/old"
+        second_update = mock_edits.listings.return_value.update.call_args_list[1].kwargs
+        assert second_update["language"] == "es-ES"
+        assert second_update["body"]["title"] == "Titulo viejo"
+        assert second_update["body"]["shortDescription"] == "Nueva corta"
+        mock_edits.commit.assert_called_once_with(packageName="com.example.app", editId="edit-123")
+
 
 class TestTesters:
     """Test testers management methods."""
@@ -881,9 +967,17 @@ class TestValidation:
         client: PlayStoreClient,
     ) -> None:
         """Test validating title that's too long."""
-        errors = client.validate_listing_text(title="A" * 51)
+        errors = client.validate_listing_text(title="A" * 31)
         assert len(errors) > 0
         assert any("title" in e.field.lower() for e in errors)
+
+    def test_validate_listing_text_title_at_limit(
+        self,
+        client: PlayStoreClient,
+    ) -> None:
+        """Test validating title at the 30 character limit."""
+        errors = client.validate_listing_text(title="A" * 30)
+        assert len(errors) == 0
 
 
 class TestBatchOperations:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,6 +34,123 @@ class TestPlayStoreClientInit:
             client._get_service()
 
 
+class TestStoreListingExperiments:
+    """Test Play Console store listing experiments capture parsing."""
+
+    DETAIL_KEY = (
+        "POST playconsoleapps-pa.clients6.google.com/v1/developers/apps/"
+        "storelistingexperiments/overview:startupData"
+    )
+    STARTUP_DATA_TYPE = PlayStoreClient._EXPERIMENTS_STARTUP_DATA_TYPE
+    LIVE_NONEMPTY_BODY_B64 = (
+        "CpgBCjEKCgj31Jf57cXMoFcSCgiF3e2R/vyUg0UaFQoTNTYxMjQ0ODQ1MzE4ODcwMzczNSIAEhhUUlBHLXBob25lLUExQTctdnMtMzBvZmYYASACKiUKGgoKCPfUl/ntxcygVxIKCIXd7ZH+/JSDRRoAGAEiBWVuLVVTOgsIoaSp0QYQ0KHsV0gBUQAAAAAAAOA/YAJoAXADeAUgASgB"
+    )
+
+    @patch("play_store_mcp.client.time.sleep")
+    def test_get_store_listing_experiments_decodes_nonempty_nested_body(
+        self,
+        _mock_sleep: MagicMock,
+        client: PlayStoreClient,
+    ) -> None:
+        """Regression fixture from the 2026-07-02 live JuJuBit Console response."""
+        listing = json.dumps({"entries": [{"key": self.DETAIL_KEY, "status": 200}]})
+        envelope = json.dumps(
+            {
+                "body": {
+                    "1": {
+                        "1": self.STARTUP_DATA_TYPE,
+                        "2": self.LIVE_NONEMPTY_BODY_B64,
+                    }
+                }
+            }
+        )
+
+        with patch.object(
+            client,
+            "_run_opencli_cli",
+            side_effect=["", "ok", listing, envelope],
+        ):
+            result = client.get_store_listing_experiments(
+                package_name="com.vast.jujubit",
+                developer_id="6287361731679611511",
+                app_id="4973755093875388037",
+            )
+
+        assert len(result.experiments) == 1
+        experiment = result.experiments[0]
+        assert experiment.experiment_id == "5612448453188703735"
+        assert experiment.name == "TRPG-phone-A1A7-vs-30off"
+        assert experiment.locale == "en-US"
+        assert experiment.status == 1
+        assert experiment.dimension_type == 2
+        assert experiment.start_timestamp == "2026-06-11T06:13:53+00:00"
+        assert experiment.traffic_split == 0.5
+
+    @patch("play_store_mcp.client.time.sleep")
+    def test_get_store_listing_experiments_polls_until_target_response(
+        self,
+        mock_sleep: MagicMock,
+        client: PlayStoreClient,
+    ) -> None:
+        """The RPC may arrive after the first network snapshot."""
+        empty_listing = json.dumps({"entries": []})
+        listing = json.dumps({"entries": [{"key": self.DETAIL_KEY, "status": 200}]})
+        envelope = json.dumps(
+            {
+                "body": {
+                    "1": {
+                        "1": self.STARTUP_DATA_TYPE,
+                        "2": self.LIVE_NONEMPTY_BODY_B64,
+                    }
+                }
+            }
+        )
+
+        with patch.object(
+            client,
+            "_run_opencli_cli",
+            side_effect=["", "ok", empty_listing, listing, envelope],
+        ):
+            result = client.get_store_listing_experiments(
+                package_name="com.vast.jujubit",
+                developer_id="6287361731679611511",
+                app_id="4973755093875388037",
+            )
+
+        assert len(result.experiments) == 1
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("play_store_mcp.client.time.sleep")
+    def test_get_store_listing_experiments_keeps_legacy_empty_payload_path(
+        self,
+        _mock_sleep: MagicMock,
+        client: PlayStoreClient,
+    ) -> None:
+        """Legacy empty-state captures used body['2']; valid zero experiments stay empty."""
+        listing = json.dumps({"entries": [{"key": self.DETAIL_KEY, "status": 200}]})
+        envelope = json.dumps({"body": {"2": "IAEoAQ=="}})
+
+        with patch.object(
+            client,
+            "_run_opencli_cli",
+            side_effect=["", "ok", listing, envelope],
+        ):
+            result = client.get_store_listing_experiments(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+            )
+
+        assert result.experiments == []
+
+    def test_missing_experiments_payload_raises_parse_error(self) -> None:
+        """Missing payload is distinct from confirmed zero experiments."""
+        with pytest.raises(PlayStoreClientError, match="did not contain"):
+            PlayStoreClient._extract_store_listing_experiments_payload(
+                {"body": {"1": {"1": self.STARTUP_DATA_TYPE}}}
+            )
+
+
 class TestGetReleases:
     """Test get_releases method."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import pytest
 
@@ -914,3 +916,202 @@ class TestBatchOperations:
         assert result.successful_count == 2
         assert result.failed_count == 0
         assert len(result.results) == 2
+
+
+def _mk_subprocess_result(stdout: str, returncode: int = 0, stderr: str = "") -> Any:
+    """Create a mock subprocess.run result."""
+    from types import SimpleNamespace
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+class TestSearchTerms:
+    """Tests for get_search_terms (browser-based via OpenCLI)."""
+
+    def test_get_search_terms_parses_response(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        sample = {
+            "1": {
+                "1": 2,
+                "2": {"2": {"1": "100"}, "3": {"1": "10"}, "4": {"1": 0.1}},
+                "3": [
+                    {"1": {"1": "alpha", "2": "alpha"}, "2": {"1": "60"}, "3": {"1": "6"}, "4": {"1": 0.1}},
+                    {"1": {"1": "beta", "2": "beta term"}, "2": {"1": "40"}, "3": {"1": "4"}, "4": {"1": 0.1}},
+                ],
+            }
+        }
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result(json.dumps(sample)),
+        ) as mock_run:
+            result = client.get_search_terms(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+                start_date="2026-04-01",
+                end_date="2026-04-28",
+            )
+
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args[0][0]
+        assert cmd[1:3] == ["browser", "eval"]
+        assert "getAcquisitionDetailsTableData" in cmd[3]
+        assert "'1':2" in cmd[3]  # STORE_QUERY dimension code
+
+        assert result.package_name == "com.example.app"
+        assert result.start_date == "2026-04-01"
+        assert result.end_date == "2026-04-28"
+        assert len(result.terms) == 2
+        # Sorted by installs descending; here both equal so order preserved
+        assert result.terms[0].term == "alpha"
+        assert result.terms[0].installs == 6
+        assert result.terms[0].store_listing_visitors == 60
+        assert result.terms[1].term == "beta term"
+
+    def test_get_search_terms_empty(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result(json.dumps({"1": {"1": 2, "2": {}}})),
+        ):
+            result = client.get_search_terms(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+                start_date="2026-04-01",
+                end_date="2026-04-28",
+            )
+        assert result.terms == []
+
+    def test_get_search_terms_invalid_json_raises(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result("not json"),
+        ):
+            with pytest.raises(PlayStoreClientError, match="Invalid JSON"):
+                client.get_search_terms(
+                    package_name="com.example.app",
+                    developer_id="123",
+                    app_id="456",
+                    start_date="2026-04-01",
+                    end_date="2026-04-28",
+                )
+
+    def test_get_search_terms_subprocess_failure_raises(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result("", returncode=1, stderr="opencli not running"),
+        ):
+            with pytest.raises(PlayStoreClientError, match="opencli browser eval failed"):
+                client.get_search_terms(
+                    package_name="com.example.app",
+                    developer_id="123",
+                    app_id="456",
+                    start_date="2026-04-01",
+                    end_date="2026-04-28",
+                )
+
+    def test_get_search_terms_sorted_by_installs(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        sample = {
+            "1": {
+                "1": 2,
+                "2": {},
+                "3": [
+                    {"1": {"1": "low", "2": "low"}, "2": {"1": "10"}, "3": {"1": "1"}, "4": {}},
+                    {"1": {"1": "high", "2": "high"}, "2": {"1": "100"}, "3": {"1": "20"}, "4": {}},
+                    {"1": {"1": "mid", "2": "mid"}, "2": {"1": "50"}, "3": {"1": "5"}, "4": {}},
+                ],
+            }
+        }
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result(json.dumps(sample)),
+        ):
+            result = client.get_search_terms(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+                start_date="2026-04-01",
+                end_date="2026-04-28",
+            )
+        assert [t.term for t in result.terms] == ["high", "mid", "low"]
+        assert [t.installs for t in result.terms] == [20, 5, 1]
+
+
+class TestAcquisitionFunnel:
+    """Tests for get_acquisition_funnel (browser-based via OpenCLI)."""
+
+    def test_get_acquisition_funnel_parses_response(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        sample = {
+            "1": {
+                "1": 6,
+                "2": {"2": {"1": "177"}, "3": {"1": "22"}, "4": {"1": 0.1242937853107345}},
+                "3": [],
+            }
+        }
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result(json.dumps(sample)),
+        ) as mock_run:
+            result = client.get_acquisition_funnel(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+                start_date="2026-03-27",
+                end_date="2026-04-23",
+            )
+
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args[0][0]
+        assert "getAcquisitionDetailsTableData" in cmd[3]
+        assert "'1':6" in cmd[3]  # COUNTRY dimension code
+
+        assert result.package_name == "com.example.app"
+        assert len(result.stages) == 2
+        assert result.stages[0].stage == "store_listing_visitors"
+        assert result.stages[0].value == 177
+        assert result.stages[0].conversion_rate == 0.0
+        assert result.stages[1].stage == "installers"
+        assert result.stages[1].value == 22
+        assert abs(result.stages[1].conversion_rate - 0.1242937853107345) < 1e-9
+
+    def test_get_acquisition_funnel_empty_totals(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with patch(
+            "play_store_mcp.client.subprocess.run",
+            return_value=_mk_subprocess_result(json.dumps({"1": {"1": 6, "2": {}}})),
+        ):
+            result = client.get_acquisition_funnel(
+                package_name="com.example.app",
+                developer_id="123",
+                app_id="456",
+                start_date="2026-03-27",
+                end_date="2026-04-23",
+            )
+        assert result.stages[0].value == 0
+        assert result.stages[1].value == 0
+        assert result.stages[1].conversion_rate == 0.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 if TYPE_CHECKING:
-    from unittest.mock import MagicMock
+    pass
 
 from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
 
@@ -914,3 +916,131 @@ class TestBatchOperations:
         assert result.successful_count == 2
         assert result.failed_count == 0
         assert len(result.results) == 2
+
+
+class TestBrowserStats:
+    """Tests for browser-based stats methods (get_search_terms, get_acquisition_funnel)."""
+
+    @pytest.fixture()
+    def bare_client(self) -> PlayStoreClient:
+        return PlayStoreClient(credentials_path="/nonexistent/path.json")
+
+    def test_get_search_terms_success(self, bare_client: PlayStoreClient) -> None:
+        response = {
+            "1": [
+                {"1": "puzzle game", "2": [{"1": 42}, {"1": 120}]},
+                {"1": "brain teaser", "2": [{"1": 15}, {"1": 60}]},
+                {"1": "word game", "2": [{"1": 28}, {"1": 95}]},
+            ]
+        }
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(response), stderr="")
+            result = bare_client.get_search_terms(
+                package_name="com.vast.jujubit",
+                developer_id="6287361731679611511",
+                app_id="4973755093875388037",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+        assert result.package_name == "com.vast.jujubit"
+        assert result.start_date == "2024-01-01"
+        assert result.end_date == "2024-01-31"
+        assert len(result.terms) == 3
+        # Should be sorted by installs descending
+        assert result.terms[0].term == "puzzle game"
+        assert result.terms[0].installs == 42
+        assert result.terms[0].store_listing_visitors == 120
+        assert result.terms[1].term == "word game"
+        assert result.terms[1].installs == 28
+        assert result.terms[2].term == "brain teaser"
+        assert result.terms[2].installs == 15
+
+    def test_get_search_terms_empty(self, bare_client: PlayStoreClient) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({}), stderr="")
+            result = bare_client.get_search_terms(
+                package_name="com.vast.jujubit",
+                developer_id="123",
+                app_id="456",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+        assert result.terms == []
+
+    def test_get_search_terms_browser_error(self, bare_client: PlayStoreClient) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"error": "Not logged into Play Console"}),
+                stderr="",
+            )
+            with pytest.raises(PlayStoreClientError, match="Not logged into Play Console"):
+                bare_client.get_search_terms(
+                    package_name="com.vast.jujubit",
+                    developer_id="123",
+                    app_id="456",
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
+                )
+
+    def test_get_acquisition_funnel_success(self, bare_client: PlayStoreClient) -> None:
+        response = {
+            "1": [
+                {"1": 1, "2": 10000},
+                {"1": 2, "2": 3000},
+                {"1": 3, "2": 500},
+                {"1": 4, "2": 50},
+            ]
+        }
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(response), stderr="")
+            result = bare_client.get_acquisition_funnel(
+                package_name="com.vast.jujubit",
+                developer_id="6287361731679611511",
+                app_id="4973755093875388037",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+        assert result.package_name == "com.vast.jujubit"
+        assert len(result.stages) == 4
+        assert result.stages[0].stage == "impressions"
+        assert result.stages[0].value == 10000
+        assert result.stages[0].conversion_rate == 0.0
+        assert result.stages[1].stage == "store_listing_visitors"
+        assert result.stages[1].value == 3000
+        assert result.stages[1].conversion_rate == 0.3
+        assert result.stages[2].stage == "installers"
+        assert result.stages[2].value == 500
+        assert round(result.stages[2].conversion_rate, 4) == round(500 / 3000, 4)
+        assert result.stages[3].stage == "buyers"
+        assert result.stages[3].value == 50
+
+    def test_get_acquisition_funnel_empty(self, bare_client: PlayStoreClient) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({}), stderr="")
+            result = bare_client.get_acquisition_funnel(
+                package_name="com.vast.jujubit",
+                developer_id="123",
+                app_id="456",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+        assert result.stages == []
+
+    def test_get_acquisition_funnel_browser_error(self, bare_client: PlayStoreClient) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"error": "Not logged into Play Console"}),
+                stderr="",
+            )
+            with pytest.raises(PlayStoreClientError, match="Not logged into Play Console"):
+                bare_client.get_acquisition_funnel(
+                    package_name="com.vast.jujubit",
+                    developer_id="123",
+                    app_id="456",
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
+                )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,36 @@ class TestGetReleases:
         assert beta_track.releases[0].rollout_percentage == 50.0
 
 
+class TestGetAppDetails:
+    """Test get_app_details method."""
+
+    def test_developer_name_is_not_website(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Bug: developer_name was incorrectly set to contactWebsite value."""
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.details.return_value.get.return_value.execute.return_value = {
+            "defaultLanguage": "en-US",
+            "contactEmail": "dev@example.com",
+            "contactWebsite": "https://example.com",
+        }
+        mock_edits.listings.return_value.get.return_value.execute.return_value = {
+            "title": "My App",
+            "shortDescription": "Short",
+            "fullDescription": "Full",
+        }
+        mock_edits.delete.return_value.execute.return_value = None
+
+        details = client.get_app_details("com.example.app")
+
+        assert details.developer_name is None
+        assert details.developer_website == "https://example.com"
+        assert details.developer_email == "dev@example.com"
+
+
 class TestDeployApp:
     """Test deploy_app method."""
 
@@ -426,20 +456,24 @@ class TestInAppProducts:
         assert product.status == "active"
 
 
-class TestVitalsMetrics:
-    """Test vitals metrics methods."""
+class TestVitalsStubs:
+    """Verify vitals methods raise clear errors rather than returning fake data."""
 
-    def test_get_vitals_metrics(
+    def test_get_vitals_overview_raises_not_implemented(
         self,
         client: PlayStoreClient,
+        _mock_service: MagicMock,
     ) -> None:
-        """Test getting vitals metrics."""
-        metrics = client.get_vitals_metrics("com.example.app", "crashRate")
+        with pytest.raises(PlayStoreClientError, match="Play Developer Reporting API"):
+            client.get_vitals_overview("com.example.app")
 
-        assert len(metrics) > 0
-        assert metrics[0].metric_type == "crashRate"
-        # Note: This is a placeholder implementation
-        assert "Requires Play Developer Reporting API" in str(metrics[0].dimension_value)
+    def test_get_vitals_metrics_raises_not_implemented(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        with pytest.raises(PlayStoreClientError, match="Play Developer Reporting API"):
+            client.get_vitals_metrics("com.example.app", "crashRate")
 
 
 class TestStoreListings:
@@ -567,6 +601,59 @@ class TestTesters:
         assert result.success is True
 
 
+class TestUpdateTesters:
+    """Test update_testers method."""
+
+    def test_individual_emails_go_to_testers_field(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        """Bug: individual tester emails must go into 'testers', not 'googleGroups'."""
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.testers.return_value.update.return_value.execute.return_value = {}
+        mock_edits.get.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.commit.return_value.execute.return_value = {}
+
+        result = client.update_testers(
+            package_name="com.example.app",
+            track="alpha",
+            tester_emails=["alice@example.com", "bob@example.com"],
+            google_group_emails=[],
+        )
+
+        assert result.success is True
+        call_kwargs = mock_edits.testers.return_value.update.call_args
+        body = call_kwargs.kwargs["body"]
+        assert body["testers"] == ["alice@example.com", "bob@example.com"]
+        assert body["googleGroups"] == []
+
+    def test_google_groups_go_to_googleGroups_field(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.testers.return_value.update.return_value.execute.return_value = {}
+        mock_edits.get.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.commit.return_value.execute.return_value = {}
+
+        result = client.update_testers(
+            package_name="com.example.app",
+            track="alpha",
+            tester_emails=[],
+            google_group_emails=["testers@example.com"],
+        )
+
+        assert result.success is True
+        call_kwargs = mock_edits.testers.return_value.update.call_args
+        body = call_kwargs.kwargs["body"]
+        assert body["testers"] == []
+        assert body["googleGroups"] == ["testers@example.com"]
+
+
 class TestOrders:
     """Test orders methods."""
 
@@ -613,6 +700,121 @@ class TestExpansionFiles:
         assert expansion.version_code == 100
         assert expansion.expansion_file_type == "main"
         assert expansion.file_size == 104857600
+
+
+class TestUploadDeobfuscationFile:
+    """Test upload_deobfuscation_file method."""
+
+    def test_upload_success(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        mapping_file = tmp_path / "mapping.txt"
+        mapping_file.write_text("obfuscated -> Original")
+
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.deobfuscationfiles.return_value.upload.return_value.execute.return_value = {
+            "deobfuscationFile": {"symbolType": "proguard"}
+        }
+        mock_edits.commit.return_value.execute.return_value = {}
+
+        result = client.upload_deobfuscation_file(
+            package_name="com.example.app",
+            version_code=100,
+            file_path=str(mapping_file),
+            deobfuscation_file_type="proguard",
+        )
+
+        assert result.success is True
+        assert result.version_code == 100
+        assert result.deobfuscation_file_type == "proguard"
+
+    def test_upload_file_not_found(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        result = client.upload_deobfuscation_file(
+            package_name="com.example.app",
+            version_code=100,
+            file_path="/nonexistent/mapping.txt",
+        )
+        assert result.success is False
+        assert "not found" in result.message.lower()
+
+
+class TestListBundles:
+    """Test list_bundles method."""
+
+    def test_list_bundles_success(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.bundles.return_value.list.return_value.execute.return_value = {
+            "bundles": [
+                {"versionCode": 100, "sha1": "abc123", "sha256": "def456"},
+                {"versionCode": 101, "sha1": "ghi789", "sha256": "jkl012"},
+            ]
+        }
+        mock_edits.delete.return_value.execute.return_value = None
+
+        bundles = client.list_bundles("com.example.app")
+
+        assert len(bundles) == 2
+        assert bundles[0].version_code == 100
+        assert bundles[0].sha1 == "abc123"
+        assert bundles[1].version_code == 101
+
+    def test_list_bundles_empty(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.bundles.return_value.list.return_value.execute.return_value = {}
+        mock_edits.delete.return_value.execute.return_value = None
+
+        bundles = client.list_bundles("com.example.app")
+        assert bundles == []
+
+
+class TestListGeneratedApks:
+    """Test list_generated_apks method."""
+
+    def test_list_generated_apks_success(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.return_value = {"id": "edit-123"}
+        mock_edits.generatedapks.return_value.list.return_value.execute.return_value = {
+            "generatedApks": [
+                {
+                    "downloadId": "download-abc",
+                    "variantId": 1,
+                    "targetSdkVersion": 33,
+                    "minSdkVersion": 21,
+                    "generatedSplitApks": [],
+                    "generatedUniversalApk": {},
+                }
+            ]
+        }
+        mock_edits.delete.return_value.execute.return_value = None
+
+        apks = client.list_generated_apks("com.example.app", bundle_version_code=100)
+
+        assert len(apks) == 1
+        assert apks[0].bundle_version_code == 100
+        assert apks[0].download_id == "download-abc"
+        assert apks[0].target_sdk_version == 33
 
 
 class TestValidation:

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -973,7 +973,7 @@ class TestValidationExtended:
     def test_validate_all_listing_text_too_long(self, client: PlayStoreClient) -> None:
         """Test validating all listing text fields too long."""
         errors = client.validate_listing_text(
-            title="A" * 51,
+            title="A" * 31,
             short_description="B" * 81,
             full_description="C" * 4001,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -280,7 +280,7 @@ class TestValidation:
         print("✓ Valid listing text passed validation")
 
         # Invalid text (too long)
-        errors = real_client.validate_listing_text(title="A" * 51)
+        errors = real_client.validate_listing_text(title="A" * 31)
         assert len(errors) > 0
         print(f"✓ Invalid listing text caught {len(errors)} errors")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ class TestServerTools:
             "get_vitals_metrics",
             "list_in_app_products",
             "get_in_app_product",
+            "consume_product_purchase",
             "get_listing",
             "update_listing",
             "batch_update_listings",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,6 +49,7 @@ class TestServerTools:
             "get_in_app_product",
             "get_listing",
             "update_listing",
+            "batch_update_listings",
             "list_all_listings",
             "get_testers",
             "update_testers",

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -15,6 +15,7 @@ from play_store_mcp.models import (
     ExpansionFile,
     InAppProduct,
     Listing,
+    ListingBatchUpdateResult,
     ListingUpdateResult,
     Order,
     Release,
@@ -31,6 +32,7 @@ from play_store_mcp.models import (
 )
 from play_store_mcp.server import (
     batch_deploy,
+    batch_update_listings,
     deploy_app,
     deploy_app_multilang,
     get_app_details,
@@ -475,6 +477,28 @@ class TestListingsTools:
         result = update_listing("com.example.app", "en-US", title="New Title")
 
         assert result["success"] is True
+
+    def test_batch_update_listings(self, mock_client: MagicMock) -> None:
+        """Test batch_update_listings tool."""
+        mock_client.batch_update_listings.return_value = ListingBatchUpdateResult(
+            success=True,
+            package_name="com.example.app",
+            commit=False,
+            validated_languages=["en-US", "es-ES"],
+            message="Dry-run passed",
+        )
+
+        result = batch_update_listings(
+            "com.example.app",
+            [
+                {"language": "en-US", "title": "New Title"},
+                {"language": "es-ES", "short_description": "Nueva corta"},
+            ],
+        )
+
+        assert result["success"] is True
+        assert result["commit"] is False
+        assert result["validated_languages"] == ["en-US", "es-ES"]
 
     def test_list_all_listings(self, mock_client: MagicMock) -> None:
         """Test list_all_listings tool."""


### PR DESCRIPTION
## Summary
- `get_crash_rate()` requested `["crashRate", "distinctUsers", "crashCount"]` from `crashRateMetricSet` — `crashCount` isn't a valid metric on this set, and the Play Developer Reporting API rejects the bare `[crashRate, distinctUsers]` shape without the weighted variants
- Every call failed with `The requested metrics, dimensions and aggregation_period do not match any possible combination`
- Fixed to mirror `get_anr_rate`'s already-working pattern: `[crashRate, crashRate7dUserWeighted, crashRate28dUserWeighted, distinctUsers]`

## Test plan
- [x] `uv run pytest tests/` — 171 passed, 19 skipped
- [x] Verified against the real Play Developer Reporting API for `com.vast.jujubit` (previously errored, need to re-verify against this branch once merged/installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for batch updating store listings across multiple languages, plus a new one-time product consumption action.
  * Expanded available Play Store tools for images, app details, country availability, users/permissions, refunds, purchases, subscriptions, vitals, stats, experiments, in-app products, and pricing utilities.

* **Documentation**
  * Updated tool reference guides and examples to cover the new workflows.
  * Tightened the maximum store listing title length to 30 characters in documentation and validation guidance.

* **Chores**
  * Updated the package version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->