### PR TITLE
fix(security): always confine downloads to a base dir (clears SonarCloud S2083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loss of functionality.
 
 ### Changed
-- **Breaking (network transports only):** `PLAY_STORE_MCP_DOWNLOAD_DIR` is now
-  **required** when serving a network transport (`--transport sse` /
-  `streamable-http`); the server refuses to start without it. Over a network
-  transport a caller can drive the download tools to write to a server path, so
-  downloads must be confined to an allowlisted directory. `stdio` (single-user
-  local) is unaffected — the variable stays optional there and, when unset, any
-  destination path is still allowed.
+- **Breaking:** APK/AAB downloads are now **always confined to a directory** —
+  there is no "write anywhere" mode. The base directory is
+  `PLAY_STORE_MCP_DOWNLOAD_DIR` when set, otherwise the server's current working
+  directory; a `destination_path` that resolves outside it is rejected. Set
+  `PLAY_STORE_MCP_DOWNLOAD_DIR` to download somewhere other than the working
+  directory. Network transports (`--transport sse` / `streamable-http`)
+  additionally **require** `PLAY_STORE_MCP_DOWNLOAD_DIR` to be set explicitly and
+  refuse to start without it.
 
 ### Security
-- Download-destination confinement moved into `PlayStoreClient` and now applies
-  to both the temporary `.part` file and the final file: the destination is
-  canonicalized and, when `PLAY_STORE_MCP_DOWNLOAD_DIR` is set, verified to stay
-  within it before anything is written (path-traversal / arbitrary-file-overwrite
-  protection). Previously the check lived only in the server tool layer.
+- Download-destination confinement lives in `PlayStoreClient` and applies to both
+  the temporary `.part` file and the final file: the destination is canonicalized
+  and verified to stay within the (always-present) base directory before anything
+  is written — closing the path-traversal / arbitrary-file-overwrite vector
+  (SonarCloud `S2083`) for both local and network use.
 
 ## [0.5.0] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Add to `.kiro/settings/mcp.json`:
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (for deployments behind a reverse proxy) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
-| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Confine APK/AAB download destinations to this directory (path-traversal / arbitrary-write protection); recommended for network-exposed deployments | No |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (path-traversal / arbitrary-write protection). Downloads are always confined; defaults to the working directory when unset | No for `stdio` (defaults to cwd); **required** for network transports |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `play-store-mcp[code-mode]` extra) | No (default: off) |
 
 ## 🧪 Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,7 +84,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
-| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Confine APK/AAB download destinations to this directory (guards against path traversal / arbitrary-file overwrite); recommended for network-exposed deployments. Unset allows any path. | No | — |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (guards against path traversal / arbitrary-file overwrite). Downloads are **always** confined; a destination outside this directory is rejected. **Required for network transports** (`sse`/`streamable-http`); optional for `stdio`, where it defaults to the current working directory. | Required for network transports | cwd |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No | off |
 
 ## HTTP Transport

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -239,11 +239,11 @@ class PlayStoreClient:
             credentials_json: JSON string or dictionary with service account credentials.
                              Defaults to GOOGLE_PLAY_STORE_CREDENTIALS env var.
             application_name: Application name for API requests.
-            download_dir: Optional directory that download destinations are
-                             confined to. Defaults to the PLAY_STORE_MCP_DOWNLOAD_DIR
-                             env var. When unset, downloads may target any path
-                             (single-user local case); when set, a destination
-                             outside it is rejected.
+            download_dir: Directory that download destinations are confined to.
+                             Defaults to the PLAY_STORE_MCP_DOWNLOAD_DIR env var,
+                             and to the current working directory when neither is
+                             set. Downloads are always confined — a destination
+                             that resolves outside this directory is rejected.
         """
         self._credentials_path = credentials_path or os.environ.get(
             "GOOGLE_APPLICATION_CREDENTIALS"
@@ -5565,17 +5565,17 @@ class PlayStoreClient:
     def _confine_download_path(self, destination_path: str) -> str:
         """Validate and canonicalize a download destination.
 
-        When ``self._download_dir`` is set, the resolved destination must stay
-        within that directory; otherwise a :class:`PlayStoreClientError` is
-        raised (path traversal / arbitrary-file overwrite protection). When it
-        is unset (the single-user local default), the base is the filesystem
-        root, so any absolute path is allowed — but the destination is still
-        canonicalized here and the canonical result is what callers write to,
-        so user-controlled input never reaches the filesystem unvalidated.
+        Downloads are **always** confined to a base directory — the resolved
+        destination must stay within it, or a :class:`PlayStoreClientError` is
+        raised (path-traversal / arbitrary-file-overwrite protection). The base
+        is ``PLAY_STORE_MCP_DOWNLOAD_DIR`` when set, otherwise the server's
+        current working directory. There is no "write anywhere" mode: a caller
+        can never write outside the base in a single call; point the base
+        elsewhere via the env var if a different location is needed.
 
         Returns the realpath-canonicalized, confinement-checked destination.
         """
-        base_real = os.path.realpath(self._download_dir) if self._download_dir else os.sep
+        base_real = os.path.realpath(self._download_dir or Path.cwd())
         dest_real = os.path.realpath(destination_path)
         try:
             within = os.path.commonpath([base_real, dest_real]) == base_real
@@ -5584,12 +5584,13 @@ class PlayStoreClient:
             within = False
         if not within:
             self._logger.warning(
-                "Blocked download outside PLAY_STORE_MCP_DOWNLOAD_DIR",
+                "Blocked download outside the allowed directory",
                 destination=destination_path,
                 allowed_dir=base_real,
             )
             raise PlayStoreClientError(
-                f"destination_path must be within PLAY_STORE_MCP_DOWNLOAD_DIR ({base_real})"
+                f"destination_path must be within the download directory ({base_real}); "
+                "set PLAY_STORE_MCP_DOWNLOAD_DIR to change it"
             )
         return dest_real
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -169,6 +169,7 @@ class TestExecuteThreadSafety:
 
         monkeypatch.setattr(client_module, "MediaIoBaseDownload", _FakeDownloader)
 
+        client._download_dir = str(tmp_path)
         client.download_generated_apk("com.example.app", 42, "split-1", str(tmp_path / "app.apk"))
 
         assert observed["locked_during_chunk"] is True
@@ -727,25 +728,31 @@ class TestOrderParsing:
 
 
 class TestDownloadOsError:
-    """Writing to an undwritable path raises OSError, now wrapped."""
-
-    _BAD_PATH = "/nonexistent_dir_xyzzy/out.apk"
+    """Writing to an unwritable path (inside the allowed dir) raises OSError, now wrapped."""
 
     def test_download_generated_apk_wraps_oserror(
         self,
         client: PlayStoreClient,
         _mock_service: MagicMock,
+        tmp_path: Any,
     ) -> None:
+        # Confined to tmp_path, but the destination's parent subdir does not
+        # exist, so the write (mkstemp) raises OSError rather than confinement.
+        client._download_dir = str(tmp_path)
+        bad = str(tmp_path / "missing_subdir" / "out.apk")
         with pytest.raises(PlayStoreClientError, match="Failed to write generated APK"):
-            client.download_generated_apk("com.example.app", 100, "download-1", self._BAD_PATH)
+            client.download_generated_apk("com.example.app", 100, "download-1", bad)
 
     def test_download_system_apk_variant_wraps_oserror(
         self,
         client: PlayStoreClient,
         _mock_service: MagicMock,
+        tmp_path: Any,
     ) -> None:
+        client._download_dir = str(tmp_path)
+        bad = str(tmp_path / "missing_subdir" / "out.apk")
         with pytest.raises(PlayStoreClientError, match="Failed to write system APK variant"):
-            client.download_system_apk_variant("com.example.app", 100, 1, self._BAD_PATH)
+            client.download_system_apk_variant("com.example.app", 100, 1, bad)
 
 
 # =========================================================================

--- a/tests/test_generated_apks.py
+++ b/tests/test_generated_apks.py
@@ -175,6 +175,7 @@ def test_download_generated_apk_success(monkeypatch, tmp_path):
     downloader_cls = MagicMock(return_value=downloader_instance)
     monkeypatch.setattr(client_module, "MediaIoBaseDownload", downloader_cls)
 
+    client._download_dir = str(tmp_path)
     destination = tmp_path / "app.apk"
     result = client.download_generated_apk("com.example.app", 42, "split-1", str(destination))
 
@@ -220,6 +221,7 @@ def test_download_generated_apk_failure_preserves_destination(monkeypatch, tmp_p
         client_module, "MediaIoBaseDownload", MagicMock(return_value=downloader_instance)
     )
 
+    client._download_dir = str(tmp_path)
     destination = tmp_path / "existing.apk"
     destination.write_bytes(b"original-contents")
 

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1330,15 +1330,19 @@ def test_code_mode_preserves_read_only_end_to_end(monkeypatch: pytest.MonkeyPatc
 
 
 class TestDownloadPathConfinement:
-    """The client confines download destinations to ``download_dir`` when set."""
+    """The client always confines download destinations to a base directory."""
 
-    def test_allows_any_path_when_unset(self) -> None:
-        # No confinement dir: base is the filesystem root, so any absolute path
-        # is allowed but still canonicalized (single-user local default).
+    def test_unset_confines_to_cwd(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        # No download_dir set: the base defaults to the current working directory.
+        monkeypatch.chdir(tmp_path)
         client = PlayStoreClient(download_dir=None)
-        assert client._confine_download_path("/anywhere/app.apk") == os.path.realpath(
-            "/anywhere/app.apk"
+        # A path under cwd is allowed and canonicalized...
+        assert client._confine_download_path("app.apk") == os.path.realpath(
+            str(tmp_path / "app.apk")
         )
+        # ...but a path outside cwd is rejected (no "write anywhere" mode).
+        with pytest.raises(PlayStoreClientError, match="download directory"):
+            client._confine_download_path("/etc/passwd")
 
     def test_allows_path_within_dir(self, tmp_path: Any) -> None:
         client = PlayStoreClient(download_dir=str(tmp_path))

--- a/tests/test_system_apks.py
+++ b/tests/test_system_apks.py
@@ -184,6 +184,7 @@ def test_download_system_apk_variant_success(monkeypatch, tmp_path):
     downloader_cls = MagicMock(return_value=downloader_instance)
     monkeypatch.setattr(client_module, "MediaIoBaseDownload", downloader_cls)
 
+    client._download_dir = str(tmp_path)
     destination = tmp_path / "variant.apk"
     result = client.download_system_apk_variant("com.example.app", 42, 1, str(destination))
 


### PR DESCRIPTION
## Summary

The safest possible handling for the download tools: **downloads are always confined to a directory — no "write anywhere" mode.** This also clears the SonarCloud **BLOCKER** `pythonsecurity:S2083` that #96 did *not* clear.

## Why #96 wasn't enough
#96 confined downloads only when `PLAY_STORE_MCP_DOWNLOAD_DIR` was set; when unset, the base fell back to the filesystem root (`/`), making the `commonpath` guard a no-op. Post-merge analysis on `main` confirmed S2083 stayed **OPEN** at the `Path(tmp_name).replace(safe_path)` sink — SonarPython (correctly) doesn't treat "confine to root" as a sanitizer.

## Change
- `_confine_download_path`: base is `PLAY_STORE_MCP_DOWNLOAD_DIR` when set, **otherwise the current working directory** (a real, non-root dir). Every destination must resolve within it or `PlayStoreClientError` is raised. Applies to both the `.part` temp file and the final rename.
- No behavior toggle for "unrestricted" — to download elsewhere, point `PLAY_STORE_MCP_DOWNLOAD_DIR` at it.
- Network transports still additionally **require** `DOWNLOAD_DIR` to be set explicitly (from #96) — cwd is not assumed for network.

## Behavior change
Callers can no longer write to an arbitrary absolute path outside the base in one call. In practice a download just needs to land somewhere retrievable; the base (cwd by default, or `DOWNLOAD_DIR`) covers that, and unrestricted absolute writes were a footgun.

## Verification
- **729 passed, 17 skipped, 100% branch coverage**; ruff / ruff format / mypy clean.
- Tests updated to configure a base dir; the OSError tests use a missing subdir *inside* the base so the write (not confinement) raises.
- **SonarCloud:** this org's plan blocks branch-analysis reads, so I'll confirm S2083 is cleared on `main`'s re-analysis immediately after merge and report — not claim it blind (as I mistakenly did for #96).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Downloads are now always confined to a designated base directory, preventing path traversal and arbitrary file overwrites.
  * Destinations outside the allowed directory are rejected before any files are written.
  * Network transports require an explicitly configured download directory and will not start without one.

* **Documentation**
  * Updated configuration guidance for download directory defaults and transport-specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->