### PR TITLE
fix!: make the code-mode sandbox a base dependency, not an extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Breaking:** `CODE_MODE` now defaults to **enabled** (was opt-in/default-off).
   Set `CODE_MODE=0` (or `false`/`no`/`off`, case-insensitive) to opt out and
-  get the classic 117-tool list back. `search`/`get_schema` work without any
-  extra install, but the `execute` meta-tool's sandbox still requires the
-  `play-store-mcp[code-mode]` extra — install it, or `execute` calls will
-  fail. Read-only enforcement still applies inside the sandbox.
+  get the classic 117-tool list back. The `execute` meta-tool's sandbox
+  (Monty) is now a base dependency — not an optional extra — so every
+  install path (`pip install play-store-mcp`, `uvx play-store-mcp`, Docker)
+  works out of the box with no separate install step. Read-only enforcement
+  still applies inside the sandbox.
 
 ### Planned
 - Consolidate and reduce the MCP tool surface (now 117 tools) by grouping

--- a/README.md
+++ b/README.md
@@ -150,12 +150,8 @@ export PLAY_STORE_MCP_READ_ONLY=1
 
 By default the tools are served as three meta-tools (`search`/`get_schema`/
 `execute`) instead of the full tool list, cutting per-request tool-list token
-overhead. **The `execute` tool's sandbox requires the `code-mode` extra** —
-install it, or `execute` calls will fail:
-
-```bash
-pip install "play-store-mcp[code-mode]"
-```
+overhead. The sandbox `execute` runs in is a base dependency, so this works
+out of the box — no extra install needed.
 
 To opt out and use the classic tool list instead (`CODE_MODE` is env-only —
 there is no CLI flag):
@@ -331,7 +327,7 @@ Add to `.kiro/settings/mcp.json`:
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (for deployments behind a reverse proxy) | No |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations (deploy, promote, rollout, reply, listing/tester updates) | No (default: off) |
 | `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (path-traversal / arbitrary-write protection). Downloads are always confined; defaults to the working directory when unset | No (defaults to cwd); **recommended** for network/hosted deployments — the server warns if unset |
-| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list (`execute` otherwise requires the `play-store-mcp[code-mode]` extra) | No (default: on) |
+| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list | No (default: on) |
 
 ## 🧪 Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ docker run -p 8000:8000 \
 | `PLAY_STORE_MCP_ADMIN_TOKEN` | Require `Authorization: Bearer <token>` on the `/credentials` endpoint (needed behind a reverse proxy, where the localhost check is insufficient) | No | — |
 | `PLAY_STORE_MCP_READ_ONLY` | Disable all write operations | No | — |
 | `PLAY_STORE_MCP_DOWNLOAD_DIR` | Directory that APK/AAB downloads are confined to (guards against path traversal / arbitrary-file overwrite). Downloads are **always** confined; a destination outside this directory is rejected. **Recommended** for network/hosted deployments (`sse`/`streamable-http`) — the server warns if it is unset and falls back to the working directory, which may be read-only on some hosts (e.g. set it to `/tmp/play-store-downloads` on Render). | No (defaults to cwd) | cwd |
-| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list (`execute` otherwise requires the `code-mode` extra) | No | on |
+| `CODE_MODE` | Set to `0` to opt out of the code-mode transform and use the classic tool list | No | on |
 
 ## HTTP Transport
 
@@ -168,14 +168,9 @@ list on every request. This cuts the per-request tool-list token overhead.
     does not need writes, run code mode with `--read-only` /
     `PLAY_STORE_MCP_READ_ONLY=1` to block those operations.
 
-**Install the sandbox extra** (the `execute` meta-tool runs in the Monty
-sandbox) — `search`/`get_schema` work without it, but `execute` calls fail
-until it's installed:
-
-```bash
-pip install "play-store-mcp[code-mode]"
-# or: uvx --from "play-store-mcp[code-mode]" play-store-mcp
-```
+The `execute` meta-tool runs in the Monty sandbox, which is a base
+dependency — no extra install needed; a plain `pip install play-store-mcp`
+or `uvx play-store-mcp` includes it.
 
 **To opt out** and get the classic full tool surface instead, set the
 environment variable to an opt-out value (`0`, `false`, `no`, or `off`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "fastmcp>=4.0.0,<5.0",
+    # [code-mode]: the Monty sandbox that powers the `execute` meta-tool.
+    # Code-mode is enabled by default (CODE_MODE=0 to opt out), so its
+    # sandbox must be a base dependency, not an optional extra -- otherwise
+    # every default install (uvx/pip/Docker) ships a server whose only
+    # actionable tool, `execute`, fails out of the box.
+    "fastmcp[code-mode]>=4.0.0,<5.0",
     "google-api-python-client>=2.180.0",
     "google-auth>=2.40.0",
     "pydantic>=2.10.0",
@@ -51,10 +56,6 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.0",
     "mypy>=1.14.0",
-    "fastmcp[code-mode]>=4.0.0,<5.0",
-]
-code-mode = [
-    "fastmcp[code-mode]>=4.0.0,<5.0",
 ]
 
 [project.scripts]

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -178,17 +178,15 @@ def _build_transforms() -> list[Any]:
     """
     if not _code_mode_enabled():
         return []
-    # Imported lazily so an install without the code-mode extra never pays for
-    # it when opted out.
-    from fastmcp.experimental.transforms.code_mode import (  # noqa: PLC0415 - lazy import: code-mode extra is optional
+    # Imported lazily so opting out (CODE_MODE=0) never touches fastmcp's
+    # experimental module.
+    from fastmcp.experimental.transforms.code_mode import (  # noqa: PLC0415
         CodeMode,
     )
 
     logger.info(
         "Exposing tools via the code-mode transform (search/get_schema/execute); "
-        "set CODE_MODE=0 to opt out and use the classic tool list instead. The "
-        "'execute' sandbox requires the code-mode extra — install "
-        "play-store-mcp[code-mode]."
+        "set CODE_MODE=0 to opt out and use the classic tool list instead."
     )
     return [CodeMode()]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1381,7 +1381,7 @@ name = "play-store-mcp"
 version = "0.5.0"
 source = { editable = "." }
 dependencies = [
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["code-mode"] },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "pydantic" },
@@ -1390,11 +1390,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-code-mode = [
-    { name = "fastmcp", extra = ["code-mode"] },
-]
 dev = [
-    { name = "fastmcp", extra = ["code-mode"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1404,9 +1400,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=4.0.0,<5.0" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'", specifier = ">=4.0.0,<5.0" },
-    { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'dev'", specifier = ">=4.0.0,<5.0" },
+    { name = "fastmcp", extras = ["code-mode"], specifier = ">=4.0.0,<5.0" },
     { name = "google-api-python-client", specifier = ">=2.180.0" },
     { name = "google-auth", specifier = ">=2.40.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
@@ -1418,7 +1412,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "structlog", specifier = ">=25.0.0" },
 ]
-provides-extras = ["dev", "code-mode"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
## Summary
Resolves a gap found while assessing readiness to promote #140 (code-mode default-on) to stable.

Since #140 made code-mode the default, every documented install path (`pip install play-store-mcp`, `uvx play-store-mcp`, the Docker build's `uv sync --frozen` with no `--extra` flag) shipped a server whose only actionable tool — `execute` — failed immediately, because the Monty sandbox it needs was still an opt-in `code-mode` extra nobody installs by default. `search`/`get_schema` "worked" but the feature was effectively broken out of the box for anyone using a standard install.

Moves `fastmcp[code-mode]` into the base `dependencies` list (was `fastmcp` + a separate optional `code-mode` extra); drops the now-fully-redundant `code-mode` extra and the `dev` extra's duplicate line. No Dockerfile change needed — `uv sync --frozen` now pulls Monty in via the base deps automatically. `pydantic-monty` ships a pure-Python `py3-none-any` wheel, so this adds no native/Alpine build risk.

## Verified
- [x] Full unit suite (731 tests), `ruff check`, `ruff format --check`, `mypy` all pass
- [x] A bare `uv sync` with zero `--extra` flags installs `pydantic-monty`
- [x] `execute` actually runs a real tool call in that bare environment (previously would have failed with a sandbox-unavailable error)
- [x] Docker build (unmodified `Dockerfile`) + container boot: `execute` reaches the real tool layer inside the container (fails only on missing credentials, which is expected/unrelated — not a sandbox/import failure)
- [x] Updated `README.md`, `docs/configuration.md`, and the not-yet-released CHANGELOG entry from #140 to drop the "install the extra" instructions

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Code Mode’s `execute` sandbox now works out of the box across standard installation methods, with no separate installation step required.

- **Documentation**
  - Updated the changelog, README, and configuration guidance to reflect that the sandbox is included by default.
  - Clarified that Code Mode can be disabled using the `CODE_MODE=0` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->