### PR TITLE
refactor: fix 9 of the remaining 13 SonarQube maintainability findings

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -14,7 +14,7 @@ echo ""
 
 # Check if .env.local exists
 if [ ! -f .env.local ]; then
-    echo "❌ Error: .env.local file not found"
+    echo "❌ Error: .env.local file not found" >&2
     echo "Please create .env.local with:"
     echo "  export GOOGLE_APPLICATION_CREDENTIALS=\"/path/to/credentials.json\""
     exit 1
@@ -31,7 +31,7 @@ fi
 
 # Check if credentials file exists
 if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-    echo "❌ Error: Credentials file not found: $GOOGLE_APPLICATION_CREDENTIALS"
+    echo "❌ Error: Credentials file not found: $GOOGLE_APPLICATION_CREDENTIALS" >&2
     exit 1
 fi
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,8 +17,8 @@ elif [ -f .venv/bin/python ]; then
     echo "✓ Using virtual environment"
     .venv/bin/python -m pytest tests/ -v --tb=short --cov=src/play_store_mcp --cov-report=term-missing
 else
-    echo "✗ Neither uv nor virtual environment found"
-    echo "Please run: uv sync --extra dev"
+    echo "✗ Neither uv nor virtual environment found" >&2
+    echo "Please run: uv sync --extra dev" >&2
     exit 1
 fi
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -72,12 +72,9 @@ class TestRealAPIConnection:
 
     def test_can_get_service(self, real_client: PlayStoreClient) -> None:
         """Test that we can get the API service."""
-        try:
-            service = real_client._get_service()
-            assert service is not None
-            print("✓ API service obtained successfully")
-        except PlayStoreClientError as e:
-            pytest.fail(f"Failed to get API service: {e}")
+        service = real_client._get_service()
+        assert service is not None
+        print("✓ API service obtained successfully")
 
 
 class TestReadOnlyOperations:
@@ -89,20 +86,17 @@ class TestReadOnlyOperations:
         test_package_name: str,
     ) -> None:
         """Test getting releases for an app."""
-        try:
-            tracks = real_client.get_releases(test_package_name)
-            assert isinstance(tracks, list)
-            print(f"✓ get_releases() returned {len(tracks)} tracks")
+        tracks = real_client.get_releases(test_package_name)
+        assert isinstance(tracks, list)
+        print(f"✓ get_releases() returned {len(tracks)} tracks")
 
-            for track in tracks:
-                print(f"  - Track: {track.track}")
-                for release in track.releases:
-                    print(f"    Version codes: {release.version_codes}")
-                    print(f"    Status: {release.status}")
-                    if release.rollout_percentage < 100:
-                        print(f"    Rollout: {release.rollout_percentage}%")
-        except PlayStoreClientError as e:
-            pytest.fail(f"Failed to get releases: {e}")
+        for track in tracks:
+            print(f"  - Track: {track.track}")
+            for release in track.releases:
+                print(f"    Version codes: {release.version_codes}")
+                print(f"    Status: {release.status}")
+                if release.rollout_percentage < 100:
+                    print(f"    Rollout: {release.rollout_percentage}%")
 
     def test_get_app_details(
         self,
@@ -110,14 +104,11 @@ class TestReadOnlyOperations:
         test_package_name: str,
     ) -> None:
         """Test getting app details."""
-        try:
-            details = real_client.get_app_details(test_package_name)
-            assert details.package_name == test_package_name
-            print("✓ get_app_details() succeeded")
-            print(f"  Title: {details.title}")
-            print(f"  Default language: {details.default_language}")
-        except PlayStoreClientError as e:
-            pytest.fail(f"Failed to get app details: {e}")
+        details = real_client.get_app_details(test_package_name)
+        assert details.package_name == test_package_name
+        print("✓ get_app_details() succeeded")
+        print(f"  Title: {details.title}")
+        print(f"  Default language: {details.default_language}")
 
     def test_get_reviews(
         self,
@@ -177,16 +168,13 @@ class TestReadOnlyOperations:
         test_package_name: str,
     ) -> None:
         """Test getting store listing."""
-        try:
-            listing = real_client.get_listing(test_package_name, "en-US")
-            assert listing.language == "en-US"
-            print("✓ get_listing() succeeded")
-            print(f"  Title: {listing.title}")
-            print(
-                f"  Short description: {listing.short_description[:50] if listing.short_description else 'None'}..."
-            )
-        except PlayStoreClientError as e:
-            pytest.fail(f"Failed to get listing: {e}")
+        listing = real_client.get_listing(test_package_name, "en-US")
+        assert listing.language == "en-US"
+        print("✓ get_listing() succeeded")
+        print(f"  Title: {listing.title}")
+        print(
+            f"  Short description: {listing.short_description[:50] if listing.short_description else 'None'}..."
+        )
 
     def test_list_all_listings(
         self,
@@ -194,15 +182,12 @@ class TestReadOnlyOperations:
         test_package_name: str,
     ) -> None:
         """Test listing all store listings."""
-        try:
-            listings = real_client.list_all_listings(test_package_name)
-            assert isinstance(listings, list)
-            print(f"✓ list_all_listings() returned {len(listings)} listings")
+        listings = real_client.list_all_listings(test_package_name)
+        assert isinstance(listings, list)
+        print(f"✓ list_all_listings() returned {len(listings)} listings")
 
-            for listing in listings:
-                print(f"  - {listing.language}: {listing.title}")
-        except PlayStoreClientError as e:
-            pytest.fail(f"Failed to list all listings: {e}")
+        for listing in listings:
+            print(f"  - {listing.language}: {listing.title}")
 
     def test_get_testers(
         self,

--- a/tests/test_purchase_management.py
+++ b/tests/test_purchase_management.py
@@ -330,7 +330,8 @@ def test_tool_revoke_subscription_invalid_type(monkeypatch):
     result = server.revoke_subscription_purchase("com.example.app", "tok", refund_type="bogus")
 
     assert "error" in result
-    assert "full" in result["error"] and "prorated" in result["error"]
+    assert "full" in result["error"]
+    assert "prorated" in result["error"]
     mc.revoke_subscription_purchase.assert_not_called()
 
 

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -100,13 +100,12 @@ def tmp_aab(tmp_path: Any) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _patch_mcp_context(mock_client: MagicMock, monkeypatch: pytest.MonkeyPatch) -> Any:
+def _patch_mcp_context(mock_client: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
     """Route get_client_from_context to the mock client for tool tests."""
     from play_store_mcp import server
 
     monkeypatch.setattr(server, "get_http_headers", dict)
     monkeypatch.setitem(server._shared_state, "client", mock_client)
-    yield
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
Fixes 9 of the 13 remaining SonarQube maintainability findings on `main` (the 10 duplicate-literal findings were already fixed in #143).

- `shelldre:S7677` (×3, `run_integration_tests.sh`, `run_tests.sh`): redirect error-message `echo` lines to stderr (`>&2`).
- `python:S9100` (`test_server_extended.py`): remove the useless `yield` from `_patch_mcp_context` — `monkeypatch` handles its own cleanup regardless.
- `python:S9073` (`test_purchase_management.py`): split a composite `assert x and y` into two separate assertions.
- `python:S8714` (×5, `test_integration.py`): remove pure-boilerplate `try/except PlayStoreClientError: pytest.fail(...)` wrappers — an uncaught exception already fails the test with a natural traceback. Left the 4 *other* try/except blocks in this file untouched (`test_get_reviews`, `test_list_subscriptions`, `test_list_in_app_products`, `test_get_testers`) — those intentionally swallow the error and print a note since those resources may not exist for every app; SonarQube correctly didn't flag them.

`python:S5778` turned out to be stale — every current `pytest.raises(...)` block already contains exactly one statement, so no code change was needed; it should clear on the next scan.

The remaining 2 findings (`python:S3776`, cognitive-complexity reductions in `client.py`/`server.py` credential-handling code) are a separate, more involved production-code refactor — deliberately not bundled here, to be done as its own PR if wanted.

## Verified
- [x] Full unit suite (731 tests), `ruff check`, `ruff format --check`, `mypy` all pass
- [x] Both modified shell scripts pass `bash -n` and `shellcheck`

## Test plan
- [ ] CI green
- [ ] Confirm the 9 findings clear on the next SonarCloud analysis of `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt