### PR TITLE
fix: return documented Result instead of raising on edit-setup failure

### DIFF
--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -625,10 +625,11 @@ class PlayStoreClient:
                 error="FileNotFoundError",
             )
 
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             # Determine content type and upload method
             is_bundle = file_path.lower().endswith(".aab")
             content_type = _MIME_TYPE_AAB if is_bundle else _MIME_TYPE_APK
@@ -702,7 +703,8 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Deployment failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -712,7 +714,8 @@ class PlayStoreClient:
             )
         except Exception as e:
             self._logger.exception("Deployment failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -749,10 +752,11 @@ class PlayStoreClient:
             version_code=version_code,
         )
 
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             # Get source track info
             source_track = self._execute(
                 service.edits()
@@ -816,7 +820,8 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Promotion failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -827,7 +832,8 @@ class PlayStoreClient:
             )
         except Exception as e:
             self._logger.exception("Promotion failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -855,10 +861,11 @@ class PlayStoreClient:
             version_code=version_code,
         )
 
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             # Get current track info
             current_track = self._execute(
                 service.edits().tracks().get(packageName=package_name, editId=edit_id, track=track)
@@ -910,7 +917,8 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Halt failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -921,7 +929,8 @@ class PlayStoreClient:
             )
         except Exception as e:
             self._logger.exception("Halt failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -957,10 +966,11 @@ class PlayStoreClient:
             rollout_percentage=rollout_percentage,
         )
 
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             # Get current track info
             current_track = self._execute(
                 service.edits().tracks().get(packageName=package_name, editId=edit_id, track=track)
@@ -1017,7 +1027,8 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Rollout update failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -1028,7 +1039,8 @@ class PlayStoreClient:
             )
         except Exception as e:
             self._logger.exception("Rollout update failed", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return DeploymentResult(
                 success=False,
                 package_name=package_name,
@@ -3918,10 +3930,11 @@ class PlayStoreClient:
             Update result.
         """
         self._logger.info("Updating store listing", package_name=package_name, language=language)
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             # Get current listing
             try:
                 current_listing = self._execute(
@@ -3975,7 +3988,8 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Failed to update listing", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return ListingUpdateResult(
                 success=False,
                 package_name=package_name,
@@ -3985,7 +3999,8 @@ class PlayStoreClient:
             )
         except Exception as e:
             self._logger.exception("Failed to update listing", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return ListingUpdateResult(
                 success=False,
                 package_name=package_name,
@@ -4088,10 +4103,11 @@ class PlayStoreClient:
             track=track,
             count=len(google_groups),
         )
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             self._execute(
                 service.edits()
                 .testers()
@@ -4109,11 +4125,13 @@ class PlayStoreClient:
 
         except HttpError as e:
             self._logger.exception("Failed to update testers", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return {"success": False, "track": track, "error": str(e)}
         except Exception as e:
             self._logger.exception("Failed to update testers", error=str(e))
-            self._delete_edit(package_name, edit_id)
+            if edit_id is not None:
+                self._delete_edit(package_name, edit_id)
             return {"success": False, "track": track, "error": str(e)}
 
     # =========================================================================

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -584,6 +584,37 @@ class PlayStoreClient:
         finally:
             self._delete_edit(package_name, edit_id)
 
+    @staticmethod
+    def _build_release_body(
+        version_code: int,
+        rollout_percentage: float,
+        release_notes: str | dict[str, str] | None,
+        release_notes_language: str,
+    ) -> dict[str, Any]:
+        """Build the release body for edits().tracks().update() from upload results."""
+        release_body: dict[str, Any] = {"versionCodes": [str(version_code)]}
+
+        if rollout_percentage < 100:
+            release_body["status"] = "inProgress"
+            release_body["userFraction"] = rollout_percentage / 100.0
+        else:
+            release_body["status"] = "completed"
+
+        # Handle release notes - support both string and dict formats
+        if release_notes:
+            if isinstance(release_notes, dict):
+                # Multi-language release notes
+                release_body["releaseNotes"] = [
+                    {"language": lang, "text": text} for lang, text in release_notes.items()
+                ]
+            else:
+                # Single language release notes
+                release_body["releaseNotes"] = [
+                    {"language": release_notes_language, "text": release_notes}
+                ]
+
+        return release_body
+
     def deploy_app(
         self,
         package_name: str,
@@ -652,29 +683,9 @@ class PlayStoreClient:
             uploaded_version_code = int(upload_response.get("versionCode", 0))
             self._logger.info("Upload complete", version_code=uploaded_version_code)
 
-            # Build release
-            release_body: dict[str, Any] = {
-                "versionCodes": [str(uploaded_version_code)],
-            }
-
-            if rollout_percentage < 100:
-                release_body["status"] = "inProgress"
-                release_body["userFraction"] = rollout_percentage / 100.0
-            else:
-                release_body["status"] = "completed"
-
-            # Handle release notes - support both string and dict formats
-            if release_notes:
-                if isinstance(release_notes, dict):
-                    # Multi-language release notes
-                    release_body["releaseNotes"] = [
-                        {"language": lang, "text": text} for lang, text in release_notes.items()
-                    ]
-                else:
-                    # Single language release notes
-                    release_body["releaseNotes"] = [
-                        {"language": release_notes_language, "text": release_notes}
-                    ]
+            release_body = self._build_release_body(
+                uploaded_version_code, rollout_percentage, release_notes, release_notes_language
+            )
 
             # Update track
             track_body = {"releases": [release_body]}

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -1289,6 +1289,97 @@ class TestEditFailures:
             client._commit_edit("com.example.app", "edit-123")
 
 
+class TestEditSetupFailureReturnsResult:
+    """A failure creating the edit (before any upload/track work) must still
+
+    return the method's documented Result object, not raise uncaught -- these
+    methods promise a typed Result on every path, and _create_edit's failure
+    is a routine one (bad package name, no permission, edit-quota exceeded,
+    transient outage), not something callers should need a try/except for.
+    """
+
+    def test_deploy_app_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"fake apk")
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.deploy_app("com.example.app", "internal", str(apk))
+
+        assert result.success is False
+        assert "Deployment failed" in result.message
+
+    def test_promote_release_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.promote_release("com.example.app", "beta", "production", 100)
+
+        assert result.success is False
+        assert "Promotion failed" in result.message
+
+    def test_halt_release_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.halt_release("com.example.app", "production", 100)
+
+        assert result.success is False
+        assert "Halt failed" in result.message
+
+    def test_update_rollout_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.update_rollout("com.example.app", "production", 100, 50.0)
+
+        assert result.success is False
+        assert "Rollout update failed" in result.message
+
+    def test_update_listing_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.update_listing("com.example.app", "en-US", title="New Title")
+
+        assert result.success is False
+        assert "Failed to update listing" in result.message
+
+    def test_update_testers_returns_result_on_create_edit_failure(
+        self,
+        client: PlayStoreClient,
+        _mock_service: MagicMock,
+    ) -> None:
+        mock_edits = _mock_service.edits.return_value
+        mock_edits.insert.return_value.execute.side_effect = _make_http_error(403, "forbidden")
+
+        result = client.update_testers("com.example.app", "internal", ["testers@example.com"])
+
+        assert result["success"] is False
+        assert "error" in result
+
+
 # =========================================================================
 # _parse_timestamp helper
 # =========================================================================


### PR DESCRIPTION
## Summary
From this session's full code audit — HIGH severity finding (api-design/error-handling domain).

**The bug:** `deploy_app`, `promote_release`, `halt_release`, `update_rollout`, `update_listing`, and `update_testers` in `client.py` all called `self._get_service()` and `self._create_edit(package_name)` **before** their own `try:` block. Both raise `PlayStoreClientError` on failure (bad package name, no permission, edit-quota exceeded, transient API outage — all routine, not exceptional), so any failure there escaped uncaught instead of returning the method's documented Result object (`DeploymentResult` / `ListingUpdateResult` / a success/error dict) — which every one of the 117 MCP tool wrappers relies on, since none of them have their own try/except.

(`deploy_app_multilang`, also flagged in the audit, turned out to be a `server.py` wrapper around `client.deploy_app`, not a separate `client.py` method — fixing `deploy_app` covers it, so this is 6 methods, not 7.)

**The fix:** move both calls inside each method's `try:` block, with `edit_id` declared as `str | None = None` beforehand so the except blocks' existing `_delete_edit(package_name, edit_id)` cleanup calls can skip cleanup when `edit_id` was never actually created (guarded with `if edit_id is not None`). Pure control-flow fix — no change to any success-path behavior or return shape.

## Test plan
- [x] 6 new regression tests (one per method) in `TestEditSetupFailureReturnsResult`, each verified to genuinely fail with an uncaught `PlayStoreClientError` against the pre-fix code (checked via `git stash`) and pass against the fix.
- [x] **Real-API smoke test**: called 5 of the 6 methods (excluding `deploy_app`, which needs a local file) against a nonexistent package name with real credentials, hitting a genuine "Invalid package name" error from Google's real API at the `_create_edit` call — confirmed every one returns its documented `success=False` Result instead of raising. No real app data touched anywhere.
- [x] Full unit suite (737 tests), `ruff check`, `ruff format --check`, `mypy`: all clean.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during app publishing and listing updates.
  * Prevented additional cleanup errors when an edit session cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->