### PR TITLE
release: v0.6.1 - release.yml version/changelog verification gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,74 @@ permissions:
   contents: read
 
 jobs:
+  verify-release:
+    name: Verify Version & Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13.2"
+
+      - name: Require pyproject.toml version and CHANGELOG.md to match the pushed tag
+        run: |
+          python3 - <<'EOF'
+          import os
+          import re
+          import sys
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          if not tag.startswith("v"):
+              print(f"::error::Tag '{tag}' doesn't start with 'v' -- expected 'vX.Y.Z'.")
+              sys.exit(1)
+          tag_version = tag[1:]
+
+          with open("pyproject.toml", encoding="utf-8") as f:
+              for line in f:
+                  m = re.match(r'^version\s*=\s*"([^"]+)"', line)
+                  if m:
+                      pyproject_version = m.group(1)
+                      break
+              else:
+                  print("::error::Could not find a `version = \"...\"` line in pyproject.toml")
+                  sys.exit(1)
+
+          print(f"tag:               {tag}")
+          print(f"pyproject version: {pyproject_version}")
+
+          if pyproject_version != tag_version:
+              print(
+                  f"::error::pyproject.toml version ({pyproject_version}) does not match "
+                  f"the pushed tag ({tag}). Update pyproject.toml (and CHANGELOG.md) and "
+                  f"re-tag before releasing."
+              )
+              sys.exit(1)
+
+          with open("CHANGELOG.md", encoding="utf-8") as f:
+              changelog = f.read()
+
+          heading = f"## [{tag_version}]"
+          if heading not in changelog:
+              print(
+                  f"::error::CHANGELOG.md has no '{heading}' heading. Add a changelog entry "
+                  f"for this version before releasing."
+              )
+              sys.exit(1)
+
+          print(f"OK: pyproject.toml and CHANGELOG.md both match tag {tag}")
+          EOF
+
   test:
     name: Test Before Release
     runs-on: ubuntu-latest
+    needs: verify-release
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   related operations, to lower per-request tool-list overhead — with no planned
   loss of functionality.
 
+## [0.6.1] - 2026-09-04
+
+### Added
+- `release.yml` now has a `Verify Version & Changelog` gate that runs before
+  any test/build/publish step: it fails the whole release if `pyproject.toml`'s
+  version doesn't exactly match the pushed tag, or if `CHANGELOG.md` has no
+  matching `## [X.Y.Z]` heading. Complements the PR-time `Version Bump Check`
+  (which only runs on PRs into `stable`) by also guarding the tag-push
+  trigger itself — nothing stops a tag from being pushed independently of a
+  PR. Verified live: a deliberately mismatched test tag failed at this gate
+  and never reached the Publish to PyPI step.
+
 ## [0.6.0] - 2026-09-04
 
 Upgrades to **FastMCP 4** and the new **MCP 2026-07-28 spec**, now that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "play-store-mcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "MCP server for Google Play Developer API - deploy apps, manage releases, reviews, and more"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1185,7 +1185,7 @@ wheels = [
 
 [[package]]
 name = "play-store-mcp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Ports #138 (already merged to main) to stable: `release.yml` now has a `Verify Version & Changelog` job that the `test`/`build`/`publish`/`github-release` chain depends on via `needs:`, blocking a release if `pyproject.toml`'s version doesn't match the pushed tag or `CHANGELOG.md` has no matching heading.

This complements the existing PR-time `Version Bump Check` — that only runs on PRs into `stable`, not on the tag push itself, and nothing stops a tag from being pushed independently of a PR.

## Verified
- [x] Live on `main`: a deliberately mismatched test tag (`v0.0.0-verify-test`) failed at this new gate, and `test`/`build`/`publish`/`github-release` were all skipped — never reached the Publish to PyPI step. Tag deleted afterward, no stray release created.
- [x] YAML validated on this branch

## Test plan
- [ ] CI green, including `Version Bump Check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt