### PR TITLE
refactor: OperationResult base class + shared error-handling helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ ignore = [
 ]
 "src/play_store_mcp/client.py" = [
     "C901",    # complexity in _get_service is acceptable for credential handling
+    "BLE001",  # write methods must return a Result rather than crash the MCP
+               # tool call on any failure; _fail_result always logs and
+               # constructs a proper error Result, never silently swallows
 ]
 
 [tool.ruff.lint.isort]

--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -13,7 +13,7 @@ import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import structlog
 from google.oauth2 import service_account
@@ -48,6 +48,7 @@ from play_store_mcp.models import (
     OneTimeProduct,
     OneTimeProductActionResult,
     OneTimeProductOffer,
+    OperationResult,
     Order,
     OrderLineItem,
     OrderRefundResult,
@@ -83,6 +84,8 @@ SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 # token_uri (e.g. from an untrusted per-request credential header) from
 # being used as an SSRF primitive during credential refresh.
 _GOOGLE_OAUTH_TOKEN_URI = "https://oauth2.googleapis.com/token"  # noqa: S105 # nosec B105 — endpoint URL, not a credential
+
+_ResultT = TypeVar("_ResultT", bound=OperationResult)
 
 # Retry configuration
 MAX_RETRIES = 3
@@ -554,6 +557,59 @@ class PlayStoreClient:
             # Edit may have already been committed or expired
             self._logger.debug("Edit cleanup failed", error=str(e))
 
+    def _fail_result(
+        self,
+        result_cls: type[_ResultT],
+        context: str,
+        error: Exception,
+        *,
+        edit_id: str | None = None,
+        package_name: str | None = None,
+        **extra_fields: Any,
+    ) -> _ResultT:
+        """Log an operation failure, clean up any open edit, and build its Result.
+
+        Collapses the ``except HttpError`` / ``except Exception`` pair that
+        nearly every write method used to repeat: both branches log, clean up,
+        and construct the same Result -- differing only in how the failure
+        reason is derived (HttpError.reason vs str(error)). Pass this as the
+        single ``except Exception as e`` handler's body via
+        ``return self._fail_result(...)``.
+
+        Args:
+            result_cls: The OperationResult subclass to construct.
+            context: Prefixes the log event and the message, e.g. "Deployment
+                failed" -- the constructed message is f"{context}: {reason}".
+                Named `context`, not `action`, since several result_cls have
+                their own `action` field (e.g. "acknowledge"/"consume") that
+                would otherwise collide with this parameter as a kwarg.
+            error: The caught exception.
+            edit_id: Open edit to clean up, if any (skipped when None -- e.g.
+                edit creation itself failed, so there's nothing to delete).
+            package_name: Used for edit cleanup (alongside edit_id) and,
+                since nearly every result_cls has a package_name field,
+                forwarded into the constructed result too. Omit entirely for
+                a result_cls with no package_name field (e.g. AccessResult)
+                and no edit to clean up.
+            **extra_fields: Additional fields for result_cls (e.g. track,
+                version_code, action).
+
+        Returns:
+            result_cls(success=False, message=..., error=str(error), **extra_fields).
+        """
+        reason = error.reason if isinstance(error, HttpError) else str(error)
+        self._logger.exception(context, error=str(error))
+        if edit_id is not None and package_name is not None:
+            self._delete_edit(package_name, edit_id)
+        if package_name is not None:
+            extra_fields = {"package_name": package_name, **extra_fields}
+        return result_cls(
+            success=False,
+            message=f"{context}: {reason}",
+            error=str(error),
+            **extra_fields,
+        )
+
     # =========================================================================
     # Publishing API
     # =========================================================================
@@ -739,27 +795,14 @@ class PlayStoreClient:
                 message=f"Successfully deployed version {uploaded_version_code} to {track}",
             )
 
-        except HttpError as e:
-            self._logger.exception("Deployment failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
-                package_name=package_name,
-                track=track,
-                message=f"Deployment failed: {e.reason}",
-                error=str(e),
-            )
         except Exception as e:
-            self._logger.exception("Deployment failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
+            return self._fail_result(
+                DeploymentResult,
+                "Deployment failed",
+                e,
+                edit_id=edit_id,
                 package_name=package_name,
                 track=track,
-                message=f"Deployment failed: {e}",
-                error=str(e),
             )
 
     def promote_release(
@@ -856,29 +899,15 @@ class PlayStoreClient:
                 message=f"Successfully promoted version {version_code} from {from_track} to {to_track}",
             )
 
-        except HttpError as e:
-            self._logger.exception("Promotion failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
-                package_name=package_name,
-                track=to_track,
-                version_code=version_code,
-                message=f"Promotion failed: {e.reason}",
-                error=str(e),
-            )
         except Exception as e:
-            self._logger.exception("Promotion failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
+            return self._fail_result(
+                DeploymentResult,
+                "Promotion failed",
+                e,
+                edit_id=edit_id,
                 package_name=package_name,
                 track=to_track,
                 version_code=version_code,
-                message=f"Promotion failed: {e}",
-                error=str(e),
             )
 
     def halt_release(self, package_name: str, track: str, version_code: int) -> DeploymentResult:
@@ -953,29 +982,15 @@ class PlayStoreClient:
                 message=f"Successfully halted version {version_code} on {track}",
             )
 
-        except HttpError as e:
-            self._logger.exception("Halt failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
-                package_name=package_name,
-                track=track,
-                version_code=version_code,
-                message=f"Halt failed: {e.reason}",
-                error=str(e),
-            )
         except Exception as e:
-            self._logger.exception("Halt failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
+            return self._fail_result(
+                DeploymentResult,
+                "Halt failed",
+                e,
+                edit_id=edit_id,
                 package_name=package_name,
                 track=track,
                 version_code=version_code,
-                message=f"Halt failed: {e}",
-                error=str(e),
             )
 
     def update_rollout(
@@ -1063,29 +1078,15 @@ class PlayStoreClient:
                 message=f"Successfully updated rollout to {rollout_percentage}% for version {version_code}",
             )
 
-        except HttpError as e:
-            self._logger.exception("Rollout update failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
-                package_name=package_name,
-                track=track,
-                version_code=version_code,
-                message=f"Rollout update failed: {e.reason}",
-                error=str(e),
-            )
         except Exception as e:
-            self._logger.exception("Rollout update failed", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return DeploymentResult(
-                success=False,
+            return self._fail_result(
+                DeploymentResult,
+                "Rollout update failed",
+                e,
+                edit_id=edit_id,
                 package_name=package_name,
                 track=track,
                 version_code=version_code,
-                message=f"Rollout update failed: {e}",
-                error=str(e),
             )
 
     def get_app_details(self, package_name: str, language: str = "en-US") -> AppDetails:
@@ -1260,13 +1261,12 @@ class PlayStoreClient:
                 message="Reply posted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to reply to review", error=str(e))
-            return ReviewReplyResult(
-                success=False,
+        except Exception as e:
+            return self._fail_result(
+                ReviewReplyResult,
+                "Failed to reply",
+                e,
                 review_id=review_id,
-                message=f"Failed to reply: {e.reason}",
-                error=str(e),
             )
 
     # =========================================================================
@@ -1524,9 +1524,16 @@ class PlayStoreClient:
                 message="Purchase acknowledged successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to acknowledge product purchase", error=str(e))
-            raise PlayStoreClientError(f"Failed to acknowledge product purchase: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                ProductPurchaseActionResult,
+                "Failed to acknowledge product purchase",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+                purchase_token=token,
+                action="acknowledge",
+            )
 
     def consume_product_purchase(
         self,
@@ -1569,9 +1576,16 @@ class PlayStoreClient:
                 message="Purchase consumed successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to consume product purchase", error=str(e))
-            raise PlayStoreClientError(f"Failed to consume product purchase: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                ProductPurchaseActionResult,
+                "Failed to consume product purchase",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+                purchase_token=token,
+                action="consume",
+            )
 
     def refund_order(
         self,
@@ -1608,9 +1622,15 @@ class PlayStoreClient:
                 message=message,
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to refund order", error=str(e))
-            raise PlayStoreClientError(f"Failed to refund order: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                OrderRefundResult,
+                "Failed to refund order",
+                e,
+                package_name=package_name,
+                order_id=order_id,
+                revoked=False,
+            )
 
     def cancel_subscription_purchase(
         self,
@@ -1651,9 +1671,15 @@ class PlayStoreClient:
                 message="Subscription cancellation scheduled",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to cancel subscription", error=str(e))
-            raise PlayStoreClientError(f"Failed to cancel subscription: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionActionResult,
+                "Failed to cancel subscription",
+                e,
+                package_name=package_name,
+                purchase_token=token,
+                action="cancel",
+            )
 
     def defer_subscription_purchase(
         self,
@@ -1696,9 +1722,15 @@ class PlayStoreClient:
                 details={"itemExpiryTimeDetails": result.get("itemExpiryTimeDetails", [])},
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to defer subscription", error=str(e))
-            raise PlayStoreClientError(f"Failed to defer subscription: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionActionResult,
+                "Failed to defer subscription",
+                e,
+                package_name=package_name,
+                purchase_token=token,
+                action="defer",
+            )
 
     def revoke_subscription_purchase(
         self,
@@ -1720,9 +1752,16 @@ class PlayStoreClient:
             "Revoking subscription purchase", package_name=package_name, refund_type=refund_type
         )
         if refund_type not in _REVOCATION_CONTEXTS:
-            raise PlayStoreClientError(
-                f"Invalid refund_type '{refund_type}'; must be one of: "
-                f"{', '.join(sorted(_REVOCATION_CONTEXTS))}"
+            return SubscriptionActionResult(
+                success=False,
+                package_name=package_name,
+                purchase_token=token,
+                action="revoke",
+                message=(
+                    f"Invalid refund_type '{refund_type}'; must be one of: "
+                    f"{', '.join(sorted(_REVOCATION_CONTEXTS))}"
+                ),
+                error="InvalidRefundType",
             )
         service = self._get_service()
 
@@ -1745,9 +1784,15 @@ class PlayStoreClient:
                 message=f"Subscription revoked ({refund_type} refund)",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to revoke subscription", error=str(e))
-            raise PlayStoreClientError(f"Failed to revoke subscription: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionActionResult,
+                "Failed to revoke subscription",
+                e,
+                package_name=package_name,
+                purchase_token=token,
+                action="revoke",
+            )
 
     def get_product_purchase_v2(
         self,
@@ -2051,9 +2096,14 @@ class PlayStoreClient:
                 message=f"In-app product {sku} deleted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete in-app product", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete in-app product: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                InAppProductActionResult,
+                "Failed to delete in-app product",
+                e,
+                package_name=package_name,
+                sku=sku,
+            )
 
     def batch_get_in_app_products(self, package_name: str, skus: list[str]) -> list[InAppProduct]:
         """Get details for multiple in-app products.
@@ -2116,9 +2166,14 @@ class PlayStoreClient:
                 message=f"Deleted {len(skus)} in-app product(s) successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to batch delete in-app products", error=str(e))
-            raise PlayStoreClientError(f"Failed to batch delete in-app products: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                InAppProductActionResult,
+                "Failed to batch delete in-app products",
+                e,
+                package_name=package_name,
+                sku=None,
+            )
 
     # =========================================================================
     # One-Time Product Catalog API
@@ -2304,9 +2359,14 @@ class PlayStoreClient:
                 message=f"One-time product {product_id} deleted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete one-time product", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete one-time product: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                OneTimeProductActionResult,
+                "Failed to delete one-time product",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     def batch_update_one_time_products(
         self, package_name: str, requests: list[dict[str, Any]]
@@ -2374,11 +2434,14 @@ class PlayStoreClient:
                 message=f"Deleted {len(requests)} one-time product(s) successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to batch delete one-time products", error=str(e))
-            raise PlayStoreClientError(
-                f"Failed to batch delete one-time products: {e.reason}"
-            ) from e
+        except Exception as e:
+            return self._fail_result(
+                OneTimeProductActionResult,
+                "Failed to batch delete one-time products",
+                e,
+                package_name=package_name,
+                product_id=None,
+            )
 
     # =========================================================================
     # One-Time Product Purchase Options API
@@ -2424,11 +2487,14 @@ class PlayStoreClient:
                 message=f"Deleted {len(requests)} purchase option(s) successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to batch delete purchase options", error=str(e))
-            raise PlayStoreClientError(
-                f"Failed to batch delete purchase options: {e.reason}"
-            ) from e
+        except Exception as e:
+            return self._fail_result(
+                OneTimeProductActionResult,
+                "Failed to batch delete purchase options",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     def batch_update_purchase_option_states(
         self, package_name: str, product_id: str, requests: list[dict[str, Any]]
@@ -2899,11 +2965,14 @@ class PlayStoreClient:
                 message=f"Deleted {len(requests)} one-time product offer(s) successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to batch delete purchase option offers", error=str(e))
-            raise PlayStoreClientError(
-                f"Failed to batch delete purchase option offers: {e.reason}"
-            ) from e
+        except Exception as e:
+            return self._fail_result(
+                OneTimeProductActionResult,
+                "Failed to batch delete purchase option offers",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     # =========================================================================
     # Subscription Catalog API
@@ -3050,9 +3119,14 @@ class PlayStoreClient:
                 message=f"Subscription {product_id} deleted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete subscription", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete subscription: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionCatalogResult,
+                "Failed to delete subscription",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     def batch_get_subscriptions(
         self, package_name: str, product_ids: list[str]
@@ -3250,9 +3324,14 @@ class PlayStoreClient:
                 message=f"Base plan {base_plan_id} deleted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete base plan", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete base plan: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionCatalogResult,
+                "Failed to delete base plan",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     def migrate_base_plan_prices(
         self,
@@ -3748,9 +3827,14 @@ class PlayStoreClient:
                 message=f"Subscription offer {offer_id} deleted successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete subscription offer", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete subscription offer: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                SubscriptionCatalogResult,
+                "Failed to delete subscription offer",
+                e,
+                package_name=package_name,
+                product_id=product_id,
+            )
 
     def batch_get_subscription_offers(
         self,
@@ -4024,27 +4108,14 @@ class PlayStoreClient:
                 message=f"Successfully updated listing for {language}",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to update listing", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return ListingUpdateResult(
-                success=False,
-                package_name=package_name,
-                language=language,
-                message=f"Failed to update listing: {e.reason}",
-                error=str(e),
-            )
         except Exception as e:
-            self._logger.exception("Failed to update listing", error=str(e))
-            if edit_id is not None:
-                self._delete_edit(package_name, edit_id)
-            return ListingUpdateResult(
-                success=False,
+            return self._fail_result(
+                ListingUpdateResult,
+                "Failed to update listing",
+                e,
+                edit_id=edit_id,
                 package_name=package_name,
                 language=language,
-                message=f"Failed to update listing: {e}",
-                error=str(e),
             )
 
     def list_all_listings(self, package_name: str) -> list[Listing]:
@@ -4731,10 +4802,11 @@ class PlayStoreClient:
             image_type=image_type,
             image_id=image_id,
         )
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             self._execute(
                 service.edits()
                 .images()
@@ -4755,14 +4827,17 @@ class PlayStoreClient:
                 deleted_count=1,
                 message=f"Deleted image {image_id}",
             )
-        except HttpError as e:
-            self._logger.exception("Failed to delete image", error=str(e))
-            self._delete_edit(package_name, edit_id)
-            raise PlayStoreClientError(f"Failed to delete image: {e.reason}") from e
         except Exception as e:
-            self._logger.exception("Failed to delete image", error=str(e))
-            self._delete_edit(package_name, edit_id)
-            raise PlayStoreClientError(f"Failed to delete image: {e}") from e
+            return self._fail_result(
+                ImageDeleteResult,
+                "Failed to delete image",
+                e,
+                edit_id=edit_id,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                deleted_count=0,
+            )
 
     def delete_all_images(
         self,
@@ -4786,10 +4861,11 @@ class PlayStoreClient:
             language=language,
             image_type=image_type,
         )
-        service = self._get_service()
-        edit_id = self._create_edit(package_name)
-
+        edit_id: str | None = None
         try:
+            service = self._get_service()
+            edit_id = self._create_edit(package_name)
+
             result = self._execute(
                 service.edits()
                 .images()
@@ -4810,14 +4886,17 @@ class PlayStoreClient:
                 deleted_count=deleted_count,
                 message=f"Deleted {deleted_count} image(s)",
             )
-        except HttpError as e:
-            self._logger.exception("Failed to delete all images", error=str(e))
-            self._delete_edit(package_name, edit_id)
-            raise PlayStoreClientError(f"Failed to delete all images: {e.reason}") from e
         except Exception as e:
-            self._logger.exception("Failed to delete all images", error=str(e))
-            self._delete_edit(package_name, edit_id)
-            raise PlayStoreClientError(f"Failed to delete all images: {e}") from e
+            return self._fail_result(
+                ImageDeleteResult,
+                "Failed to delete all images",
+                e,
+                edit_id=edit_id,
+                package_name=package_name,
+                language=language,
+                image_type=image_type,
+                deleted_count=0,
+            )
 
     # =========================================================================
     # External Transactions API (alternative billing)
@@ -5219,9 +5298,8 @@ class PlayStoreClient:
                 message=f"User {email} removed successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete user", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete user: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(AccessResult, "Failed to delete user", e)
 
     def create_grant(self, developer_id: str, email: str, grant: dict[str, Any]) -> Grant:
         """Grant a user app-level access.
@@ -5314,9 +5392,8 @@ class PlayStoreClient:
                 message=f"Grant for {package_name} removed successfully",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to delete grant", error=str(e))
-            raise PlayStoreClientError(f"Failed to delete grant: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(AccessResult, "Failed to delete grant", e)
 
     # =========================================================================
     # Data Safety API
@@ -5353,9 +5430,13 @@ class PlayStoreClient:
                 message="Data safety labels updated",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to update data safety labels", error=str(e))
-            raise PlayStoreClientError(f"Failed to update data safety labels: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                DataSafetyResult,
+                "Failed to update data safety labels",
+                e,
+                package_name=package_name,
+            )
 
     # =========================================================================
     # App Recovery API
@@ -5466,9 +5547,14 @@ class PlayStoreClient:
                 message="App recovery deployed",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to deploy app recovery", error=str(e))
-            raise PlayStoreClientError(f"Failed to deploy app recovery: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                AppRecoveryResult,
+                "Failed to deploy app recovery",
+                e,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+            )
 
     def cancel_app_recovery(
         self,
@@ -5506,9 +5592,14 @@ class PlayStoreClient:
                 message="App recovery canceled",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to cancel app recovery", error=str(e))
-            raise PlayStoreClientError(f"Failed to cancel app recovery: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                AppRecoveryResult,
+                "Failed to cancel app recovery",
+                e,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+            )
 
     def add_app_recovery_targeting(
         self,
@@ -5549,9 +5640,14 @@ class PlayStoreClient:
                 message="App recovery targeting added",
             )
 
-        except HttpError as e:
-            self._logger.exception("Failed to add app recovery targeting", error=str(e))
-            raise PlayStoreClientError(f"Failed to add app recovery targeting: {e.reason}") from e
+        except Exception as e:
+            return self._fail_result(
+                AppRecoveryResult,
+                "Failed to add app recovery targeting",
+                e,
+                package_name=package_name,
+                app_recovery_id=app_recovery_id,
+            )
 
     # =========================================================================
     # Generated APKs API
@@ -5745,13 +5841,19 @@ class PlayStoreClient:
             )
 
         except HttpError as e:
-            self._logger.exception("Failed to download generated APK", error=str(e))
-            raise PlayStoreClientError(f"Failed to download generated APK: {e.reason}") from e
+            return self._fail_result(
+                DownloadResult,
+                "Failed to download generated APK",
+                e,
+                destination_path=destination_path,
+            )
         except OSError as e:
-            self._logger.exception("Failed to write generated APK", error=str(e))
-            raise PlayStoreClientError(
-                f"Failed to write generated APK to {destination_path}: {e}"
-            ) from e
+            return self._fail_result(
+                DownloadResult,
+                f"Failed to write generated APK to {destination_path}",
+                e,
+                destination_path=destination_path,
+            )
 
     # =========================================================================
     # System APK Variants API
@@ -5937,13 +6039,19 @@ class PlayStoreClient:
             )
 
         except HttpError as e:
-            self._logger.exception("Failed to download system APK variant", error=str(e))
-            raise PlayStoreClientError(f"Failed to download system APK variant: {e.reason}") from e
+            return self._fail_result(
+                DownloadResult,
+                "Failed to download system APK variant",
+                e,
+                destination_path=destination_path,
+            )
         except OSError as e:
-            self._logger.exception("Failed to write system APK variant", error=str(e))
-            raise PlayStoreClientError(
-                f"Failed to write system APK variant to {destination_path}: {e}"
-            ) from e
+            return self._fail_result(
+                DownloadResult,
+                f"Failed to write system APK variant to {destination_path}",
+                e,
+                destination_path=destination_path,
+            )
 
     # =========================================================================
     # Internal App Sharing API

--- a/src/play_store_mcp/models.py
+++ b/src/play_store_mcp/models.py
@@ -15,6 +15,18 @@ _DESC_ORDER_ID = "Order ID"
 _DESC_SUCCESS = "Whether the action succeeded"
 
 
+class OperationResult(BaseModel):
+    """Base for write-action results: the shared success/message/error trio.
+
+    Subclasses add whatever identifying fields (package_name, track, ...)
+    their specific operation needs.
+    """
+
+    success: bool = Field(..., description=_DESC_SUCCESS)
+    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
+    error: str | None = Field(None, description=_DESC_ERROR)
+
+
 class Release(BaseModel):
     """Represents an app release on a track."""
 
@@ -36,16 +48,13 @@ class TrackInfo(BaseModel):
     releases: list[Release] = Field(default_factory=list, description="Releases on this track")
 
 
-class DeploymentResult(BaseModel):
+class DeploymentResult(OperationResult):
     """Result of a deployment operation."""
 
-    success: bool = Field(..., description="Whether deployment succeeded")
     edit_id: str | None = Field(None, description="Edit ID for the operation")
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     track: str = Field(..., description="Target track")
     version_code: int | None = Field(None, description="Deployed version code")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class AppDetails(BaseModel):
@@ -78,13 +87,10 @@ class Review(BaseModel):
     developer_reply_time: datetime | None = Field(None, description="Reply time")
 
 
-class ReviewReplyResult(BaseModel):
+class ReviewReplyResult(OperationResult):
     """Result of replying to a review."""
 
-    success: bool = Field(..., description="Whether reply succeeded")
     review_id: str = Field(..., description="Review ID")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class SubscriptionProduct(BaseModel):
@@ -138,14 +144,11 @@ class InAppProduct(BaseModel):
     default_price: dict[str, Any] | None = Field(None, description="Default price information")
 
 
-class InAppProductActionResult(BaseModel):
+class InAppProductActionResult(OperationResult):
     """Result of a delete/batch-delete action on in-app products."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     sku: str | None = Field(None, description="Product SKU (None for batch operations)")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class Listing(BaseModel):
@@ -158,14 +161,11 @@ class Listing(BaseModel):
     video: str | None = Field(None, description="YouTube video URL")
 
 
-class ListingUpdateResult(BaseModel):
+class ListingUpdateResult(OperationResult):
     """Result of updating a store listing."""
 
-    success: bool = Field(..., description="Whether update succeeded")
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     language: str = Field(..., description="Language code")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class TesterInfo(BaseModel):
@@ -259,16 +259,13 @@ class AppImage(BaseModel):
     sha256: str | None = Field(None, description="SHA256 hash of the image content")
 
 
-class ImageDeleteResult(BaseModel):
+class ImageDeleteResult(OperationResult):
     """Result of deleting one or all store-listing images."""
 
-    success: bool = Field(..., description="Whether the delete action succeeded")
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     language: str = Field(..., description="Language localization code (BCP-47 tag)")
     image_type: str = Field(..., description="Image type the deletion applied to")
     deleted_count: int = Field(0, description="Number of images deleted")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class BatchDeploymentResult(BaseModel):
@@ -308,16 +305,13 @@ class ProductPurchase(BaseModel):
     developer_payload: str | None = Field(None, description="Developer-supplied payload")
 
 
-class ProductPurchaseActionResult(BaseModel):
+class ProductPurchaseActionResult(OperationResult):
     """Result of an acknowledge/consume action on an in-app product purchase."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     product_id: str = Field(..., description="In-app product SKU")
     purchase_token: str = Field(..., description=_DESC_PURCHASE_TOKEN)
     action: str = Field(..., description="Action performed (acknowledge or consume)")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class ValidationResult(BaseModel):
@@ -328,41 +322,32 @@ class ValidationResult(BaseModel):
     value: Any | None = Field(None, description="Invalid value")
 
 
-class OrderRefundResult(BaseModel):
+class OrderRefundResult(OperationResult):
     """Result of refunding an order."""
 
-    success: bool = Field(..., description="Whether the refund succeeded")
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     order_id: str = Field(..., description=_DESC_ORDER_ID)
     revoked: bool = Field(..., description="Whether the entitlement was also revoked")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
-class SubscriptionActionResult(BaseModel):
+class SubscriptionActionResult(OperationResult):
     """Result of a cancel/defer/revoke action on a subscription purchase."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     purchase_token: str = Field(..., description=_DESC_PURCHASE_TOKEN)
     action: str = Field(..., description="Action performed (cancel, defer, or revoke)")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
     details: dict[str, Any] | None = Field(
         None, description="Extra result data (e.g. defer expiry)"
     )
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
-class SubscriptionCatalogResult(BaseModel):
+class SubscriptionCatalogResult(OperationResult):
     """Result of a delete action on a subscription catalog product."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     product_id: str | None = Field(
         None, description="Subscription product ID (None for batch operations)"
     )
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class SubscriptionOffer(BaseModel):
@@ -399,16 +384,13 @@ class OneTimeProduct(BaseModel):
     )
 
 
-class OneTimeProductActionResult(BaseModel):
+class OneTimeProductActionResult(OperationResult):
     """Result of a delete/batch-delete action on a one-time product catalog resource."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     product_id: str | None = Field(
         None, description="One-time product ID (None for batch operations)"
     )
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class OneTimeProductOffer(BaseModel):
@@ -505,21 +487,14 @@ class Grant(BaseModel):
     )
 
 
-class AccessResult(BaseModel):
+class AccessResult(OperationResult):
     """Result of a user/grant write that returns an empty response (delete)."""
 
-    success: bool = Field(..., description="Whether the operation succeeded")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
-
-class DataSafetyResult(BaseModel):
+class DataSafetyResult(OperationResult):
     """Result of updating an app's data safety labels (applications.dataSafety)."""
 
-    success: bool = Field(..., description="Whether the update succeeded")
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class AppRecovery(BaseModel):
@@ -534,14 +509,11 @@ class AppRecovery(BaseModel):
     create_time: str | None = Field(None, description="Time the recovery action was created")
 
 
-class AppRecoveryResult(BaseModel):
+class AppRecoveryResult(OperationResult):
     """Result of a deploy/cancel/add-targeting action on an app recovery action."""
 
-    success: bool = Field(..., description=_DESC_SUCCESS)
     package_name: str = Field(..., description=_DESC_PACKAGE_NAME)
     app_recovery_id: str | None = Field(None, description="App recovery action ID")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class GeneratedApksDownload(BaseModel):
@@ -570,13 +542,10 @@ class SystemApkVariant(BaseModel):
     options: dict[str, Any] | None = Field(None, description="Options applied to the generated APK")
 
 
-class DownloadResult(BaseModel):
+class DownloadResult(OperationResult):
     """Result of downloading a file to a local path."""
 
-    success: bool = Field(..., description="Whether the download succeeded")
     destination_path: str = Field(..., description="Local path the file was written to")
-    message: str = Field(..., description=_DESC_STATUS_MESSAGE)
-    error: str | None = Field(None, description=_DESC_ERROR)
 
 
 class InternalAppSharingArtifact(BaseModel):

--- a/tests/test_app_recovery.py
+++ b/tests/test_app_recovery.py
@@ -169,8 +169,10 @@ def test_deploy_app_recovery_http_error():
     _rec(service).deploy.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to deploy app recovery"):
-        client.deploy_app_recovery("com.example.app", "123")
+    result = client.deploy_app_recovery("com.example.app", "123")
+
+    assert result.success is False
+    assert "Failed to deploy app recovery" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -199,8 +201,10 @@ def test_cancel_app_recovery_http_error():
     _rec(service).cancel.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to cancel app recovery"):
-        client.cancel_app_recovery("com.example.app", "123")
+    result = client.cancel_app_recovery("com.example.app", "123")
+
+    assert result.success is False
+    assert "Failed to cancel app recovery" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -230,8 +234,10 @@ def test_add_app_recovery_targeting_http_error():
     _rec(service).addTargeting.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to add app recovery targeting"):
-        client.add_app_recovery_targeting("com.example.app", "123", {})
+    result = client.add_app_recovery_targeting("com.example.app", "123", {})
+
+    assert result.success is False
+    assert "Failed to add app recovery targeting" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -100,9 +100,10 @@ class TestExecuteRetryThroughOperation:
             {},
         ]
 
-        with pytest.raises(PlayStoreClientError, match="Failed to acknowledge"):
-            client.acknowledge_product_purchase("com.example.app", "sku-1", "tok-1")
+        result = client.acknowledge_product_purchase("com.example.app", "sku-1", "tok-1")
 
+        assert result.success is False
+        assert "Failed to acknowledge" in result.message
         assert ack.execute.call_count == 1
 
     def test_non_idempotent_operation_retries_on_429(
@@ -436,9 +437,10 @@ class TestEditOrphanCleanup:
         # The image delete itself succeeds; the commit step blows up.
         edits.commit.return_value.execute.side_effect = RuntimeError("commit boom")
 
-        with pytest.raises(PlayStoreClientError, match="Failed to delete image"):
-            client.delete_image("com.example.app", "en-US", "icon", "img-1")
+        result = client.delete_image("com.example.app", "en-US", "icon", "img-1")
 
+        assert result.success is False
+        assert "Failed to delete image" in result.message
         edits.delete.assert_called()
 
     def test_delete_all_images_cleanup_on_runtime_error(
@@ -450,9 +452,10 @@ class TestEditOrphanCleanup:
         edits.images.return_value.deleteall.return_value.execute.return_value = {"deleted": []}
         edits.commit.return_value.execute.side_effect = RuntimeError("commit boom")
 
-        with pytest.raises(PlayStoreClientError, match="Failed to delete all images"):
-            client.delete_all_images("com.example.app", "en-US", "icon")
+        result = client.delete_all_images("com.example.app", "en-US", "icon")
 
+        assert result.success is False
+        assert "Failed to delete all images" in result.message
         edits.delete.assert_called()
 
     def test_update_testers_cleanup_on_runtime_error(
@@ -477,13 +480,17 @@ class TestEditOrphanCleanup:
 
 
 class TestRevokeSubscriptionRefundType:
-    def test_invalid_refund_type_raises(
+    def test_invalid_refund_type_returns_failure_result(
         self,
         client: PlayStoreClient,
         _mock_service: MagicMock,
     ) -> None:
-        with pytest.raises(PlayStoreClientError, match="Invalid refund_type"):
-            client.revoke_subscription_purchase("com.example.app", "token-1", refund_type="bogus")
+        result = client.revoke_subscription_purchase(
+            "com.example.app", "token-1", refund_type="bogus"
+        )
+
+        assert result.success is False
+        assert "Invalid refund_type" in result.message
 
 
 # =========================================================================
@@ -740,8 +747,10 @@ class TestDownloadOsError:
         # exist, so the write (mkstemp) raises OSError rather than confinement.
         client._download_dir = str(tmp_path)
         bad = str(tmp_path / "missing_subdir" / "out.apk")
-        with pytest.raises(PlayStoreClientError, match="Failed to write generated APK"):
-            client.download_generated_apk("com.example.app", 100, "download-1", bad)
+        result = client.download_generated_apk("com.example.app", 100, "download-1", bad)
+
+        assert result.success is False
+        assert "Failed to write generated APK" in result.message
 
     def test_download_system_apk_variant_wraps_oserror(
         self,
@@ -751,8 +760,10 @@ class TestDownloadOsError:
     ) -> None:
         client._download_dir = str(tmp_path)
         bad = str(tmp_path / "missing_subdir" / "out.apk")
-        with pytest.raises(PlayStoreClientError, match="Failed to write system APK variant"):
-            client.download_system_apk_variant("com.example.app", 100, 1, bad)
+        result = client.download_system_apk_variant("com.example.app", 100, 1, bad)
+
+        assert result.success is False
+        assert "Failed to write system APK variant" in result.message
 
 
 # =========================================================================

--- a/tests/test_data_safety.py
+++ b/tests/test_data_safety.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 from googleapiclient.errors import HttpError
 
 import play_store_mcp.server as server
-from play_store_mcp.client import PlayStoreClient, PlayStoreClientError
+from play_store_mcp.client import PlayStoreClient
 from play_store_mcp.models import DataSafetyResult
 
 # ---------------------------------------------------------------------------
@@ -78,8 +77,10 @@ def test_set_data_safety_http_error():
     )
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to update data safety labels"):
-        client.set_data_safety("com.example.app", {"safetyLabels": "csv"})
+    result = client.set_data_safety("com.example.app", {"safetyLabels": "csv"})
+
+    assert result.success is False
+    assert "Failed to update data safety labels" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_generated_apks.py
+++ b/tests/test_generated_apks.py
@@ -204,8 +204,12 @@ def test_download_generated_apk_http_error(monkeypatch, tmp_path):
 
     monkeypatch.setattr(client_module, "MediaIoBaseDownload", MagicMock())
 
-    with pytest.raises(PlayStoreClientError, match="Failed to download generated APK"):
-        client.download_generated_apk("com.example.app", 42, "split-1", str(tmp_path / "app.apk"))
+    result = client.download_generated_apk(
+        "com.example.app", 42, "split-1", str(tmp_path / "app.apk")
+    )
+
+    assert result.success is False
+    assert "Failed to download generated APK" in result.message
 
 
 def test_download_generated_apk_failure_preserves_destination(monkeypatch, tmp_path):
@@ -225,8 +229,10 @@ def test_download_generated_apk_failure_preserves_destination(monkeypatch, tmp_p
     destination = tmp_path / "existing.apk"
     destination.write_bytes(b"original-contents")
 
-    with pytest.raises(PlayStoreClientError, match="Failed to download generated APK"):
-        client.download_generated_apk("com.example.app", 42, "split-1", str(destination))
+    result = client.download_generated_apk("com.example.app", 42, "split-1", str(destination))
+
+    assert result.success is False
+    assert "Failed to download generated APK" in result.message
 
     # The pre-existing file is untouched and no partial/temp file is left behind.
     assert destination.read_bytes() == b"original-contents"

--- a/tests/test_inappproducts.py
+++ b/tests/test_inappproducts.py
@@ -213,8 +213,10 @@ def test_delete_in_app_product_http_error():
     _iap(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete in-app product"):
-        client.delete_in_app_product("com.example.app", "sku1")
+    result = client.delete_in_app_product("com.example.app", "sku1")
+
+    assert result.success is False
+    assert "Failed to delete in-app product" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -291,8 +293,10 @@ def test_batch_delete_in_app_products_http_error():
     _iap(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to batch delete in-app products"):
-        client.batch_delete_in_app_products("com.example.app", ["sku1"])
+    result = client.batch_delete_in_app_products("com.example.app", ["sku1"])
+
+    assert result.success is False
+    assert "Failed to batch delete in-app products" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_listing_images.py
+++ b/tests/test_listing_images.py
@@ -312,9 +312,10 @@ def test_delete_image_http_error_abandons_edit():
     _images(service).delete.return_value.execute.side_effect = _make_http_error("nope")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete image"):
-        client.delete_image("com.example.app", "en-US", "icon", "img-1")
+    result = client.delete_image("com.example.app", "en-US", "icon", "img-1")
 
+    assert result.success is False
+    assert "Failed to delete image" in result.message
     _edits(service).delete.assert_called_once_with(packageName="com.example.app", editId="edit-123")
     _edits(service).commit.assert_not_called()
 
@@ -365,9 +366,10 @@ def test_delete_all_images_http_error_abandons_edit():
     _images(service).deleteall.return_value.execute.side_effect = _make_http_error("nope")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete all images"):
-        client.delete_all_images("com.example.app", "en-US", "icon")
+    result = client.delete_all_images("com.example.app", "en-US", "icon")
 
+    assert result.success is False
+    assert "Failed to delete all images" in result.message
     _edits(service).delete.assert_called_once_with(packageName="com.example.app", editId="edit-123")
     _edits(service).commit.assert_not_called()
 

--- a/tests/test_onetimeproduct_offers.py
+++ b/tests/test_onetimeproduct_offers.py
@@ -135,10 +135,12 @@ def test_batch_delete_purchase_options_http_error():
     _options(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to batch delete purchase options"):
-        client.batch_delete_purchase_options(
-            "com.example.app", "coins_pack", [{"purchaseOptionId": "opt1"}]
-        )
+    result = client.batch_delete_purchase_options(
+        "com.example.app", "coins_pack", [{"purchaseOptionId": "opt1"}]
+    )
+
+    assert result.success is False
+    assert "Failed to batch delete purchase options" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -536,10 +538,12 @@ def test_batch_delete_purchase_option_offers_http_error():
     _offers(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to batch delete purchase option offers"):
-        client.batch_delete_purchase_option_offers(
-            "com.example.app", "coins_pack", "opt1", [{"offerId": "intro"}]
-        )
+    result = client.batch_delete_purchase_option_offers(
+        "com.example.app", "coins_pack", "opt1", [{"offerId": "intro"}]
+    )
+
+    assert result.success is False
+    assert "Failed to batch delete purchase option offers" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_onetimeproducts.py
+++ b/tests/test_onetimeproducts.py
@@ -306,8 +306,10 @@ def test_delete_one_time_product_http_error():
     _otp(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete one-time product"):
-        client.delete_one_time_product("com.example.app", "coins_pack")
+    result = client.delete_one_time_product("com.example.app", "coins_pack")
+
+    assert result.success is False
+    assert "Failed to delete one-time product" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -383,8 +385,10 @@ def test_batch_delete_one_time_products_http_error():
     _otp(service).batchDelete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to batch delete one-time products"):
-        client.batch_delete_one_time_products("com.example.app", [{"productId": "coins_pack"}])
+    result = client.batch_delete_one_time_products("com.example.app", [{"productId": "coins_pack"}])
+
+    assert result.success is False
+    assert "Failed to batch delete one-time products" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_product_purchases.py
+++ b/tests/test_product_purchases.py
@@ -164,8 +164,10 @@ def test_acknowledge_product_purchase_http_error():
     products.acknowledge.return_value.execute.side_effect = _make_http_error("bad")
     client = _client_with_products(products)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to acknowledge product purchase"):
-        client.acknowledge_product_purchase("com.example.app", "sku1", "tok")
+    result = client.acknowledge_product_purchase("com.example.app", "sku1", "tok")
+
+    assert result.success is False
+    assert "Failed to acknowledge product purchase" in result.message
 
 
 def test_consume_product_purchase_success():
@@ -186,8 +188,10 @@ def test_consume_product_purchase_http_error():
     products.consume.return_value.execute.side_effect = _make_http_error("bad")
     client = _client_with_products(products)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to consume product purchase"):
-        client.consume_product_purchase("com.example.app", "sku1", "tok")
+    result = client.consume_product_purchase("com.example.app", "sku1", "tok")
+
+    assert result.success is False
+    assert "Failed to consume product purchase" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_purchase_management.py
+++ b/tests/test_purchase_management.py
@@ -103,8 +103,10 @@ def test_refund_order_http_error():
     service.orders.return_value.refund.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to refund order"):
-        client.refund_order("com.example.app", "GPA.1")
+    result = client.refund_order("com.example.app", "GPA.1")
+
+    assert result.success is False
+    assert "Failed to refund order" in result.message
 
 
 def test_cancel_subscription_success():
@@ -126,8 +128,10 @@ def test_cancel_subscription_http_error():
     _subs_v2(service).cancel.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to cancel subscription"):
-        client.cancel_subscription_purchase("com.example.app", "tok")
+    result = client.cancel_subscription_purchase("com.example.app", "tok")
+
+    assert result.success is False
+    assert "Failed to cancel subscription" in result.message
 
 
 def test_defer_subscription_success():
@@ -155,8 +159,10 @@ def test_defer_subscription_http_error():
     _subs_v2(service).defer.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to defer subscription"):
-        client.defer_subscription_purchase("com.example.app", "tok", "604800s", "etag")
+    result = client.defer_subscription_purchase("com.example.app", "tok", "604800s", "etag")
+
+    assert result.success is False
+    assert "Failed to defer subscription" in result.message
 
 
 def test_revoke_subscription_full():
@@ -189,8 +195,10 @@ def test_revoke_subscription_http_error():
     _subs_v2(service).revoke.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to revoke subscription"):
-        client.revoke_subscription_purchase("com.example.app", "tok")
+    result = client.revoke_subscription_purchase("com.example.app", "tok")
+
+    assert result.success is False
+    assert "Failed to revoke subscription" in result.message
 
 
 def test_get_product_purchase_v2_success():

--- a/tests/test_subscription_baseplans.py
+++ b/tests/test_subscription_baseplans.py
@@ -140,8 +140,10 @@ def test_delete_base_plan_http_error():
     _base_plans(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete base plan"):
-        client.delete_base_plan("com.example.app", "premium_monthly", "monthly")
+    result = client.delete_base_plan("com.example.app", "premium_monthly", "monthly")
+
+    assert result.success is False
+    assert "Failed to delete base plan" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_subscription_catalog.py
+++ b/tests/test_subscription_catalog.py
@@ -243,8 +243,10 @@ def test_delete_subscription_http_error():
     _subs(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete subscription"):
-        client.delete_subscription("com.example.app", "premium_monthly")
+    result = client.delete_subscription("com.example.app", "premium_monthly")
+
+    assert result.success is False
+    assert "Failed to delete subscription" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_subscription_offers.py
+++ b/tests/test_subscription_offers.py
@@ -401,8 +401,12 @@ def test_delete_subscription_offer_http_error():
     _offers(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete subscription offer"):
-        client.delete_subscription_offer("com.example.app", "premium_monthly", "monthly", "intro")
+    result = client.delete_subscription_offer(
+        "com.example.app", "premium_monthly", "monthly", "intro"
+    )
+
+    assert result.success is False
+    assert "Failed to delete subscription offer" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_apks.py
+++ b/tests/test_system_apks.py
@@ -211,8 +211,12 @@ def test_download_system_apk_variant_http_error(monkeypatch, tmp_path):
 
     monkeypatch.setattr(client_module, "MediaIoBaseDownload", MagicMock())
 
-    with pytest.raises(PlayStoreClientError, match="Failed to download system APK variant"):
-        client.download_system_apk_variant("com.example.app", 42, 1, str(tmp_path / "variant.apk"))
+    result = client.download_system_apk_variant(
+        "com.example.app", 42, 1, str(tmp_path / "variant.apk")
+    )
+
+    assert result.success is False
+    assert "Failed to download system APK variant" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_users_grants.py
+++ b/tests/test_users_grants.py
@@ -228,8 +228,10 @@ def test_delete_user_http_error():
     _users(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete user"):
-        client.delete_user("dev123", "a@b.com")
+    result = client.delete_user("dev123", "a@b.com")
+
+    assert result.success is False
+    assert "Failed to delete user" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -340,8 +342,10 @@ def test_delete_grant_http_error():
     _grants(service).delete.return_value.execute.side_effect = _make_http_error("bad")
     client = _client(service)
 
-    with pytest.raises(PlayStoreClientError, match="Failed to delete grant"):
-        client.delete_grant("dev123", "a@b.com", "com.example.app")
+    result = client.delete_grant("dev123", "a@b.com", "com.example.app")
+
+    assert result.success is False
+    assert "Failed to delete grant" in result.message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
From this session's full code audit — MEDIUM findings (models.py duplication + client.py error-handling duplication). Two changes, bundled because the second depends on the first:

1. **`models.py`**: added an `OperationResult(BaseModel)` base with the `success`/`message`/`error` trio that 14 write-action Result models all redeclared identically. Pure inheritance refactor — no code/test depends on Pydantic field order, and all construction in this codebase is kwargs-only (Pydantic v2 requires it), so this is behaviorally invisible.
2. **`client.py`**: added a `_fail_result` helper that collapses the `except HttpError` / `except Exception` pair nearly every write method repeated — both branches always did the same thing (log, clean up any open edit, construct the same Result), differing only in how the failure reason is derived. Applied across every method returning one of the 14 `OperationResult` subclasses.

**While doing this mechanical pass, direct code reading turned up ~25 *additional* instances of the exact bug fixed for 6 methods in #148**: a method typed to return a Result object that actually `raise`s `PlayStoreClientError` on failure instead of returning it — so a routine failure escapes uncaught since none of the 117 MCP tool wrappers have their own try/except. Fixed all of them the same way as part of this pass:
`acknowledge_product_purchase`, `consume_product_purchase`, `refund_order`, `cancel_subscription_purchase`, `defer_subscription_purchase`, `revoke_subscription_purchase`, `delete_in_app_product`, `batch_delete_in_app_products`, `delete_one_time_product`, `batch_delete_one_time_products`, `batch_delete_purchase_options`, `batch_delete_purchase_option_offers`, `delete_subscription`, `delete_base_plan`, `delete_subscription_offer`, `delete_image`, `delete_all_images`, `delete_user`, `delete_grant`, `set_data_safety`, `deploy_app_recovery`, `cancel_app_recovery`, `add_app_recovery_targeting`, `download_generated_apk`, `download_system_apk_variant`.

`delete_image`/`delete_all_images` also had the same `get_service()`/`create_edit()`-before-`try` setup bug as #148 (fixed the same way). `reply_to_review` previously caught only `HttpError`; using `_fail_result` broadens it to catch anything, matching every sibling method — strictly more robust, not a behavior removal.

**ruff**: catching bare `Exception` in these methods now needs a per-file `BLE001` ignore for `client.py` — previously every site had a preceding `except HttpError` clause (satisfies flake8-blind-except); collapsing to one `except Exception` is now the intended pattern, since `_fail_result` always logs and returns a structured error Result, never silently swallows.

## Test plan
- [x] Full unit suite (746 tests). Every existing test exercising the old raise-on-failure behavior updated to check the returned Result instead; spot-checked via `git stash` that they genuinely fail against the pre-fix code.
- [x] **Real-API smoke test**: 10 methods across every Result family, called against a nonexistent package name / fake identifiers with real credentials, hitting genuine Google API errors ("Invalid package name", "No application was found", "Package not found", ...) — confirmed every one returns its documented failure Result instead of raising. No real app data touched anywhere.
- [x] Real credentialed read against the live test app (`app.lusk.underseerr`) confirms the legitimate path is unaffected.
- [x] `ruff check`, `ruff format --check`, `mypy`: all clean.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Write operations now return structured failure results when API requests fail, including an explanatory error message.
  - Invalid refund types now produce a failure result instead of causing an exception.
  - Failure handling consistently cleans up incomplete operations.

- **Improvements**
  - Operation results now use a consistent format with success status, message, and optional error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->