### PR TITLE
fix: audit #2 findings — media-download thread-safety + path confinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across pages via `tokenPagination`, rather than returning a single page.
 - `delete_subscription_offer` now returns the parent `product_id` instead of
   mislabeling the deleted `offer_id` as `product_id`.
+- Media downloads (`download_generated_apk` / `download_system_apk_variant`) now
+  acquire the client's transport lock per chunk, closing a gap in the shared-client
+  thread-safety fix: a download concurrent with another call on the shared client
+  no longer races on the non-thread-safe `httplib2` transport (which could corrupt
+  the downloaded file or raise `ResponseNotReady`).
 
 ### Security
 - APK/AAB downloads (`download_generated_apk`, `download_system_apk_variant`)
   now write to a temporary file and atomically rename on success, so a failed
   or unauthorized download can no longer truncate an existing file or leave a
   partial one at the destination.
+- Optional `PLAY_STORE_MCP_DOWNLOAD_DIR` confines download destinations to an
+  allowlisted directory — recommended for network-exposed deployments so a caller
+  cannot write outside it (path traversal / arbitrary-file overwrite). Unset (the
+  default, single-user local case) allows any path, preserving existing behavior.
 
 ## [0.4.0] - 2026-07-02
 

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -5551,14 +5551,18 @@ class PlayStoreClient:
             self._logger.exception("Failed to list generated APKs", error=str(e))
             raise PlayStoreClientError(f"Failed to list generated APKs: {e.reason}") from e
 
