### PR TITLE
fix: block SSRF via spoofed token_uri in credential JSON (CRITICAL)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,14 @@ docker run -p 8000:8000 \
   --transport streamable-http --host 0.0.0.0 --port 8000
 ```
 
+> **Warning:** `--host 0.0.0.0` binds the MCP tool-invocation endpoint (`/mcp`) itself,
+> which has **no built-in authentication** — only `/credentials` is gated (see
+> [Per-Request Credentials](#per-request-credentials) below). Exposing this port
+> directly, as above, gives anyone with network access to it full read/write access to
+> the Google Play account configured via `GOOGLE_APPLICATION_CREDENTIALS`. Put a reverse
+> proxy with its own authentication in front before exposing this port beyond
+> localhost/a private network.
+
 ## Environment Variables
 
 | Variable | Description | Required | Default |

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -78,6 +78,12 @@ logger = structlog.get_logger(__name__)
 # API scopes required for Play Developer API
 SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 
+# The fixed OAuth token endpoint Google issues in every service account JSON
+# key. Enforced in _build_credentials_from_info to prevent a spoofed
+# token_uri (e.g. from an untrusted per-request credential header) from
+# being used as an SSRF primitive during credential refresh.
+_GOOGLE_OAUTH_TOKEN_URI = "https://oauth2.googleapis.com/token"  # noqa: S105 # nosec B105 — endpoint URL, not a credential
+
 # Retry configuration
 MAX_RETRIES = 3
 INITIAL_BACKOFF = 1.0  # seconds
@@ -392,9 +398,7 @@ class PlayStoreClient:
             return None
 
         if isinstance(self._credentials_json, dict):
-            return service_account.Credentials.from_service_account_info(
-                self._credentials_json, scopes=SCOPES
-            )
+            return self._build_credentials_from_info(self._credentials_json)
 
         if not isinstance(self._credentials_json, str):
             return None
@@ -403,13 +407,9 @@ class PlayStoreClient:
             # Check if it's actually JSON or a path to a file
             if self._credentials_json.strip().startswith("{"):
                 creds_info = json.loads(self._credentials_json)
-                return service_account.Credentials.from_service_account_info(
-                    creds_info, scopes=SCOPES
-                )
+                return self._build_credentials_from_info(creds_info)
             if Path(self._credentials_json).exists():
-                return service_account.Credentials.from_service_account_file(
-                    self._credentials_json, scopes=SCOPES
-                )
+                return self._build_credentials_from_file(self._credentials_json)
         except json.JSONDecodeError:
             # If it's not JSON, maybe it's a path that doesn't exist?
             self._logger.warning(
@@ -424,7 +424,34 @@ class PlayStoreClient:
         creds_path = Path(self._credentials_path)
         if not creds_path.exists():
             return None
-        return service_account.Credentials.from_service_account_file(str(creds_path), scopes=SCOPES)
+        return self._build_credentials_from_file(str(creds_path))
+
+    def _build_credentials_from_file(self, path: str) -> Any:
+        """Load a service account JSON key file and build validated credentials."""
+        with Path(path).open(encoding="utf-8") as f:
+            creds_info = json.load(f)
+        return self._build_credentials_from_info(creds_info)
+
+    def _build_credentials_from_info(self, creds_info: dict[str, Any]) -> Any:
+        """Build service-account credentials, rejecting a spoofed ``token_uri``.
+
+        Every service account key Google issues has a fixed, well-known
+        ``token_uri`` (``https://oauth2.googleapis.com/token``). This client
+        also accepts per-request credentials from untrusted HTTP headers
+        (``X-Google-Credentials``/``X-Google-Credentials-Base64`` in
+        server.py's ``get_client_from_context``), so without this check a
+        caller could supply a spoofed ``token_uri`` and turn the OAuth
+        refresh request google-auth makes internally into an SSRF primitive
+        (an outbound request to an attacker-chosen URL, on this server's
+        network, triggered by any tool call).
+        """
+        token_uri = creds_info.get("token_uri")
+        if token_uri is not None and token_uri != _GOOGLE_OAUTH_TOKEN_URI:
+            raise PlayStoreClientError(
+                f"Invalid token_uri in service account credentials: {token_uri!r} "
+                f"(expected {_GOOGLE_OAUTH_TOKEN_URI!r})"
+            )
+        return service_account.Credentials.from_service_account_info(creds_info, scopes=SCOPES)
 
     def _resolve_credentials(self) -> Any:
         """Resolve credentials, trying credentials_json before credentials_path."""

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -91,6 +91,11 @@ def get_client_from_context() -> PlayStoreClient:
 # can reach it without depending on framework-internal context plumbing.
 _shared_state: dict[str, Any] = {"client": None, "credentials_updated": False}
 
+# Recommended minimum length for PLAY_STORE_MCP_ADMIN_TOKEN, below which
+# _run_http logs a startup warning. `openssl rand -hex 32` (the documented
+# recommendation) produces a 64-char token; this is a low bar, not a target.
+_MIN_ADMIN_TOKEN_LENGTH = 16
+
 
 @asynccontextmanager
 async def lifespan(_server: FastMCP):  # type: ignore[no-untyped-def]
@@ -3795,6 +3800,15 @@ def _run_http(transport: str, host: str, port: int) -> None:
             "the server's working directory. Set it to a writable directory to control where "
             "downloads are written on a network-exposed deployment.",
             transport=transport,
+        )
+    admin_token = os.environ.get("PLAY_STORE_MCP_ADMIN_TOKEN")
+    if admin_token and len(admin_token) < _MIN_ADMIN_TOKEN_LENGTH:
+        logger.warning(
+            "PLAY_STORE_MCP_ADMIN_TOKEN is shorter than recommended; a weak token makes "
+            "the /credentials endpoint's Bearer-token check easier to brute-force. Use a "
+            "long random value, e.g. `openssl rand -hex 32`.",
+            token_length=len(admin_token),
+            recommended_minimum=_MIN_ADMIN_TOKEN_LENGTH,
         )
     middleware: list[Middleware] = []
     if not _dns_rebinding_disabled():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,15 @@ def _reset_shared_state() -> Generator[None, None, None]:
 
 @pytest.fixture
 def _mock_credentials() -> Generator[MagicMock, None, None]:
-    """Mock Google credentials."""
+    """Mock Google credentials.
+
+    All credential-resolution branches (dict, JSON string, file path) funnel
+    through ``from_service_account_info`` so the token_uri validation in
+    ``_build_credentials_from_info`` is a single, universal choke point —
+    so that's the call this mocks, not ``from_service_account_file``.
+    """
     with patch(
-        "play_store_mcp.client.service_account.Credentials.from_service_account_file"
+        "play_store_mcp.client.service_account.Credentials.from_service_account_info"
     ) as mock:
         mock.return_value = MagicMock()
         yield mock

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -157,7 +157,7 @@ class TestGetServiceErrors:
 
         with (
             patch(
-                "play_store_mcp.client.service_account.Credentials.from_service_account_file",
+                "play_store_mcp.client.service_account.Credentials.from_service_account_info",
                 side_effect=ValueError("bad creds"),
             ),
             pytest.raises(PlayStoreClientError, match="Failed to initialize API client"),
@@ -1353,18 +1353,18 @@ class TestCredentialsJson:
         mock_info.assert_called_once()
 
     def test_credentials_json_path(self, _mock_service: MagicMock, tmp_path: Any) -> None:
-        """A filesystem path string uses from_service_account_file."""
+        """A filesystem path string is read and passed to from_service_account_info."""
         creds_file = tmp_path / "creds.json"
         creds_file.write_text('{"type": "service_account"}')
         client = PlayStoreClient(credentials_json=str(creds_file))
 
         with patch(
-            "play_store_mcp.client.service_account.Credentials.from_service_account_file"
-        ) as mock_file:
-            mock_file.return_value = MagicMock()
+            "play_store_mcp.client.service_account.Credentials.from_service_account_info"
+        ) as mock_info:
+            mock_info.return_value = MagicMock()
             client._get_service()
 
-        mock_file.assert_called_once()
+        mock_info.assert_called_once()
 
     def test_credentials_json_invalid_json(self, _mock_service: MagicMock) -> None:
         """An invalid JSON string starting with '{' logs a warning and yields no creds."""
@@ -1398,6 +1398,69 @@ class TestCredentialsJson:
 
         with pytest.raises(PlayStoreClientError, match="No valid credentials found"):
             client._get_service()
+
+    def test_credentials_json_dict_rejects_spoofed_token_uri(
+        self, _mock_service: MagicMock
+    ) -> None:
+        """A dict with a non-Google token_uri is rejected before credentials are built.
+
+        Regression test for an SSRF: per-request credentials arrive over an
+        unauthenticated HTTP header (X-Google-Credentials), so an attacker
+        could otherwise point token_uri at an arbitrary URL and have this
+        server POST a signed JWT-bearer assertion there on refresh.
+        """
+        client = PlayStoreClient(
+            credentials_json={
+                "type": "service_account",
+                "client_email": "test@example.com",
+                "token_uri": "https://attacker.example.com/steal",
+            }
+        )
+
+        with pytest.raises(PlayStoreClientError, match="Invalid token_uri"):
+            client._get_service()
+
+    def test_credentials_json_string_rejects_spoofed_token_uri(
+        self, _mock_service: MagicMock
+    ) -> None:
+        """A JSON string with a non-Google token_uri is rejected the same way."""
+        client = PlayStoreClient(
+            credentials_json=(
+                '{"type": "service_account", "client_email": "test@example.com", '
+                '"token_uri": "https://attacker.example.com/steal"}'
+            )
+        )
+
+        with pytest.raises(PlayStoreClientError, match="Invalid token_uri"):
+            client._get_service()
+
+    def test_credentials_json_path_rejects_spoofed_token_uri(
+        self, _mock_service: MagicMock, tmp_path: Any
+    ) -> None:
+        """A credentials file with a non-Google token_uri is rejected the same way."""
+        creds_file = tmp_path / "spoofed-creds.json"
+        creds_file.write_text(
+            '{"type": "service_account", "client_email": "test@example.com", '
+            '"token_uri": "https://attacker.example.com/steal"}'
+        )
+        client = PlayStoreClient(credentials_json=str(creds_file))
+
+        with pytest.raises(PlayStoreClientError, match="Invalid token_uri"):
+            client._get_service()
+
+    def test_credentials_json_missing_token_uri_not_rejected_by_validation(
+        self, _mock_service: MagicMock
+    ) -> None:
+        """No token_uri at all passes our validation (google-auth enforces required fields itself)."""
+        client = PlayStoreClient(credentials_json={"type": "service_account"})
+
+        with patch(
+            "play_store_mcp.client.service_account.Credentials.from_service_account_info"
+        ) as mock_info:
+            mock_info.return_value = MagicMock()
+            client._get_service()
+
+        mock_info.assert_called_once()
 
 
 # =========================================================================

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -892,6 +892,73 @@ def test_run_http_warns_without_download_dir_but_starts(monkeypatch: pytest.Monk
     assert captured.get("served") is True
 
 
+def _stub_run_http_startup(monkeypatch: pytest.MonkeyPatch, server: Any) -> None:
+    """Stub out the ASGI app/uvicorn bits of _run_http so it returns immediately."""
+
+    def fake_http_app(**_kwargs: Any) -> str:
+        return "ASGI_APP"
+
+    class FakeUvicorn:
+        @staticmethod
+        def run(*_args: Any, **_kwargs: Any) -> None:
+            pass
+
+    monkeypatch.setattr(server.mcp, "http_app", fake_http_app)
+    monkeypatch.setattr(server, "uvicorn", FakeUvicorn)
+
+
+@pytest.mark.parametrize("admin_token", ["short", "a" * 15])
+def test_run_http_warns_on_weak_admin_token(
+    admin_token: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """A PLAY_STORE_MCP_ADMIN_TOKEN under the recommended minimum length logs a warning."""
+    from play_store_mcp import server
+
+    monkeypatch.setenv("PLAY_STORE_MCP_ADMIN_TOKEN", admin_token)
+    monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(tmp_path))
+    _stub_run_http_startup(monkeypatch, server)
+
+    with patch.object(server.logger, "warning") as mock_warning:
+        server._run_http("streamable-http", "127.0.0.1", 8000)
+
+    messages = [call.args[0] for call in mock_warning.call_args_list]
+    assert any("PLAY_STORE_MCP_ADMIN_TOKEN is shorter than recommended" in m for m in messages)
+
+
+def test_run_http_no_warning_for_strong_admin_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """An admin token at or above the recommended minimum length logs no warning."""
+    from play_store_mcp import server
+
+    monkeypatch.setenv("PLAY_STORE_MCP_ADMIN_TOKEN", "a" * 32)
+    monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(tmp_path))
+    _stub_run_http_startup(monkeypatch, server)
+
+    with patch.object(server.logger, "warning") as mock_warning:
+        server._run_http("streamable-http", "127.0.0.1", 8000)
+
+    messages = [call.args[0] for call in mock_warning.call_args_list]
+    assert not any("PLAY_STORE_MCP_ADMIN_TOKEN" in m for m in messages)
+
+
+def test_run_http_no_warning_when_admin_token_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """No admin token configured logs no admin-token warning (loopback-only mode is not weak)."""
+    from play_store_mcp import server
+
+    monkeypatch.delenv("PLAY_STORE_MCP_ADMIN_TOKEN", raising=False)
+    monkeypatch.setenv("PLAY_STORE_MCP_DOWNLOAD_DIR", str(tmp_path))
+    _stub_run_http_startup(monkeypatch, server)
+
+    with patch.object(server.logger, "warning") as mock_warning:
+        server._run_http("streamable-http", "127.0.0.1", 8000)
+
+    messages = [call.args[0] for call in mock_warning.call_args_list]
+    assert not any("PLAY_STORE_MCP_ADMIN_TOKEN" in m for m in messages)
+
+
 @pytest.mark.parametrize(
     ("host", "expected"),
     [
@@ -987,6 +1054,35 @@ class TestGetClientFromContext:
         monkeypatch.setitem(server._shared_state, "client", None)
         with pytest.raises(server.PlayStoreClientError, match="No credentials"):
             server.get_client_from_context()
+
+    def test_json_header_with_spoofed_token_uri_blocked_on_first_use(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end SSRF regression test for the X-Google-Credentials header.
+
+        get_client_from_context() takes headers from any unauthenticated
+        request and builds a real PlayStoreClient from them (unlike
+        /credentials, which is gated). Confirm a spoofed token_uri is
+        rejected the first time the resulting client is actually used
+        (_get_service(), called at the top of every client method), before
+        any outbound request using it could occur.
+        """
+        from play_store_mcp import server
+
+        monkeypatch.setattr(
+            server,
+            "get_http_headers",
+            lambda: {
+                "x-google-credentials": (
+                    '{"type": "service_account", "client_email": "test@example.com", '
+                    '"token_uri": "https://attacker.example.com/steal"}'
+                )
+            },
+        )
+
+        client = server.get_client_from_context()
+        with pytest.raises(server.PlayStoreClientError, match="Invalid token_uri"):
+            client._get_service()
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
From this session's full code audit — CRITICAL finding, plus 2 lower-severity findings from the same credential/HTTP-surface area bundled in.

**The vulnerability:** `get_client_from_context()` (`server.py`) reads `X-Google-Credentials`/`X-Google-Credentials-Base64` from *any* incoming request — no auth check at all, unlike `/credentials` which is gated — and builds a real `PlayStoreClient` straight from the header JSON. `google.oauth2.service_account.Credentials.from_service_account_info` only requires `client_email` + `token_uri`, and stores `token_uri` verbatim; on refresh it POSTs a signed JWT-bearer assertion to that URL with no allowlist. An attacker could supply their own key plus an arbitrary `token_uri` and get the server to make an outbound HTTP request to any URL of their choosing (cloud metadata endpoints, internal-only services), triggered by any of the 117 MCP tools.

**The fix:** every credential-resolution branch in `client.py` (dict, JSON string, file path, `credentials_path` fallback) now funnels through one `_build_credentials_from_info()` choke point that rejects any `token_uri` other than `https://oauth2.googleapis.com/token` — the fixed value Google issues in every service account key, so no legitimate credential is affected. The file-path branches now read+parse the JSON themselves instead of calling `from_service_account_file`, so the check applies uniformly everywhere.

**Also bundled** (same area, lower severity, from the same audit):
- `docs/configuration.md`: warns that `--host 0.0.0.0` in the Docker/HTTP example exposes the unauthenticated `/mcp` endpoint directly; a reverse proxy with its own auth is required before exposing beyond localhost/a private network.
- `server.py`: `_run_http` now logs a startup warning if `PLAY_STORE_MCP_ADMIN_TOKEN` is set but under 16 characters.

## Test plan
- [x] New tests for the client-level check across all 3 credential input shapes (dict/string/file), including one proving `token_uri` absence still passes (google-auth enforces required fields itself).
- [x] New end-to-end test: a real `PlayStoreClient` built from a spoofed header, `_get_service()` called, confirmed rejected.
- [x] **Live verification against a real running server**: booted `streamable-http` transport, used a real `fastmcp` `Client` to call `get_app_details` with the spoofed `X-Google-Credentials` header — confirmed blocked with `Invalid token_uri...` before any outbound request could occur.
- [x] Real credentialed smoke test against the live test app (`app.lusk.underseerr`): legitimate credentials still resolve and complete a real API call, unaffected by the fix.
- [x] Full unit suite (740 tests), `ruff check`, `ruff format --check`, `mypy`, `bandit`: all clean.
- [x] Live-verified the new admin-token warning fires for a short token.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt