### PR TITLE
ci: bump github/codeql-action init+analyze to v4.37.3 (supersedes #106, #107)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
## Summary

Bumps `github/codeql-action/init` **and** `github/codeql-action/analyze` from v4.36.3 → **v4.37.3** together in `codeql.yml`.

## Why combined
CodeQL requires `init` and `analyze` to run the **same version**. Dependabot split the bump into two separate PRs — #107 (init) and #106 (analyze) — so each one alone created a version mismatch and failed the `Analyze (python)` job. Bumping both in one commit fixes that. The version/SHA (`e4fba868…` / v4.37.3) matches `upload-sarif`, already bumped in #105.

**Supersedes #106 and #107** — Dependabot will auto-close them once this lands.

Lockstep pin change only (2 lines); YAML validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL analysis tooling to a newer version for improved security scanning reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->