### PR TITLE
feat!: enable code-mode by default, opt out via CODE_MODE=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Breaking — code-mode is now enabled by default.** Clients that expect the
+> full 117-tool list (e.g. anything enumerating tools by name) will instead
+> see three meta-tools (`search`/`get_schema`/`execute`) unless `CODE_MODE=0`
+> is set. See Changed below.
+
+### Changed
+- **Breaking:** `CODE_MODE` now defaults to **enabled** (was opt-in/default-off).
+  Set `CODE_MODE=0` (or `false`/`no`/`off`, case-insensitive) to opt out and
+  get the classic 117-tool list back. `search`/`get_schema` work without any
+  extra install, but the `execute` meta-tool's sandbox still requires the
+  `play-store-mcp[code-mode]` extra — install it, or `execute` calls will
+  fail. Read-only enforcement still applies inside the sandbox.
+
 ### Planned
 - Consolidate and reduce the MCP tool surface (now 117 tools) by grouping
   related operations, to lower per-request tool-list overhead — with no planned

--- a/README.md
+++ b/README.md
@@ -146,17 +146,22 @@ play-store-mcp --read-only
 export PLAY_STORE_MCP_READ_ONLY=1
 ```
 
-### Code Mode (Experimental)
+### Code Mode (Experimental, enabled by default)
 
-Opt in to the experimental code-mode transform to serve the tools as three
-meta-tools (`search`/`get_schema`/`execute`) instead of the full tool list,
-cutting per-request tool-list token overhead. It is off by default. Install the
-sandbox extra and set the environment variable (`CODE_MODE` is env-only — there
-is no CLI flag):
+By default the tools are served as three meta-tools (`search`/`get_schema`/
+`execute`) instead of the full tool list, cutting per-request tool-list token
+overhead. **The `execute` tool's sandbox requires the `code-mode` extra** —
+install it, or `execute` calls will fail:
 
 ```bash
 pip install "play-store-mcp[code-mode]"
-export CODE_MODE=1
+```
+
+To opt out and use the classic tool list instead (`CODE_MODE` is env-only —
+there is no CLI flag):
+
+```bash
+export CODE_MODE=0
 ```
 
 Under code mode one `execute` call can invoke up to 50 tool calls (including mutations) behind a single approval. Read-only enforcement still applies inside the sandbox, so pair it with `--read-only` / `PLAY_STORE_MCP_READ_ONLY=1` unless you need writes.
@@ -326,7 +331,7 @@ Add to `.kiro/settings/mcp.json`:
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (for deployments behind a reverse proxy) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
 | `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (path-traversal / arbitrary-write protection). Downloads are always confined; defaults to the working directory when unset | No (defaults to cwd); **recommended** for network/hosted deployments — the server warns if unset |
-| `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `play-store-mcp[code-mode]` extra) | No (default: off) |
+| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list (`execute` otherwise requires the `play-store-mcp[code-mode]` extra) | No (default: on) |
 
 ## 🧪 Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
 | `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (guards against path traversal / arbitrary-file overwrite). Downloads are **always** confined; a destination outside this directory is rejected. **Recommended** for network/hosted deployments (`sse`/`streamable-http`) — the server warns if it is unset and falls back to the working directory, which may be read-only on some hosts (e.g. set it to `/tmp/play-store-downloads` on Render). | No (defaults to cwd) | cwd |
-| `CODE_MODE` | Enable the experimental code-mode transform (opt-in; requires the `code-mode` extra) | No | off |
+| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list (`execute` otherwise requires the `code-mode` extra) | No | on |
 
 ## HTTP Transport
 
@@ -148,11 +148,12 @@ Or the environment variable (truthy values: `1`, `true`, `yes`, `on`):
 export PLAY_STORE_MCP_READ_ONLY=1
 ```
 
-## Code Mode (Experimental)
+## Code Mode (Experimental, enabled by default)
 
-!!! warning "Experimental — off by default"
-    Code mode is opt-in and disabled by default. It wraps the tool surface in
-    FastMCP's experimental code-mode transform.
+!!! warning "Experimental — enabled by default"
+    Code mode wraps the tool surface in FastMCP's experimental code-mode
+    transform, and is **enabled by default** (breaking change from earlier
+    releases, which shipped it opt-in). Set `CODE_MODE=0` to opt out.
 
 Code mode replaces the individual tools with three meta-tools — `search`,
 `get_schema`, and `execute` — so the client discovers tools on demand and runs a
@@ -167,24 +168,26 @@ list on every request. This cuts the per-request tool-list token overhead.
     does not need writes, run code mode with `--read-only` /
     `PLAY_STORE_MCP_READ_ONLY=1` to block those operations.
 
-Enabling it requires two things:
+**Install the sandbox extra** (the `execute` meta-tool runs in the Monty
+sandbox) — `search`/`get_schema` work without it, but `execute` calls fail
+until it's installed:
 
-1. Install the sandbox extra (the `execute` meta-tool runs in the Monty sandbox):
+```bash
+pip install "play-store-mcp[code-mode]"
+# or: uvx --from "play-store-mcp[code-mode]" play-store-mcp
+```
 
-    ```bash
-    pip install "play-store-mcp[code-mode]"
-    # or: uvx --from "play-store-mcp[code-mode]" play-store-mcp
-    ```
+**To opt out** and get the classic full tool surface instead, set the
+environment variable to an opt-out value (`0`, `false`, `no`, or `off`,
+case-insensitive):
 
-2. Set the environment variable (truthy values: `1`, `true`, `yes`, `on`):
-
-    ```bash
-    export CODE_MODE=1
-    ```
+```bash
+export CODE_MODE=0
+```
 
 `CODE_MODE` is an environment variable only — there is no CLI flag — because the
 transform is fixed when the server is constructed (before command-line arguments
-are parsed). When it is unset, the classic full tool surface is served unchanged.
+are parsed).
 
 ## Logging
 

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -160,30 +160,35 @@ def _read_only_block(operation: str) -> dict[str, Any] | None:
 
 
 def _code_mode_enabled() -> bool:
-    """Return True if CODE_MODE enables the experimental code-mode transform."""
-    return os.environ.get("CODE_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
+    """Return True unless CODE_MODE explicitly opts out of the code-mode transform.
+
+    Enabled by default; set CODE_MODE=0/false/no/off (case-insensitive) to opt
+    out and fall back to the classic tool list.
+    """
+    return os.environ.get("CODE_MODE", "").strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _build_transforms() -> list[Any]:
     """Return the FastMCP transforms for this process.
 
-    When CODE_MODE is enabled, wrap the tool surface in the experimental CodeMode
-    transform (search/get_schema/execute meta-tools + sandboxed execution), which
-    cuts per-request tool-list overhead. Default: no transforms — the classic
-    117-tool surface, unchanged.
+    Default: the tool surface is wrapped in the experimental CodeMode transform
+    (search/get_schema/execute meta-tools + sandboxed execution), which cuts
+    per-request tool-list overhead. Set CODE_MODE=0 to opt out and expose the
+    classic 117-tool surface instead.
     """
     if not _code_mode_enabled():
         return []
-    # Imported lazily so the base install (without the code-mode extra) never
-    # pays for it when the flag is off.
+    # Imported lazily so an install without the code-mode extra never pays for
+    # it when opted out.
     from fastmcp.experimental.transforms.code_mode import (  # noqa: PLC0415 - lazy import: code-mode extra is optional
         CodeMode,
     )
 
-    logger.warning(
-        "CODE_MODE enabled: exposing tools via the experimental code-mode transform "
-        "(search/get_schema/execute). The 'execute' sandbox requires the code-mode "
-        "extra — install play-store-mcp[code-mode]."
+    logger.info(
+        "Exposing tools via the code-mode transform (search/get_schema/execute); "
+        "set CODE_MODE=0 to opt out and use the classic tool list instead. The "
+        "'execute' sandbox requires the code-mode extra — install "
+        "play-store-mcp[code-mode]."
     )
     return [CodeMode()]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,17 @@ import structlog
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+# CODE_MODE now defaults to enabled, but the module-level `mcp` singleton in
+# server.py is built once at import time from whatever CODE_MODE is in the
+# environment at that moment — most of this suite (and the "117 tools"
+# classic-surface assertion) exercises that singleton directly, so pin it to
+# the classic tool list here. Must run before ANY `play_store_mcp` import
+# below (even `play_store_mcp.client`), since `play_store_mcp/__init__.py`
+# eagerly imports `server`. Code-mode-specific tests build fresh transforms
+# via server._build_transforms() with their own monkeypatched CODE_MODE and
+# are unaffected by this default.
+os.environ.setdefault("CODE_MODE", "0")
+
 import pytest
 
 from play_store_mcp.client import PlayStoreClient

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -60,7 +60,12 @@ from play_store_mcp.server import (
 
 
 def test_server_uses_fastmcp_and_registers_all_tools() -> None:
-    """The server is built on the standalone fastmcp package with all 117 tools."""
+    """The server is built on the standalone fastmcp package with all 117 tools.
+
+    Depends on conftest.py pinning CODE_MODE=0 for the test process, since
+    `server.mcp` is a module-level singleton built once at import time and
+    CODE_MODE now defaults to enabled (meta-tool surface) in production.
+    """
     import asyncio
 
     import fastmcp
@@ -1264,25 +1269,36 @@ class TestMainEntryPoint:
         ("true", True),
         ("YES", True),
         ("on", True),
+        ("", True),
+        ("anything-else", True),
         ("0", False),
         ("false", False),
-        ("no", False),
-        ("", False),
+        ("NO", False),
+        ("off", False),
     ],
 )
 def test_code_mode_flag_parsing(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
-    """CODE_MODE parses like the read-only flag (case-insensitive truthy set)."""
+    """CODE_MODE defaults to enabled; only an explicit opt-out value disables it."""
     from play_store_mcp import server
 
     monkeypatch.setenv("CODE_MODE", val)
     assert server._code_mode_enabled() is expected
 
 
-def test_code_mode_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With CODE_MODE unset, no transforms are built (classic tool surface)."""
+def test_code_mode_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With CODE_MODE unset, the code-mode transform is built (meta-tool surface)."""
     from play_store_mcp import server
 
     monkeypatch.delenv("CODE_MODE", raising=False)
+    assert server._code_mode_enabled() is True
+    assert len(server._build_transforms()) == 1
+
+
+def test_code_mode_disabled_via_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CODE_MODE=0 opts out, falling back to the classic tool list (no transforms)."""
+    from play_store_mcp import server
+
+    monkeypatch.setenv("CODE_MODE", "0")
     assert server._code_mode_enabled() is False
     assert server._build_transforms() == []
 
@@ -1295,7 +1311,7 @@ def test_build_transforms_enabled_wraps_tools(monkeypatch: pytest.MonkeyPatch) -
 
     from play_store_mcp import server
 
-    monkeypatch.setenv("CODE_MODE", "1")
+    monkeypatch.delenv("CODE_MODE", raising=False)
     transforms = server._build_transforms()
     assert len(transforms) == 1
 


### PR DESCRIPTION
## Summary
**Breaking change.** Reverses the `CODE_MODE` flag: now enabled by default (was opt-in/default-off). Clients that expect the classic 117-tool list will instead see three meta-tools (`search`/`get_schema`/`execute`) unless `CODE_MODE` is explicitly set to an opt-out value (`0`/`false`/`no`/`off`, case-insensitive).

`search`/`get_schema` work without the code-mode extra installed (the sandbox is created lazily at `execute` time), but `execute` calls fail until `play-store-mcp[code-mode]` is installed — unchanged from before, just now the default path instead of an opt-in one.

### Test-suite note
`mcp` is a module-level singleton built once at import time from whatever `CODE_MODE` is in the environment then (`play_store_mcp/__init__.py` eagerly imports `server`, so even `import play_store_mcp.client` triggers it). Most of the suite — including the "117 tools" classic-surface assertion — exercises that singleton directly, so `conftest.py` now pins `CODE_MODE=0` before any project import, keeping the bulk of the suite on the classic surface. The code-mode-specific tests build fresh transforms via `server._build_transforms()` with their own monkeypatched `CODE_MODE` and are unaffected by this default either way.

## Verified
- [x] Full unit suite (731 tests), `ruff check`, `ruff format --check`, `mypy` all pass
- [x] Live over `streamable-http`: default (`CODE_MODE` unset) serves exactly 3 tools (`search`/`get_schema`/`execute`); `CODE_MODE=0` serves all 117 classic tools
- [x] Updated `README.md`, `docs/configuration.md`, `CHANGELOG.md` (with a `Breaking` callout)

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt