### PR TITLE
ci: bump github/codeql-action init+analyze to v4.37.9 (supersedes #132, #133)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- Dependabot opened #132 (bumps `autobuild` to v4.37.9 alone) and #133 (bumps `analyze` to v4.37.9 alone). Merging either individually leaves `init` at v4.37.3, mismatched against the other two — this repo hit the exact same issue before with #106/#107, fixed by bumping all three together in #111.
- This PR bumps `init`, `autobuild`, and `analyze` to the same v4.37.9 release together.
- Closes #132 and #133 as superseded.

## Test plan
- [ ] CI green, specifically `Analyze (python)` (this is exactly the job that failed on #132/#133 individually)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security analysis tooling to a newer version.
  * This maintenance keeps code scanning aligned with the latest available improvements and supports ongoing security checks.
  * No user-facing functionality or workflow behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->