### PR TITLE
test: verify Version Bump Check blocks merges to stable (throwaway)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ credentials*.json
 
 # uv
 .uv/
+# ruleset verification test - safe to delete


### PR DESCRIPTION
Throwaway PR to verify the new ruleset actually blocks merging to stable without a version bump. Will close without merging once confirmed.