### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
 
+## [0.5.0] - 2026-07-06
+
+Adds opt-in **code-mode**, migrates the server onto the standalone **`fastmcp`**
+package, hardens shared-client concurrency, and removes the non-functional Vitals
+tools.
+
+> **Breaking — Vitals tools removed.** `get_vitals_overview` and
+> `get_vitals_metrics` no longer exist (see Removed); they returned placeholder
+> data and never called an API.
+
 ### Added
 - **Experimental code-mode (opt-in):** set `CODE_MODE=1` to expose tools through
   FastMCP's code-mode transform (`search`/`get_schema`/`execute` meta-tools with a
@@ -51,12 +61,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across pages via `tokenPagination`, rather than returning a single page.
 - `delete_subscription_offer` now returns the parent `product_id` instead of
   mislabeling the deleted `offer_id` as `product_id`.
+- The shared (env / `/credentials`) client now serializes its HTTP transport with
+  a per-client lock, so concurrent tool calls under network transports no longer
+  race on the non-thread-safe `httplib2` connection (which could interleave
+  requests or deliver a response to the wrong caller). Per-request header-auth
+  clients each get their own client and stay fully concurrent.
 
 ### Security
 - APK/AAB downloads (`download_generated_apk`, `download_system_apk_variant`)
   now write to a temporary file and atomically rename on success, so a failed
   or unauthorized download can no longer truncate an existing file or leave a
   partial one at the destination.
+- Documented that the server-side credential fallback
+  (`GOOGLE_PLAY_STORE_CREDENTIALS` / `/credentials`) is a process-global client
+  shared by every request that omits a credential header; multi-tenant
+  deployments should leave it unset so a missing header fails closed rather than
+  running under a shared identity.
+- Recommend pairing code-mode with `--read-only` / `PLAY_STORE_MCP_READ_ONLY=1`
+  unless writes are needed: one `execute` can invoke up to 50 tool calls
+  (including mutations) behind a single approval. Read-only enforcement still
+  applies inside the sandbox.
 
 ## [0.4.0] - 2026-07-02
 
@@ -141,6 +165,7 @@ Security hardening, dependency upgrades, and CI improvements.
 
 See the [GitHub Releases](https://github.com/lusky3/play-store-mcp/releases) page.
 
-[Unreleased]: https://github.com/lusky3/play-store-mcp/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/lusky3/play-store-mcp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/lusky3/play-store-mcp/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/lusky3/play-store-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/lusky3/play-store-mcp/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "play-store-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for Google Play Developer API - deploy apps, manage releases, reviews, and more"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "play-store-mcp"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Bumps the version **0.4.0 → 0.5.0** and cuts the `[Unreleased]` changelog into a dated `[0.5.0]` release. Version is single-sourced in `pyproject.toml` (read via `importlib.metadata`), so this is the only place the number lives — `__version__` now reports `0.5.0` (verified after `uv sync`).

## Why 0.5.0 (minor)

Pre-1.0 SemVer: a minor bump carries new features **and** breaking changes. This release has all three shapes:
- **Added** — opt-in code-mode (#89).
- **Changed** — migrated the framework to the standalone `fastmcp` package (#88, behavior-preserving).
- **Removed (breaking)** — the non-functional `get_vitals_overview` / `get_vitals_metrics` tools.
- **Fixed / Security** — order-shape/pagination/offer-id fixes, the shared-client thread-safety lock (#90), atomic downloads, and operator guidance.

## Changelog changes

- `## [Unreleased]` → `## [0.5.0] - 2026-07-06` with a one-line summary and a **breaking-change callout** for the Vitals removal; a fresh `[Unreleased]` retains only the forward-looking **Planned** (tool-surface reduction) note.
- Added two entries that landed in #90 without a changelog line: the **shared-client thread-safety lock** (under Fixed) and the **credential-fallback / code-mode read-only** operator guidance (under Security).
- Updated the compare-link footer (`v0.5.0...HEAD`, `v0.4.0...v0.5.0`).

## Verification

- `uv sync` + `python -c "import play_store_mcp; print(play_store_mcp.__version__)"` → **0.5.0**.
- **719 passed, 17 skipped**; `ruff` / `mypy` clean. No hardcoded version strings and no version-asserting tests (checked), so nothing else needed updating.

## After merge

Cutting the actual release is your step — tag `v0.5.0` and push (`git tag v0.5.0 && git push origin v0.5.0`) to trigger the release/publish workflow. Happy to draft release notes from the `[0.5.0]` section if you want them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published a new 0.5.0 release entry and updated release comparison links.

* **Bug Fixes**
  * Added guidance to prevent request mix-ups when sharing a client across concurrent operations.
  * Clarified safer download handling for APK/AAB files.

* **Security**
  * Expanded security notes with recommendations for credential handling and read-only enforcement.

* **Breaking Changes**
  * Removed two non-functional Vitals tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->