### PR TITLE
docs: document uvx --from git+URL prerelease failure on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unmodified. Pinned to the exact beta version (not an open range) since
   FastMCP 4 isn't GA yet; `stable` is unaffected (still capped `<4.0`).
 
+### Known limitation
+- **Nightly-only:** `uvx --from git+https://github.com/lusky3/play-store-mcp
+  play-store-mcp` fails to resolve on `main` — the `fastmcp==4.0.0b3` pin
+  above transitively requires a prerelease of `fastmcp-slim` that `uv`'s
+  default resolver policy doesn't auto-allow for a *transitive* dependency
+  during a fresh, non-lockfile resolve (`uvx --from git+URL` always
+  resolves fresh; it doesn't use this repo's `uv.lock`, so the version
+  already pinned there doesn't help). Cloning the repo and running `uv sync`
+  / `uv run`, or `pip install -e .`, both work fine (they either use the
+  lockfile or, for pip, its more permissive transitive-prerelease handling).
+  To use `uvx` with `git+URL` against `main` specifically, add
+  `--prerelease=allow`. For normal (non-beta-testing) use, prefer
+  `uvx play-store-mcp` (installs the released version from PyPI, unaffected
+  by this).
+
 ## [0.5.0] - 2026-08-14
 
 Adds opt-in **code-mode**, migrates the server onto the standalone **`fastmcp`**

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ pip install -e .
 play-store-mcp
 ```
 
+> **Note:** `uvx --from git+https://github.com/lusky3/play-store-mcp
+> play-store-mcp` (installing directly from Git via `uvx`, without cloning)
+> currently fails to resolve on the `main` branch, which nightly-tests a
+> FastMCP 4 beta pin — `uvx --from git+URL` always does a fresh dependency
+> resolution, and `uv`'s default resolver policy won't auto-allow the
+> transitive prerelease that pin requires. `git clone` + `pip install -e .`
+> (above) or `uv sync`/`uv run` both work fine, since they either use the
+> lockfile or (for pip) its more permissive prerelease handling. If you do
+> want `uvx --from git+URL` against `main`, add `--prerelease=allow`. For
+> normal use, prefer plain `uvx play-store-mcp` (from PyPI) instead.
+
 ### Configuration
 
 Set the path to your service account key:


### PR DESCRIPTION
## Summary
Reported failure: `uvx --from git+https://github.com/lusky3/play-store-mcp play-store-mcp` fails to resolve on `main` right now.

Root cause: `main` pins `fastmcp==4.0.0b3` (the nightly-only MCP 2026-07-28 beta trial — see #124), which transitively requires `fastmcp-slim[client]==4.0.0b3`. `uvx --from git+URL` always does a fresh, non-lockfile dependency resolution, and uv's default prerelease policy won't auto-allow a prerelease pinned only by a transitive dependency's own metadata (as opposed to a directly-requested one).

**I initially tried `[tool.uv] prerelease = "allow"` expecting it to fix this project-wide — it doesn't.** That setting only affects uv commands run *inside* the project (`uv sync`/`uv lock`/`uv run`, which already worked fine via the lockfile); `uvx --from git+URL` resolves using the *invoking* environment's uv config, not the target repo's `pyproject.toml`. Verified this against a real pushed branch over `git+https` (local-path / `git+file://` tests gave misleading false positives here, likely from uv's resolver cache treating identical requirement sets as equivalent regardless of source path).

**Good news: this repo's actually-documented install paths are unaffected** — verified both work correctly with `fastmcp==4.0.0b3`:
- `uvx play-store-mcp` (installs the released PyPI version — no beta pin at all)
- `git clone` + `pip install -e .` (pip's transitive-prerelease handling is more permissive than uv's)

Only the undocumented `uvx --from git+URL` idiom is affected. This PR documents the real workaround (`--prerelease=allow`, or just use the PyPI release) in the README and CHANGELOG instead of shipping a config change that doesn't actually help.

## Test plan
- [x] Reproduced the exact failure against `origin/main` via a real `git+https://` URL
- [x] Confirmed `[tool.uv] prerelease = "allow"` does NOT fix it (tested against a real pushed branch)
- [x] Confirmed `uvx play-store-mcp` (PyPI) works
- [x] Confirmed `git clone` + `pip install -e .` works (installs fastmcp 4.0.0b3 correctly)
- [x] Confirmed `uvx --prerelease=allow --from git+https://github.com/lusky3/play-store-mcp play-store-mcp` works
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for resolving installation issues when installing directly from the repository.
  * Documented supported alternatives, including installing from PyPI, using a local checkout, or allowing prerelease dependencies.
  * Added a known limitation to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->