### PR TITLE
docs: publish 0.5.0 to Pages + document PLAY_STORE_MCP_DOWNLOAD_DIR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      # The Changelog page includes the root CHANGELOG.md via a snippet, so a
+      # release cut that only touches CHANGELOG.md must still rebuild the site.
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -323,7 +323,9 @@ Add to `.kiro/settings/mcp.json`:
 | `GOOGLE_PLAY_STORE_CREDENTIALS` | Inline JSON credentials string | Alternative to file path |
 | `PLAY_STORE_MCP_LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR) | No (default: INFO) |
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No |
+| `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (for deployments behind a reverse proxy) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Confine APK/AAB download destinations to this directory (path-traversal / arbitrary-write protection); recommended for network-exposed deployments | No |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `play-store-mcp[code-mode]` extra) | No (default: off) |
 
 ## 🧪 Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Confine APK/AAB download destinations to this directory (guards against path traversal / arbitrary-file overwrite); recommended for network-exposed deployments. Unset allows any path. | No | — |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No | off |
 
 ## HTTP Transport


### PR DESCRIPTION
## Summary

Brings the docs and the published GitHub Pages site in sync with the 0.5.0 release. Docs/CI only — no code changes.

### The Pages staleness bug (main fix)
The Changelog page single-sources root `CHANGELOG.md` via a `--8<--` snippet, but `docs.yml` only rebuilds on `paths: docs/** | mkdocs.yml`. The 0.5.0 cut (#92) and the audit-2 fixes (#93) changed **root** `CHANGELOG.md` — nothing under `docs/` — so **Pages never republished**. The live site (`/changelog/`) still tops out at `Unreleased → 0.4.0`, with no 0.5.0 entry.

**Fix:** add `CHANGELOG.md` to the workflow's trigger `paths` so release cuts republish. Merging this PR (it touches `docs/`) also triggers an immediate rebuild, bringing 0.5.0 live.

### Env-var doc drift
- **`PLAY_STORE_MCP_DOWNLOAD_DIR`** (shipped in #93, download-path confinement) was absent from both `docs/configuration.md` and the README env tables — added to both.
- **`PLAY_STORE_MCP_ADMIN_TOKEN`** was documented in `configuration.md` but missing from the README table — added for parity.

## What was checked and found already-correct (not changed)
- README + `configuration.md` already document `CODE_MODE` and the `play-store-mcp[code-mode]` install extra (landed in #89, which touched `docs/`, so it's already live).
- The Vitals tools are already absent from the reference docs.
- `MCP_HOST` default of `0.0.0.0` in the Docker transport table is **correct** — the Dockerfile sets `ENV MCP_HOST=0.0.0.0`, and that table is explicitly scoped "When running in Docker."
- No stale version strings in docs prose (version isn't hardcoded).

## Verification
- `mkdocs build --strict` passes.
- The built `site/changelog/index.html` now contains the `0.5.0` entry (8 hits); the built config page contains `PLAY_STORE_MCP_DOWNLOAD_DIR`.
- Workflow YAML validated.

Diff: 3 files, +6 lines.