### PR TITLE
fix: warn (don't crash) when PLAY_STORE_MCP_DOWNLOAD_DIR unset on network transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PLAY_STORE_MCP_DOWNLOAD_DIR` when set, otherwise the server's current working
   directory; a `destination_path` that resolves outside it is rejected. Set
   `PLAY_STORE_MCP_DOWNLOAD_DIR` to download somewhere other than the working
-  directory. Network transports (`--transport sse` / `streamable-http`)
-  additionally **require** `PLAY_STORE_MCP_DOWNLOAD_DIR` to be set explicitly and
-  refuse to start without it.
+  directory. On network transports (`--transport sse` / `streamable-http`),
+  setting `PLAY_STORE_MCP_DOWNLOAD_DIR` is **recommended** but not required: the
+  server now logs a warning (instead of refusing to start) when it is unset and
+  falls back to the working directory. Point it at a writable directory on
+  cloud/hosted deployments, where the working directory may be read-only.
 
 ### Security
 - Download-destination confinement lives in `PlayStoreClient` and applies to both

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Add to `.kiro/settings/mcp.json`:
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (for deployments behind a reverse proxy) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
-| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (path-traversal / arbitrary-write protection). Downloads are always confined; defaults to the working directory when unset | No for `stdio` (defaults to cwd); **required** for network transports |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (path-traversal / arbitrary-write protection). Downloads are always confined; defaults to the working directory when unset | No (defaults to cwd); **recommended** for network/hosted deployments — the server warns if unset |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `play-store-mcp[code-mode]` extra) | No (default: off) |
 
 ## 🧪 Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,7 +84,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_DISABLE_DNS_REBINDING` | Disable DNS rebinding protection (for cloud/reverse-proxy deployments) | No | — |
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
-| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (guards against path traversal / arbitrary-file overwrite). Downloads are **always** confined; a destination outside this directory is rejected. **Required for network transports** (`sse`/`streamable-http`); optional for `stdio`, where it defaults to the current working directory. | Required for network transports | cwd |
+| `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (guards against path traversal / arbitrary-file overwrite). Downloads are **always** confined; a destination outside this directory is rejected. **Recommended** for network/hosted deployments (`sse`/`streamable-http`) — the server warns if it is unset and falls back to the working directory, which may be read-only on some hosts (e.g. set it to `/tmp/play-store-downloads` on Render). | No (defaults to cwd) | cwd |
 | `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No | off |
 
 ## HTTP Transport

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -3748,16 +3748,19 @@ def _run_http(transport: str, host: str, port: int) -> None:
     TrustedHostMiddleware (which is exactly Host-header validation) unless
     PLAY_STORE_MCP_DISABLE_DNS_REBINDING is set.
 
-    Network transports also require PLAY_STORE_MCP_DOWNLOAD_DIR: over a network
-    transport a caller can drive the download tools to write to a server path,
-    so downloads must be confined to an allowlisted directory. It stays optional
-    for stdio (single-user local).
+    Downloads are always confined to a base directory by the client (defaulting
+    to the working directory when PLAY_STORE_MCP_DOWNLOAD_DIR is unset), so a
+    network transport is safe to start either way. When the variable is unset we
+    only warn — a network-exposed deployment should point it at a writable
+    directory to control where APK/AAB downloads land, rather than defaulting to
+    the process working directory (which may be read-only on some hosts).
     """
     if not os.environ.get("PLAY_STORE_MCP_DOWNLOAD_DIR"):
-        raise SystemExit(
-            "PLAY_STORE_MCP_DOWNLOAD_DIR must be set when serving a network transport "
-            f"({transport}) so APK/AAB downloads are confined to an allowlisted directory. "
-            "Set it to a writable directory, or use --transport stdio for local single-user use."
+        logger.warning(
+            "PLAY_STORE_MCP_DOWNLOAD_DIR is not set; APK/AAB downloads will be confined to "
+            "the server's working directory. Set it to a writable directory to control where "
+            "downloads are written on a network-exposed deployment.",
+            transport=transport,
         )
     middleware: list[Middleware] = []
     if not _dns_rebinding_disabled():

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -859,13 +859,33 @@ def test_run_http_wildcard_bind_stays_localhost_only(
     assert "127.0.0.1" in allowed
 
 
-def test_run_http_requires_download_dir(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A network transport must refuse to start without PLAY_STORE_MCP_DOWNLOAD_DIR."""
+def test_run_http_warns_without_download_dir_but_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without PLAY_STORE_MCP_DOWNLOAD_DIR a network transport warns but still starts.
+
+    Downloads are confined by the client regardless (defaulting to the working
+    directory), so the server must not crash on boot when the var is unset.
+    """
     from play_store_mcp import server
 
     monkeypatch.delenv("PLAY_STORE_MCP_DOWNLOAD_DIR", raising=False)
-    with pytest.raises(SystemExit, match="PLAY_STORE_MCP_DOWNLOAD_DIR"):
-        server._run_http("streamable-http", "127.0.0.1", 8000)
+    monkeypatch.delenv("PLAY_STORE_MCP_DISABLE_DNS_REBINDING", raising=False)
+    captured: dict[str, Any] = {}
+
+    def fake_http_app(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "ASGI_APP"
+
+    class FakeUvicorn:
+        @staticmethod
+        def run(*_args: Any, **_kwargs: Any) -> None:
+            captured["served"] = True
+
+    monkeypatch.setattr(server.mcp, "http_app", fake_http_app)
+    monkeypatch.setattr(server, "uvicorn", FakeUvicorn)
+
+    # Must not raise SystemExit; the server proceeds to serve.
+    server._run_http("streamable-http", "127.0.0.1", 8000)
+    assert captured.get("served") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`_run_http` raised `SystemExit` when `PLAY_STORE_MCP_DOWNLOAD_DIR` was unset on a network transport (`sse`/`streamable-http`), so **cloud-hosted deployments crash on boot** (this is what breaks the Render deployment, and previously Manufact).

That hard exit was **redundant**: since the confinement work, `PlayStoreClient._confine_download_path` already confines *unconditionally* — the base defaults to the working directory (`Path.cwd()`) when the env var is unset. So downloads were already confined regardless; the `SystemExit` protected nothing and only prevented startup.

## Change
- `_run_http` now **logs a warning** instead of raising `SystemExit` when the var is unset. The server starts; downloads still confine (to the working directory by default). Operators are advised to point `PLAY_STORE_MCP_DOWNLOAD_DIR` at a writable directory on hosted deployments (e.g. `/tmp/play-store-downloads` on Render, since the working dir may be read-only).
- Test `test_run_http_requires_download_dir` → `test_run_http_warns_without_download_dir_but_starts`: asserts the server proceeds to serve (mocked `http_app`/`uvicorn`) instead of crashing.
- CHANGELOG / README / configuration docs updated: `DOWNLOAD_DIR` is now **recommended**, not required, for network transports.

## Verification
- **729 passed, 17 skipped, 100% branch coverage**; ruff / ruff format / mypy clean.

## Context
Unblocks the public Render (and Manufact) deployments once 0.5.0 ships. Note the deployed PyPI version is still 0.3.0 (see #110) — this fix is for the 0.5.0 line that carries the network `DOWNLOAD_DIR` behavior.