### PR TITLE
refactor: reduce cognitive complexity in credential-handling code (S3776)

### DIFF
--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -386,6 +386,56 @@ class PlayStoreClient:
 
         return errors
 
+    def _resolve_credentials_from_json(self) -> Any | None:
+        """Resolve credentials from ``self._credentials_json`` (JSON string, file path, or dict)."""
+        if not self._credentials_json:
+            return None
+
+        if isinstance(self._credentials_json, dict):
+            return service_account.Credentials.from_service_account_info(
+                self._credentials_json, scopes=SCOPES
+            )
+
+        if not isinstance(self._credentials_json, str):
+            return None
+
+        try:
+            # Check if it's actually JSON or a path to a file
+            if self._credentials_json.strip().startswith("{"):
+                creds_info = json.loads(self._credentials_json)
+                return service_account.Credentials.from_service_account_info(
+                    creds_info, scopes=SCOPES
+                )
+            if Path(self._credentials_json).exists():
+                return service_account.Credentials.from_service_account_file(
+                    self._credentials_json, scopes=SCOPES
+                )
+        except json.JSONDecodeError:
+            # If it's not JSON, maybe it's a path that doesn't exist?
+            self._logger.warning(
+                "credentials_json string is not valid JSON and not a valid file path",
+            )
+        return None
+
+    def _resolve_credentials_from_path(self) -> Any | None:
+        """Resolve credentials from ``self._credentials_path``, if it exists."""
+        if not self._credentials_path:
+            return None
+        creds_path = Path(self._credentials_path)
+        if not creds_path.exists():
+            return None
+        return service_account.Credentials.from_service_account_file(str(creds_path), scopes=SCOPES)
+
+    def _resolve_credentials(self) -> Any:
+        """Resolve credentials, trying credentials_json before credentials_path."""
+        credentials = self._resolve_credentials_from_json() or self._resolve_credentials_from_path()
+        if not credentials:
+            raise PlayStoreClientError(
+                "No valid credentials found. Set GOOGLE_APPLICATION_CREDENTIALS (path) "
+                "or GOOGLE_PLAY_STORE_CREDENTIALS (JSON or path)."
+            )
+        return credentials
+
     @retry_with_backoff
     def _get_service(self) -> AndroidPublisherResource:
         """Get or create the API service instance."""
@@ -395,47 +445,7 @@ class PlayStoreClient:
         self._logger.info("Initializing Google Play Developer API client")
 
         try:
-            credentials = None
-
-            # Try credentials_json first (from string or dict)
-            if self._credentials_json:
-                if isinstance(self._credentials_json, str):
-                    try:
-                        # Check if it's actually JSON or a path to a file
-                        if self._credentials_json.strip().startswith("{"):
-                            creds_info = json.loads(self._credentials_json)
-                            credentials = service_account.Credentials.from_service_account_info(
-                                creds_info, scopes=SCOPES
-                            )
-                        elif Path(self._credentials_json).exists():
-                            credentials = service_account.Credentials.from_service_account_file(
-                                self._credentials_json, scopes=SCOPES
-                            )
-                    except json.JSONDecodeError:
-                        # If it's not JSON, maybe it's a path that doesn't exist?
-                        self._logger.warning(
-                            "credentials_json string is not valid JSON and not a valid file path",
-                        )
-
-                elif isinstance(self._credentials_json, dict):
-                    credentials = service_account.Credentials.from_service_account_info(
-                        self._credentials_json, scopes=SCOPES
-                    )
-
-            # Fall back to credentials_path
-            if not credentials and self._credentials_path:
-                creds_path = Path(self._credentials_path)
-                if creds_path.exists():
-                    credentials = service_account.Credentials.from_service_account_file(
-                        str(creds_path), scopes=SCOPES
-                    )
-
-            if not credentials:
-                raise PlayStoreClientError(
-                    "No valid credentials found. Set GOOGLE_APPLICATION_CREDENTIALS (path) "
-                    "or GOOGLE_PLAY_STORE_CREDENTIALS (JSON or path)."
-                )
-
+            credentials = self._resolve_credentials()
             self._service = build(
                 "androidpublisher",
                 "v3",

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -3611,6 +3611,78 @@ def _authorize_credentials_request(request: Request) -> JSONResponse | None:
     return None
 
 
+def _parse_base64_credentials_payload(
+    credentials_base64: str,
+) -> tuple[PlayStoreClient | None, JSONResponse | None]:
+    """Decode a base64-encoded service account JSON payload into a new client.
+
+    Returns (client, None) on success, or (None, error_response) on failure.
+    """
+    try:
+        decoded = base64.b64decode(credentials_base64).decode("utf-8")
+        credentials_dict = json.loads(decoded)
+    except (binascii.Error, UnicodeDecodeError) as e:
+        return None, JSONResponse(
+            {"success": False, "error": f"Invalid base64 encoding: {e}"},
+            status_code=400,
+        )
+    except json.JSONDecodeError:
+        return None, JSONResponse(
+            {"success": False, "error": "Invalid JSON in base64-decoded credentials"},
+            status_code=400,
+        )
+    return PlayStoreClient(credentials_json=credentials_dict), None
+
+
+def _parse_inline_credentials_payload(
+    credentials: Any,
+) -> tuple[PlayStoreClient | None, JSONResponse | None]:
+    """Parse an inline ``credentials`` value (JSON string or object) into a new client.
+
+    Returns (client, None) on success, or (None, error_response) on failure.
+    """
+    if isinstance(credentials, str):
+        # Validate it's valid JSON
+        try:
+            json.loads(credentials)
+        except json.JSONDecodeError:
+            return None, JSONResponse(
+                {"success": False, "error": "Invalid JSON in credentials string"},
+                status_code=400,
+            )
+        return PlayStoreClient(credentials_json=credentials), None
+    if isinstance(credentials, dict):
+        return PlayStoreClient(credentials_json=credentials), None
+    return None, JSONResponse(
+        {"success": False, "error": "credentials must be a string or object"},
+        status_code=400,
+    )
+
+
+def _parse_credentials_request_body(
+    body: dict[str, Any],
+) -> tuple[PlayStoreClient | None, JSONResponse | None]:
+    """Parse a /credentials POST body into a new ``PlayStoreClient``.
+
+    Returns (client, None) on success, or (None, error_response) on failure.
+    """
+    credentials = body.get("credentials")
+    credentials_base64 = body.get("credentials_base64")
+
+    if not credentials and not credentials_base64:
+        return None, JSONResponse(
+            {
+                "success": False,
+                "error": "Missing 'credentials' or 'credentials_base64' in request body",
+            },
+            status_code=400,
+        )
+
+    if credentials_base64:
+        return _parse_base64_credentials_payload(credentials_base64)
+    return _parse_inline_credentials_payload(credentials)
+
+
 @mcp.custom_route("/credentials", methods=["POST"])
 async def update_credentials(request: Request) -> JSONResponse:
     """Update Google Play Store credentials via HTTP POST.
@@ -3633,57 +3705,12 @@ async def update_credentials(request: Request) -> JSONResponse:
     if auth_error is not None:
         return auth_error
 
-    new_client: PlayStoreClient | None = None
     try:
         body = await request.json()
 
-        credentials = body.get("credentials")
-        credentials_base64 = body.get("credentials_base64")
-
-        if not credentials and not credentials_base64:
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": "Missing 'credentials' or 'credentials_base64' in request body",
-                },
-                status_code=400,
-            )
-
-        # Create new client with provided credentials
-        if credentials_base64:
-            # Decode base64 credentials
-            try:
-                decoded = base64.b64decode(credentials_base64).decode("utf-8")
-                credentials_dict = json.loads(decoded)
-                new_client = PlayStoreClient(credentials_json=credentials_dict)
-            except (binascii.Error, UnicodeDecodeError) as e:
-                return JSONResponse(
-                    {"success": False, "error": f"Invalid base64 encoding: {e}"},
-                    status_code=400,
-                )
-            except json.JSONDecodeError:
-                return JSONResponse(
-                    {"success": False, "error": "Invalid JSON in base64-decoded credentials"},
-                    status_code=400,
-                )
-        elif credentials:
-            if isinstance(credentials, str):
-                # Validate it's valid JSON
-                try:
-                    json.loads(credentials)
-                except json.JSONDecodeError:
-                    return JSONResponse(
-                        {"success": False, "error": "Invalid JSON in credentials string"},
-                        status_code=400,
-                    )
-                new_client = PlayStoreClient(credentials_json=credentials)
-            elif isinstance(credentials, dict):
-                new_client = PlayStoreClient(credentials_json=credentials)
-            else:
-                return JSONResponse(
-                    {"success": False, "error": "credentials must be a string or object"},
-                    status_code=400,
-                )
+        new_client, parse_error = _parse_credentials_request_body(body)
+        if parse_error is not None:
+            return parse_error
 
         if (
             new_client is None


### PR DESCRIPTION
## Summary
Fixes the last 2 SonarQube maintainability findings on `main` (`python:S3776`, cognitive complexity 20 vs. the 15 allowed), both in auth-critical credential-handling code — deliberately held back from #143/#144 for their own careful review.

- **`client.py`'s `_get_service`**: extracted the nested credentials_json (JSON string / file path / dict) vs. credentials_path resolution logic into `_resolve_credentials_from_json`, `_resolve_credentials_from_path`, and `_resolve_credentials`. `_get_service` itself now just resolves credentials and builds the service.
- **`server.py`'s `update_credentials`** (`/credentials` POST handler): extracted the three credentials input shapes (base64, inline JSON string, inline dict) into `_parse_base64_credentials_payload`, `_parse_inline_credentials_payload`, and `_parse_credentials_request_body`, each returning `(client, None)` or `(None, error_response)`.

This is a pure extraction — every error message, status code, and control-flow order is unchanged. No behavior change, no new feature.

## Test plan
- [x] `uv run pytest tests/ -q` (excluding live/integration suites) — 731 passed. Caught one real behavioral gap during the refactor: a test (`test_credentials_json_wrong_type`) exercises a truthy non-str/non-dict `credentials_json` value, which the original code silently ignored (falls through to the `credentials_path` fallback) but my first draft of `_resolve_credentials_from_json` would have raised `AttributeError` on it. Added an explicit `isinstance(..., str)` guard to restore the original fallthrough behavior.
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] Real, credentialed smoke test against the live test app (`app.lusk.underseerr`): `PlayStoreClient()._get_service()` resolves credentials and a real `get_listing()` call succeeds end to end.
- [x] Booted a real server (`streamable-http` transport) and exercised every branch of `/credentials` with real service-account credentials: dict, JSON string, and base64 success paths, plus missing-body, malformed-JSON-body, invalid-JSON-string, wrong-type, and invalid-base64 error paths — all responses identical to pre-refactor behavior.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge
- [ ] Confirm SonarCloud's live maintainability count on `main` drops to 0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal organization of credential resolution and credential request parsing.
  - Existing credential formats, validation rules, authorization checks, and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->