### PR TITLE
deps: bump fastmcp to GA (4.0.2), off the beta pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,37 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidate and reduce the MCP tool surface (now 117 tools) by grouping
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
-- Promote the FastMCP 4 / MCP 2026-07-28 upgrade (below) to `stable` once
-  FastMCP 4 reaches a stable release. `stable` remains pinned to `fastmcp<4.0`
-  until then; this is nightly-only for now.
 
 ### Dependencies
-- **Nightly-only:** bumped `fastmcp` to the `4.0.0b3` beta, which migrates to
-  MCP Python SDK v2 and the new MCP 2026-07-28 spec (stateless protocol core;
-  no more mandatory `initialize`/`Mcp-Session-Id`). FastMCP 4 negotiates the
-  best mutual protocol era per client by default, so existing clients still on
-  the older handshake keep working unchanged — verified locally: full unit
-  suite (728 tests), lint, mypy, both transports (`stdio` and
+- Bumped `fastmcp` from the `4.0.0b3`/`b5` betas to the stable GA release
+  (`>=4.0.0,<5.0`, currently resolving to `4.0.2`), which migrates to MCP
+  Python SDK v2 and the new MCP 2026-07-28 spec (stateless protocol core; no
+  more mandatory `initialize`/`Mcp-Session-Id`). FastMCP 4 negotiates the
+  best mutual protocol era per client by default, so existing clients still
+  on the older handshake keep working unchanged — verified locally: full
+  unit suite (728 tests), lint, mypy, both transports (`stdio` and
   `streamable-http`) boot and complete a legacy `initialize` →
-  `notifications/initialized` → `tools/list` round trip, and the live
-  read-only integration suite against a real Play Console app all pass
-  unmodified. Pinned to the exact beta version (not an open range) since
-  FastMCP 4 isn't GA yet; `stable` is unaffected (still capped `<4.0`).
-
-### Known limitation
-- **Nightly-only:** `uvx --from git+https://github.com/lusky3/play-store-mcp
-  play-store-mcp` fails to resolve on `main` — the `fastmcp==4.0.0b3` pin
-  above transitively requires a prerelease of `fastmcp-slim` that `uv`'s
-  default resolver policy doesn't auto-allow for a *transitive* dependency
-  during a fresh, non-lockfile resolve (`uvx --from git+URL` always
-  resolves fresh; it doesn't use this repo's `uv.lock`, so the version
-  already pinned there doesn't help). Cloning the repo and running `uv sync`
-  / `uv run`, or `pip install -e .`, both work fine (they either use the
-  lockfile or, for pip, its more permissive transitive-prerelease handling).
-  To use `uvx` with `git+URL` against `main` specifically, add
-  `--prerelease=allow`. For normal (non-beta-testing) use, prefer
-  `uvx play-store-mcp` (installs the released version from PyPI, unaffected
-  by this).
+  `notifications/initialized` → `tools/list` round trip, the live read-only
+  integration suite against a real Play Console app, and the Docker build
+  all pass unmodified. Now that FastMCP 4 is GA, the `uvx --from git+URL`
+  prerelease limitation noted in earlier releases no longer applies —
+  regular installs work without `--prerelease=allow`. `stable` will follow
+  in its own release once this has soaked.
 
 ## [0.5.0] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -77,17 +77,6 @@ pip install -e .
 play-store-mcp
 ```
 
-> **Note:** `uvx --from git+https://github.com/lusky3/play-store-mcp
-> play-store-mcp` (installing directly from Git via `uvx`, without cloning)
-> currently fails to resolve on the `main` branch, which nightly-tests a
-> FastMCP 4 beta pin — `uvx --from git+URL` always does a fresh dependency
-> resolution, and `uv`'s default resolver policy won't auto-allow the
-> transitive prerelease that pin requires. `git clone` + `pip install -e .`
-> (above) or `uv sync`/`uv run` both work fine, since they either use the
-> lockfile or (for pip) its more permissive prerelease handling. If you do
-> want `uvx --from git+URL` against `main`, add `--prerelease=allow`. For
-> normal use, prefer plain `uvx play-store-mcp` (from PyPI) instead.
-
 ### Configuration
 
 Set the path to your service account key:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "fastmcp==4.0.0b5",
+    "fastmcp>=4.0.0,<5.0",
     "google-api-python-client>=2.180.0",
     "google-auth>=2.40.0",
     "pydantic>=2.10.0",
@@ -51,10 +51,10 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.0",
     "mypy>=1.14.0",
-    "fastmcp[code-mode]==4.0.0b5",
+    "fastmcp[code-mode]>=4.0.0,<5.0",
 ]
 code-mode = [
-    "fastmcp[code-mode]==4.0.0b5",
+    "fastmcp[code-mode]>=4.0.0,<5.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -697,14 +697,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "4.0.0b5"
+version = "4.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/5c/e2d22d1f2b9f062cda7e99a3b485232078c4f183aecf865a0d3d2d323b46/fastmcp-4.0.0b5.tar.gz", hash = "sha256:39e970a556872e90eed7e34972477eeef24d1a0949be05e0ed57045d474a4608", size = 42188980, upload-time = "2026-08-28T02:58:17.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1c/981a1854f91a08872f4b8b9a627d5d751cafc1340d29b21b747f0b520b0a/fastmcp-4.0.2.tar.gz", hash = "sha256:60d5c5ead3b6a117bfada5c0f95fe5c1aba53d1577079ecbdf42eeff0cd9b931", size = 42306015, upload-time = "2026-09-02T23:28:08.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/f4/e8e36c93f36eb2014d941882da984b398d5326f78da07394e6d7e74db2cb/fastmcp-4.0.0b5-py3-none-any.whl", hash = "sha256:b6771dae5b0c1502e287b94e473c0e43b186db001e4a5786464e9085e5bdff7b", size = 8089, upload-time = "2026-08-28T02:58:13.085Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3f/b97cfb92e0d6db8232c67c258117cd0dd9def86c8b472270bd7196d5cd9d/fastmcp-4.0.2-py3-none-any.whl", hash = "sha256:9075e64a94634ad660971ed14374c87be06f2a16a921028ca87987e6aa2f3bfa", size = 8078, upload-time = "2026-09-02T23:28:03.777Z" },
 ]
 
 [package.optional-dependencies]
@@ -714,7 +714,7 @@ code-mode = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "4.0.0b5"
+version = "4.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp-types" },
@@ -725,9 +725,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/0e/93a8e2e20071ae9c5b5dc0cdd59fffabb0a78c9c25412854459605de19c1/fastmcp_slim-4.0.0b5.tar.gz", hash = "sha256:548677ab0859a0e2dc6fe78602ac6d235d3dce2355d885933cdfd4268f9f429e", size = 682434, upload-time = "2026-08-28T02:57:49.134Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/7d/c2597734e3a0859d62c9d8f6f35067d1e296537512e280db3af19204be64/fastmcp_slim-4.0.2.tar.gz", hash = "sha256:86b99bdcb872b52d964c79bc6d43ce79f40ed5538b589d102792b4a7cf3947f4", size = 684052, upload-time = "2026-09-02T23:27:39.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/a7/a34e1ce3a6ae3b22bc8a9d1ea6b6cc9c0c6f4d2693b13cd4884c2fe83896/fastmcp_slim-4.0.0b5-py3-none-any.whl", hash = "sha256:4c47372fab61cbdcedc4c8f726e29229d37b03e60044a0288111aa19d0709690", size = 856273, upload-time = "2026-08-28T02:57:47.623Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c0/c022eba3a25ebb56111de1b5f76fbfca81925def58880464263582acfcd8/fastmcp_slim-4.0.2-py3-none-any.whl", hash = "sha256:6bd5b5885628f73263fa2247ea1d26e4a514499a6e079ee3e340cd03a7fe5ed8", size = 858100, upload-time = "2026-09-02T23:27:38.459Z" },
 ]
 
 [package.optional-dependencies]
@@ -1404,9 +1404,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = "==4.0.0b5" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = "==4.0.0b5" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = "==4.0.0b5" },
+    { name = "fastmcp", specifier = ">=4.0.0,<5.0" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = ">=4.0.0,<5.0" },
+    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = ">=4.0.0,<5.0" },
     { name = "google-api-python-client", specifier = ">=2.180.0" },
     { name = "google-auth", specifier = ">=2.40.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },


### PR DESCRIPTION
## Summary
FastMCP 4 has reached stable GA (4.0.0, 4.0.1, 4.0.2 all published on PyPI — no longer beta). This bumps `main` off the exact beta pins (`4.0.0b3` → `4.0.0b5` → now GA) to an open range, `fastmcp>=4.0.0,<5.0`, matching the style of other dependency ranges in this project and of `stable`'s own (now-obsolete) `fastmcp<4.0` cap.

This is the trigger condition recorded from the original beta-trial work (#124) — the next step is promoting this to `stable` in a follow-up release once this has soaked on `main`.

## Verified against the real GA release
- [x] Full unit suite (728 tests), `ruff check`, `mypy` all pass unmodified
- [x] `stdio` transport boots; legacy `initialize` request gets a correct `2025-06-18`-era response
- [x] `streamable-http` transport boots; `/health` → 200; full legacy round trip (`initialize` → `Mcp-Session-Id` issued → `notifications/initialized` → `tools/list`) works over HTTP
- [x] Live read-only integration suite (17 tests) against the real Play Developer API (`app.lusk.underseerr`) passes — no writes made
- [x] Docker build (`uv sync --frozen`) builds and boots correctly; `/health` → 200
- [x] `uvx --from git+URL` (previously broken on the beta pin, documented as a known limitation in README/CHANGELOG) now works with no `--prerelease=allow` flag needed — verified against this real pushed branch over `git+https`. README/CHANGELOG updated to drop that caveat.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt