### PR TITLE
fix: close cold-start race in _get_service; type _shared_state

### DIFF
--- a/src/play_store_mcp/client.py
+++ b/src/play_store_mcp/client.py
@@ -276,6 +276,12 @@ class PlayStoreClient:
         # transport. The shared fallback client is used across concurrent tool
         # worker threads; per-request header clients each get their own lock.
         self._http_lock = threading.Lock()
+        # Guards the check-then-build sequence in _get_service so concurrent
+        # first calls (MCP tools dispatch to worker threads) don't each
+        # redundantly resolve credentials and build() a service. Separate from
+        # _http_lock since that guards the transport call itself, which this
+        # never touches.
+        self._service_lock = threading.Lock()
         self._logger = logger.bind(component="PlayStoreClient")
 
     # =========================================================================
@@ -468,27 +474,38 @@ class PlayStoreClient:
 
     @retry_with_backoff
     def _get_service(self) -> AndroidPublisherResource:
-        """Get or create the API service instance."""
+        """Get or create the API service instance.
+
+        Double-checked locking: MCP tools are plain ``def``s, so FastMCP
+        dispatches concurrent tool calls to worker threads. Without the lock,
+        two threads could both pass the first None-check before either
+        assigns ``self._service``, each redundantly resolving credentials and
+        calling ``build()``.
+        """
         if self._service is not None:
             return self._service
 
-        self._logger.info("Initializing Google Play Developer API client")
+        with self._service_lock:
+            if self._service is not None:
+                return self._service
 
-        try:
-            credentials = self._resolve_credentials()
-            self._service = build(
-                "androidpublisher",
-                "v3",
-                credentials=credentials,
-                cache_discovery=False,
-            )
-            self._logger.info("API client initialized successfully")
-            return self._service  # type: ignore[return-value]
-        except Exception as e:
-            if isinstance(e, PlayStoreClientError):
-                raise
-            self._logger.exception("Failed to initialize API client", error=str(e))
-            raise PlayStoreClientError(f"Failed to initialize API client: {e}") from e
+            self._logger.info("Initializing Google Play Developer API client")
+
+            try:
+                credentials = self._resolve_credentials()
+                self._service = build(
+                    "androidpublisher",
+                    "v3",
+                    credentials=credentials,
+                    cache_discovery=False,
+                )
+                self._logger.info("API client initialized successfully")
+                return self._service  # type: ignore[return-value]
+            except Exception as e:
+                if isinstance(e, PlayStoreClientError):
+                    raise
+                self._logger.exception("Failed to initialize API client", error=str(e))
+                raise PlayStoreClientError(f"Failed to initialize API client: {e}") from e
 
     def _execute(self, request: Any) -> Any:
         """Execute a googleapiclient request with retry/backoff.

--- a/src/play_store_mcp/server.py
+++ b/src/play_store_mcp/server.py
@@ -14,7 +14,7 @@ import secrets
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import structlog
 import uvicorn
@@ -85,11 +85,25 @@ def get_client_from_context() -> PlayStoreClient:
     )
 
 
+class AppState(TypedDict):
+    """Shared state threaded through the FastMCP lifespan context.
+
+    A TypedDict, not a dataclass, so every existing subscript access
+    (``_shared_state["client"]``, including the dict-style access FastMCP's
+    yielded lifespan context and this module's own tests use) keeps working
+    unchanged -- this only adds mypy key-name and value-type checking, no
+    runtime behavior change.
+    """
+
+    client: PlayStoreClient | None
+    credentials_updated: bool
+
+
 # Shared fallback client, used when a request carries no per-request
 # credential header. Populated by the lifespan on startup and swapped by the
 # /credentials route. Module-level so custom routes and get_client_from_context
 # can reach it without depending on framework-internal context plumbing.
-_shared_state: dict[str, Any] = {"client": None, "credentials_updated": False}
+_shared_state: AppState = {"client": None, "credentials_updated": False}
 
 # Recommended minimum length for PLAY_STORE_MCP_ADMIN_TOKEN, below which
 # _run_http logs a startup warning. `openssl rand -hex 32` (the documented

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -8,6 +8,7 @@ below). These bring branch coverage of the newly hardened code paths back to
 from __future__ import annotations
 
 import json
+import threading
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -175,6 +176,51 @@ class TestExecuteThreadSafety:
 
         assert observed["locked_during_chunk"] is True
         assert client._http_lock.locked() is False
+
+
+class TestGetServiceThreadSafety:
+    """_get_service double-checked locking closes a cold-start race.
+
+    Without the lock, concurrent first calls could each pass the initial
+    None-check before either assigned self._service, each redundantly
+    resolving credentials and calling build().
+    """
+
+    def test_concurrent_first_calls_build_service_exactly_once(self, tmp_path: Any) -> None:
+        creds_file = tmp_path / "creds.json"
+        creds_file.write_text('{"type": "service_account"}')
+        client = PlayStoreClient(credentials_path=str(creds_file))
+
+        build_calls = 0
+        start_gate = threading.Event()
+
+        def fake_build(*_args: Any, **_kwargs: Any) -> MagicMock:
+            nonlocal build_calls
+            build_calls += 1
+            return MagicMock()
+
+        def call_get_service() -> None:
+            start_gate.wait()
+            client._get_service()
+
+        with (
+            patch(
+                "play_store_mcp.client.service_account.Credentials.from_service_account_info"
+            ) as mock_creds,
+            patch("play_store_mcp.client.build", side_effect=fake_build),
+        ):
+            mock_creds.return_value = MagicMock()
+            # Every thread blocks on start_gate, then all race _get_service()
+            # at once -- this is what would expose the race without the lock.
+            threads = [threading.Thread(target=call_get_service) for _ in range(20)]
+            for t in threads:
+                t.start()
+            start_gate.set()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert build_calls == 1
+        assert client._service is not None
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
From this session's full code audit — MEDIUM (concurrency) + LOW (architecture) findings.

**Concurrency**: `client.py`'s `_get_service` had an unsynchronized check-then-build sequence, unlike `_execute`'s deliberate `_http_lock` usage. Since MCP tools are plain `def`s, FastMCP dispatches concurrent tool calls to worker threads — two threads could both pass the `if self._service is not None` check before either assigned it, each redundantly resolving credentials and calling `build()`. Not data-corrupting, but real wasted work under concurrent first-request load. Added a dedicated `_service_lock` (separate from `_http_lock`, which guards only the transport call) with double-checked locking.

**Typing**: `server.py`'s `_shared_state` was an untyped `dict[str, Any]` holding the app's only two pieces of mutable state, with no protection against a key-name typo. Replaced with an `AppState(TypedDict)`. A TypedDict, not a dataclass, so every existing subscript access (including FastMCP's own yielded lifespan context and this module's tests) keeps working unchanged — this only adds mypy checking, no runtime behavior change.

## Test plan
- [x] New deterministic regression test: 20 threads released simultaneously via an `Event`, all calling `_get_service()` with `build()` mocked to count calls. Verified it genuinely fails against the pre-fix code (via `git stash`) — 7-20 `build()` calls across 8 runs — and passes deterministically with the fix (always exactly 1).
- [x] Real credentialed smoke test against the live test app (`app.lusk.underseerr`): single-threaded and concurrent access both work correctly. (Concurrent `get_listing()` calls did surface Google's own edit-lifecycle/quota errors on some threads — a pre-existing, independent property of the edits API's single-edit-per-app model, correctly returned as `PlayStoreClientError` — not a regression: no `_get_service` failures, no duplicate builds.)
- [x] Full unit suite (747 tests), `ruff check`, `ruff format --check`, `mypy`: all clean.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt
