### PR TITLE
docs: document write-tools-return-Result vs read-tools-raise convention

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -2,6 +2,17 @@
 
 Complete reference for all MCP tools provided by the Play Store MCP server.
 
+## Error Handling
+
+Tools follow one of two conventions, depending on what they return:
+
+- **Write tools that document a result object** (fields like `success`, `message`,
+  `error` — e.g. `deploy_app`, `update_listing`, `refund_order`) always return that
+  object, even on failure: check `success` rather than expecting an MCP tool error.
+- **Tools that return plain data** (a single resource or a list — e.g. `get_listing`,
+  `get_order`, `list_subscriptions`) raise an MCP tool error on failure instead, since
+  there's no result shape to report `success: false` in.
+
 ## Publishing Tools
 
 | Tool | Description |


### PR DESCRIPTION
## Summary
From this session's full code audit (MEDIUM, api-design domain): which of the two error-reporting conventions a given MCP tool uses was undocumented anywhere. After PR #149 fixed the remaining tools that were supposed to return a Result object but actually raised, the split is now a clean rule rather than an arbitrary per-tool choice. Documented it at the top of `docs/tools-reference.md`.

## Test plan
- [x] `mkdocs build --strict` (matching the docs CI workflow's exact method) builds cleanly.
- [ ] Confirm SonarCloud + Codacy show zero issues on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbxo6sumLNp257iYWVypNt