### PR TITLE
chore(deps): cap fastmcp to <4.0 pending MCP 2026-07-28 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidate and reduce the MCP tool surface (now 117 tools) by grouping
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
+- Migrate to FastMCP 4 / the MCP 2026-07-28 spec once FastMCP 4 reaches a
+  stable release (currently in beta). Tracked deliberately rather than via
+  Dependabot: see the dependency cap below.
+
+### Dependencies
+- Capped `fastmcp` to `<4.0` (was open-ended `>=3.4.2`). FastMCP 4 targets the
+  new, backward-incompatible MCP 2026-07-28 spec (stateless protocol core,
+  no more `initialize`/`Mcp-Session-Id`) and is still in beta upstream. This
+  keeps Dependabot from silently proposing/merging a major protocol jump;
+  the migration will be a deliberate, manually-verified upgrade instead.
 
 ## [0.5.0] - 2026-08-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "fastmcp>=3.4.2",
+    "fastmcp>=3.4.2,<4.0",
     "google-api-python-client>=2.180.0",
     "google-auth>=2.40.0",
     "pydantic>=2.10.0",
@@ -51,10 +51,10 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.0",
     "mypy>=1.14.0",
-    "fastmcp[code-mode]>=3.4.2",
+    "fastmcp[code-mode]>=3.4.2,<4.0",
 ]
 code-mode = [
-    "fastmcp[code-mode]>=3.4.2",
+    "fastmcp[code-mode]>=3.4.2,<4.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1194,9 +1194,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.4.2" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = ">=3.4.2" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = ">=3.4.2" },
+    { name = "fastmcp", specifier = ">=3.4.2,<4.0" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = ">=3.4.2,<4.0" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = ">=3.4.2,<4.0" },
     { name = "google-api-python-client", specifier = ">=2.180.0" },
     { name = "google-auth", specifier = ">=2.40.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },


### PR DESCRIPTION
## Summary
Cherry-pick of #122 (already merged to main) onto stable.

- FastMCP 4 targets the new, backward-incompatible MCP 2026-07-28 spec (stateless protocol core, removes `initialize`/`Mcp-Session-Id`) and is still in beta upstream.
- Caps `fastmcp` from open-ended `>=3.4.2` to `>=3.4.2,<4.0` in all three spots (main dep + both `code-mode` extras) so Dependabot can't silently propose/merge a major protocol jump on the production branch.
- `uv.lock` resolution is unchanged (still 3.4.2) — pure ceiling, no downgrade, no behavior change.

## Test plan
- [x] `uv lock` confirms no dependency version change on main's identical commit (#122), only the constraint metadata
- [ ] CI green