-    @staticmethod
-    def _download_to_file(request, destination_path: str) -> None:  # type: ignore[no-untyped-def]
+    def _download_to_file(self, request: Any, destination_path: str) -> None:
         """Stream a media download request to ``destination_path`` atomically.
 
         Writes to a temporary file in the same directory and renames it onto
         ``destination_path`` only after the download completes successfully, so
         a failed or unauthorized download never truncates an existing file or
         leaves a partial one in its place.
+
+        Each ``next_chunk()`` is guarded by ``_http_lock`` (per chunk, not for
+        the whole download) so a download shares the non-thread-safe httplib2
+        transport safely with concurrent calls on the shared client, without
+        serializing an entire multi-hundred-MB download under one held lock.
         """
         dest = Path(destination_path)
         tmp_fd, tmp_name = tempfile.mkstemp(
@@ -5570,7 +5574,8 @@ class PlayStoreClient:
                 downloader = MediaIoBaseDownload(fh, request)
                 done = False
                 while not done:
-                    _status, done = downloader.next_chunk()
+                    with self._http_lock:
+                        _status, done = downloader.next_chunk()
             Path(tmp_name).replace(destination_path)
             succeeded = True
         finally:

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -159,6 +159,32 @@ def _read_only_block(operation: str) -> dict[str, Any] | None:
     return None
 
 
+def _download_path_block(destination_path: str) -> dict[str, Any] | None:
+    """Confine a download destination to PLAY_STORE_MCP_DOWNLOAD_DIR, if set.
+
+    Download tools are the only tools that write to the server's filesystem at a
+    caller-supplied path. On a network-exposed deployment, set
+    PLAY_STORE_MCP_DOWNLOAD_DIR so a caller cannot write outside it (path
+    traversal / arbitrary-file overwrite). When unset (the default, single-user
+    local case) any path is allowed, preserving existing behavior.
+    """
+    base = os.environ.get("PLAY_STORE_MCP_DOWNLOAD_DIR")
+    if not base:
+        return None
+    base_real = os.path.realpath(base)
+    dest_real = os.path.realpath(destination_path)
+    if dest_real != base_real and not dest_real.startswith(base_real + os.sep):
+        logger.warning(
+            "Blocked download outside PLAY_STORE_MCP_DOWNLOAD_DIR",
+            destination=destination_path,
+            allowed_dir=base_real,
+        )
+        return {
+            "error": (f"destination_path must be within PLAY_STORE_MCP_DOWNLOAD_DIR ({base_real})")
+        }
+    return None
+
+
 def _code_mode_enabled() -> bool:
     """Return True if CODE_MODE enables the experimental code-mode transform."""
     return os.environ.get("CODE_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
@@ -2944,6 +2970,8 @@ def download_generated_apk(
     Returns:
         Download result with success status and destination path
     """
+    if blocked := _download_path_block(destination_path):
+        return blocked
     client = get_client_from_context()
 
     result = client.download_generated_apk(
@@ -3057,6 +3085,8 @@ def download_system_apk_variant(
     Returns:
         Download result with success status and destination path
     """
+    if blocked := _download_path_block(destination_path):
+        return blocked
     client = get_client_from_context()
 
     result = client.download_system_apk_variant(
@@ -3311,7 +3341,9 @@ def delete_image(
     Args:
         package_name: App package name
         language: Language localization code (BCP-47 tag, e.g. en-US)
-        image_type: Image type the image belongs to
+        image_type: Image type - one of: phoneScreenshots, sevenInchScreenshots,
+            tenInchScreenshots, tvScreenshots, wearScreenshots, icon, featureGraphic,
+            tvBanner
         image_id: Unique identifier of the image to delete
 
     Returns:
@@ -3339,7 +3371,9 @@ def delete_all_images(package_name: str, language: str, image_type: str) -> dict
     Args:
         package_name: App package name
         language: Language localization code (BCP-47 tag, e.g. en-US)
-        image_type: Image type to clear all images for
+        image_type: Image type to clear all images for - one of: phoneScreenshots,
+            sevenInchScreenshots, tenInchScreenshots, tvScreenshots, wearScreenshots,
+            icon, featureGraphic, tvBanner
 
     Returns:
         Delete result with success status and the number of images deleted

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -148,6 +148,32 @@ class TestExecuteThreadSafety:
         assert observed["locked_during_call"] is True
         assert client._http_lock.locked() is False
 
+    def test_download_holds_lock_during_next_chunk(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Media downloads hold _http_lock per next_chunk() (transport race closed)."""
+        _mock_service.generatedapks.return_value.download.return_value = MagicMock()
+        observed: dict[str, bool] = {}
+
+        class _FakeDownloader:
+            def __init__(self, fh: Any, request: Any) -> None:
+                pass
+
+            def next_chunk(self) -> tuple[Any, bool]:
+                observed["locked_during_chunk"] = client._http_lock.locked()
+                return (MagicMock(), True)
+
+        monkeypatch.setattr(client_module, "MediaIoBaseDownload", _FakeDownloader)
+
+        client.download_generated_apk("com.example.app", 42, "split-1", str(tmp_path / "app.apk"))
+
+        assert observed["locked_during_chunk"] is True
+        assert client._http_lock.locked() is False
+
 
 # =========================================================================
 # Finding 2: _parse_rfc3339

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -551,6 +551,14 @@ class TestTesters:
         )
 
         assert result["success"] is True
+        # Pin the request mapping (the dotted-param/body-shape class of the
+        # historical Order bug): track passed through, groups in body.googleGroups.
+        mock_edits.testers.return_value.update.assert_called_once_with(
+            packageName="com.example.app",
+            editId="edit-123",
+            track="alpha",
+            body={"googleGroups": ["alpha-testers@example.com"]},
+        )
 
 
 class TestOrders:

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1304,3 +1304,66 @@ def test_code_mode_preserves_read_only_end_to_end(monkeypatch: pytest.MonkeyPatc
     text = result.content[0].text
     assert "read-only" in text.lower()
     assert "refund_order" in text
+
+
+# =========================================================================
+# Download destination-path confinement (PLAY_STORE_MCP_DOWNLOAD_DIR)
+# =========================================================================
+
+
+class TestDownloadPathConfinement:
+    """When PLAY_STORE_MCP_DOWNLOAD_DIR is set, downloads must stay within it."""
+
+    def test_allows_any_path_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from play_store_mcp import server
+
+        monkeypatch.delenv("PLAY_STORE_MCP_DOWNLOAD_DIR", raising=False)
+        assert server._download_path_block("/anywhere/app.apk") is None
+
+    def test_allows_path_within_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        from play_store_mcp import server
+
+        monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(tmp_path))
+        assert server._download_path_block(str(tmp_path / "app.apk")) is None
+
+    def test_allows_the_dir_itself(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        from play_store_mcp import server
+
+        monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(tmp_path))
+        assert server._download_path_block(str(tmp_path)) is None
+
+    def test_rejects_path_outside_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        from play_store_mcp import server
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(allowed))
+        err = server._download_path_block(str(tmp_path / "evil.apk"))
+        assert err is not None
+        assert "PLAY_STORE_MCP_DOWNLOAD_DIR" in err["error"]
+
+    def test_download_tool_blocks_outside_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from play_store_mcp import server
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(allowed))
+        result = server.download_generated_apk(
+            "com.example.app", 42, "split-1", str(tmp_path / "evil.apk")
+        )
+        assert "PLAY_STORE_MCP_DOWNLOAD_DIR" in result["error"]
+
+    def test_variant_download_tool_blocks_outside_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from play_store_mcp import server
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(allowed))
+        result = server.download_system_apk_variant(
+            "com.example.app", 42, 1, str(tmp_path / "evil.apk")
+        )
+        assert "PLAY_STORE_MCP_DOWNLOAD_DIR" in result["error"]


### PR DESCRIPTION
## Summary

Fixes the substantive, non-breaking findings from the second full audit. **726 passed, 100% branch coverage; ruff/format/mypy/bandit clean; pip-audit clean.**

### Fixed
- **HIGH — media downloads bypassed the shared-client thread-safety lock** (a gap in the earlier H1 fix). `_download_to_file` was a `@staticmethod` driving `MediaIoBaseDownload.next_chunk()` directly, never taking `_http_lock` — so a download concurrent with any other call on the shared fallback client raced on the non-thread-safe `httplib2` transport (corrupt-but-complete file / `ResponseNotReady`). Now an instance method that locks **per `next_chunk()`** (not the whole loop, so a large download doesn't serialize other calls). Regression test asserts the lock is held during `next_chunk`.

### Security
- **`destination_path` confinement (opt-in).** New `PLAY_STORE_MCP_DOWNLOAD_DIR` confines both download tools to an allowlisted directory — recommended for network-exposed deployments so a caller can't write outside it (path traversal / arbitrary-file overwrite). Unset (the default single-user local case) allows any path, so **no behavior change by default.**

### Tests / Docs
- **`update_testers` request-wiring assertion** — pins `track` + `body={"googleGroups": ...}` (the exact dotted-param/body-shape class as the historical Order-shape bug; previously only truthiness was checked).
- **`delete_image` / `delete_all_images` docstrings** now list the `image_type` enum values, matching `list_images`/`upload_image` — improves code-mode `search`/`get_schema` discoverability.

## Deliberately deferred (with reasons — happy to do any on request)
- **Read-only gate on downloads** (audit suggested it): declined — a download is a *read* from the Play Store (no store mutation); gating it would break the legitimate "inspect a prod app in `--read-only` and grab the APK" flow. Path confinement targets the actual host-write risk instead.
- **`update_credentials` dedup / complexity**: security-sensitive endpoint, and the complexity isn't gated (`PLR` isn't in the ruff `select`; `C901` is already ignored for `server.py`) — DRY-only benefit not worth the refactor risk in this batch.
- **Per-chunk lock for resumable uploads** (availability-only): correctness is fine (uploads are serialized); a safe fix needs reworking the upload retry/error path — separate focused change.
- **Breaking API renames** (`get_releases`/`get_reviews`→`list_*`, `sku`→`product_id`, `subscription_id`, `set_data_safety`): change the just-released 0.5.0 tool/param surface — a conscious major-version decision; overlaps the planned tool-consolidation refactor.
- **Typed-model / consolidation refactor** (3 raw-dict tools, exact-dup Result model, batch-input normalization, typed `_shared_state`, 114/117-passthrough dedup): the large planned effort; some change the public output contract.
- **CI-workflow hardening** (docker.yml PR-build token scope, docs.yml perms, harden-runner `egress: audit`→`block`): can't be validated locally, and a wrong egress allowlist red-lines CI — a separate, CI-iterated pass.
- **Minor cleanups** (dead `credentials_updated` + `_reset_shared_state` rebind across 11 test sites, magic-value constants, `Order.product_ids`→computed, `_make_http_error` dedup, `token_uri` SSRF allowlist): low value / high churn — a batchable cleanup PR.

## Release coordination
Branched off `main` (pre-#92), so this touches `CHANGELOG.md [Unreleased]` and will trivially conflict with the pending #92 (0.5.0 cut). **Recommendation:** merge this **before** cutting 0.5.0 so the HIGH download fix ships in 0.5.0 — then re-cut/refresh #92's `[0.5.0]` section. (Alternatively, ship as 0.5.1 after.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened concurrent APK/AAB download behavior to prevent race conditions during chunked transfers.
  * Added optional `PLAY_STORE_MCP_DOWNLOAD_DIR` allowlisting to block downloads from being written outside approved directories.
  * Downloads continue to use a safer temporary-file workflow with atomic rename on success.
* **Documentation**
  * Updated release notes and tool documentation, including clarified supported `image_type` values for image deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->