### PR TITLE
ci: block release publish unless version/changelog match the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,74 @@ permissions:
   contents: read
 
 jobs:
+  verify-release:
+    name: Verify Version & Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13.2"
+
+      - name: Require pyproject.toml version and CHANGELOG.md to match the pushed tag
+        run: |
+          python3 - <<'EOF'
+          import os
+          import re
+          import sys
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          if not tag.startswith("v"):
+              print(f"::error::Tag '{tag}' doesn't start with 'v' -- expected 'vX.Y.Z'.")
+              sys.exit(1)
+          tag_version = tag[1:]
+
+          with open("pyproject.toml", encoding="utf-8") as f:
+              for line in f:
+                  m = re.match(r'^version\s*=\s*"([^"]+)"', line)
+                  if m:
+                      pyproject_version = m.group(1)
+                      break
+              else:
+                  print("::error::Could not find a `version = \"...\"` line in pyproject.toml")
+                  sys.exit(1)
+
+          print(f"tag:               {tag}")
+          print(f"pyproject version: {pyproject_version}")
+
+          if pyproject_version != tag_version:
+              print(
+                  f"::error::pyproject.toml version ({pyproject_version}) does not match "
+                  f"the pushed tag ({tag}). Update pyproject.toml (and CHANGELOG.md) and "
+                  f"re-tag before releasing."
+              )
+              sys.exit(1)
+
+          with open("CHANGELOG.md", encoding="utf-8") as f:
+              changelog = f.read()
+
+          heading = f"## [{tag_version}]"
+          if heading not in changelog:
+              print(
+                  f"::error::CHANGELOG.md has no '{heading}' heading. Add a changelog entry "
+                  f"for this version before releasing."
+              )
+              sys.exit(1)
+
+          print(f"OK: pyproject.toml and CHANGELOG.md both match tag {tag}")
+          EOF
+
   test:
     name: Test Before Release
     runs-on: ubuntu-latest
+    needs: verify-release
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0


### PR DESCRIPTION
## Summary
`release.yml` (triggered on any `v*` tag push) had nothing stopping it from building and publishing to PyPI even if `pyproject.toml`'s version or `CHANGELOG.md` were never actually updated for that tag. The existing safeguard (`Version Bump Check`) only runs on PRs into `stable`, not on the tag push itself — and tags aren't restricted to a branch by the branch ruleset, so this is a separate gap.

Adds a new first job, **Verify Version & Changelog**, that the existing `test`/`build`/`publish`/`github-release` chain now depends on via `needs:`. Fails if `pyproject.toml`'s version doesn't exactly match the pushed tag (stripped of its leading `v`), or if `CHANGELOG.md` has no `## [X.Y.Z]` heading for that version — before any test/build/publish step runs.

## Test plan
- [x] Logic unit-tested locally against three cases: matching tag+version+changelog (passes), version mismatch (fails), version matches but no changelog heading (fails)
- [x] YAML validated
- [ ] Will live-test against a real (deliberately mismatched, safe) tag push after merging, since `release.yml` only triggers on tag push and won't run for this PR
- [ ] CI green (existing checks only — this PR doesn't touch source code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release validation to confirm version tags match the project version and changelog.
  * Release testing now runs only after these validation checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->