### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
 - Migrate to FastMCP 4 / the MCP 2026-07-28 spec once FastMCP 4 reaches a
-  stable release (currently in beta). Tracked deliberately rather than via
-  Dependabot: see the dependency cap below.
+  stable release (currently in beta; see the `fastmcp<4.0` cap in
+  [0.5.1](#051---2026-08-19)). Tracked deliberately rather than via
+  Dependabot.
+
+## [0.5.1] - 2026-08-19
+
+### Added
+- CI now requires a version bump and a matching `CHANGELOG.md` entry on every
+  pull request into `stable`, so a dependency or config change can no longer
+  slip onto the production branch without a corresponding release.
 
 ### Dependencies
 - Capped `fastmcp` to `<4.0` (was open-ended `>=3.4.2`). FastMCP 4 targets the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "play-store-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for Google Play Developer API - deploy apps, manage releases, reviews, and more"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "play-store-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
`stable` picked up two changes without a version bump: the `fastmcp<4.0` dependency cap (#123) and the new `require-version-bump` CI check (#126) — the published `v0.5.0` package on PyPI still ships the old open-ended `fastmcp>=3.4.2`, the exact exposure the cap was meant to close. This folds both into a proper `0.5.1` release.

### Added
- CI now requires a version bump and matching `CHANGELOG.md` entry on every PR into `stable`.

### Dependencies
- Capped `fastmcp` to `<4.0` (already on `stable` since #123, now actually released).

## Test plan
- [x] Full unit suite (728 tests) passes on this branch
- [x] `Version Bump Check` dry-run confirms 0.5.1 > 0.5.0 and `## [0.5.1]` heading present
- [ ] CI green, including `Version Bump Check` passing for real this time