### PR TITLE
ci(release): bump pypa/gh-action-pypi-publish 1.14.0 → 1.14.2 (fixes v0.5.0 PyPI publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

The `v0.5.0` release workflow **failed at "Publish to PyPI"** with:
> `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`

Test + Build passed; nothing was uploaded (PyPI still shows 0.3.0), and the GitHub-release step was skipped — so re-releasing is clean.

**Root cause:** hatchling emits `Metadata-Version: 2.5` (PEP 639 `License-Expression`/`License-File`), but `pypa/gh-action-pypi-publish@v1.14.0` bundles an old Twine that doesn't recognize 2.5. The wheel itself is valid — standalone `twine` 15.0.0 `check` passes.

**Fix:** bump the action to **v1.14.2**, whose release notes state it updates the internal **Twine to v7**, which "will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI." (Also pulls in the v1.14.1/1.14.2 sigstore/pypi-attestations fixes.)

Pinned by commit SHA (`dc37677…`) per repo convention. YAML validated.

## After merge
Re-tag `v0.5.0` on the updated `main` to re-run the release with the fixed publisher.